### PR TITLE
ci: add manual workflow dispatch for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,37 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (e.g. v0.2.0-beta)"
+        required: true
+        type: string
 
 permissions:
   contents: write
 
+env:
+  RELEASE_TAG: ${{ github.event.inputs.version || github.ref_name }}
+
 jobs:
+  tag:
+    name: Create Tag
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create and push tag
+        run: |
+          git tag "${{ github.event.inputs.version }}"
+          git push origin "${{ github.event.inputs.version }}"
+
   build:
     name: Build (${{ matrix.platform.name }})
+    needs: [tag]
+    if: always() && (needs.tag.result == 'success' || needs.tag.result == 'skipped')
     strategy:
       fail-fast: false
       matrix:
@@ -159,4 +183,5 @@ jobs:
           files: release-assets/*
           generate_release_notes: true
           draft: false
-          prerelease: ${{ contains(github.ref_name, '-') }}
+          tag_name: ${{ env.RELEASE_TAG }}
+          prerelease: ${{ contains(env.RELEASE_TAG, '-') }}


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to the Release workflow with a version input
- Automatically creates and pushes the git tag when triggered manually
- Keeps existing tag-push trigger as fallback
- Release via: **Actions → Release → Run workflow → type version (e.g. `v1.0.0-beta.2`)**

## Test plan
- [ ] Merge PR, then trigger workflow manually with `v1.0.0-beta.2`
- [ ] Verify tag is created and 3-platform build runs
- [ ] Verify GitHub Release is created with correct prerelease flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)