### PR TITLE
feat: Phase 2 complete (Twitter, IG/FB, Distribution UI, agents, crew templates) + Reddit + cron scheduler

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-ContextuAI Solo is a single-user desktop AI assistant with 81 pre-built business agents. It's a Tauri v2 desktop app with a React 19 frontend and a FastAPI Python backend running as a sidecar process. Data is stored locally in SQLite. Supports both cloud AI providers (Anthropic, AWS Bedrock) and local GGUF models via llama-cpp-python.
+ContextuAI Solo is a single-user desktop AI assistant with 93 pre-built business agents (105 in repo, engineering category excluded from desktop). It's a Tauri v2 desktop app with a React 19 frontend and a FastAPI Python backend running as a sidecar process. Data is stored locally in SQLite. Supports both cloud AI providers (Anthropic, AWS Bedrock) and local GGUF models via llama-cpp-python.
 
 ## Commands
 
@@ -77,7 +77,7 @@ GGUF models downloaded from HuggingFace, stored in `~/.contextuai-solo/models/`.
 - Models appear in chat dropdown after sync
 
 ### Agent Library (`agent-library/`)
-81 business agents as markdown files organized by category (c-suite, marketing-sales, finance-operations, etc.). Engineering category is excluded from desktop mode. Each markdown file contains a system prompt, recommended model, and tool configs. Auto-seeded into `workspace_agents` collection on first startup. Re-seed via `POST /api/v1/desktop/reseed`.
+105 business agents as markdown files across 13 categories (c-suite, marketing-sales, finance-operations, etc.). Engineering category (12 agents) is excluded from desktop mode, so users see 93 across 12 categories. Each markdown file contains a system prompt, recommended model, and tool configs. Auto-seeded into `workspace_agents` collection on first startup. Re-seed via `POST /api/v1/desktop/reseed`.
 
 ### Crew System
 Multi-agent teams with persistent memory. Crew builder (`components/crews/crew-builder.tsx`) is a 5-step wizard:
@@ -92,8 +92,11 @@ Channel bindings stored as `channel_bindings[]` on the crew document (`ChannelBi
 ### Blueprint Library (`blueprints/`)
 10 pre-built workflow templates across 5 categories (strategy, content, marketing, product, research). Markdown files auto-seeded into `blueprints` collection on startup. Integrated into crew builder and workspace project dialog via `BlueprintSelector` component. API: `GET /api/v1/blueprints/`, `GET /api/v1/blueprints/{id}`.
 
+### Reddit Connection (`routers/reddit.py`, `services/reddit_poller.py`)
+Inbound polling via praw (Reddit API wrapper). `RedditPoller` runs a 60s background loop, fetching new comments from configured subreddits (filtered by keywords) and inbox DMs. Dispatches through `channel_service.handle_message()` so triggers + approval pipeline apply. Account config stored in `reddit_accounts` collection. REST API: `GET/POST/PUT/DELETE /api/v1/reddit/account`, `POST /api/v1/reddit/test`, `POST /api/v1/reddit/reply`.
+
 ### Connections (`routes/connections.tsx`)
-External platform integrations: Telegram, Discord, LinkedIn (OAuth), Twitter/X, Instagram (OAuth), Facebook (OAuth). Token-paste flow for Telegram/Discord/Twitter; OAuth2 flow for LinkedIn/Instagram/Facebook with provider-specific setup instructions.
+External platform integrations: Telegram, Discord, Reddit, LinkedIn (OAuth), Twitter/X, Instagram (OAuth), Facebook (OAuth). Token-paste flow for Telegram/Discord/Twitter/Reddit; OAuth2 flow for LinkedIn/Instagram/Facebook with provider-specific setup instructions.
 
 ### Authentication
 Desktop mode uses a static admin user — no login required. Auth is bypassed via dependency overrides in `app.py`. The `auth_service.py` has Cognito JWT support for the enterprise edition.

--- a/CONNECTIONS-GUIDE.md
+++ b/CONNECTIONS-GUIDE.md
@@ -71,6 +71,40 @@ curl "https://api.telegram.org/botYOUR_BOT_TOKEN/deleteWebhook"
 
 ---
 
+## Reddit
+
+**Type:** Token paste (script app) | **Inbound + Outbound**
+
+### Setup Steps
+
+1. Go to [reddit.com/prefs/apps](https://www.reddit.com/prefs/apps)
+2. Scroll down and click **"create another app…"**
+3. Fill in:
+   - **Name:** ContextuAI Solo (or whatever you like)
+   - **Type:** select **script**
+   - **Redirect URI:** `http://localhost:18741` (not used, but required)
+4. Click **Create app**
+5. Copy your **Client ID** (under the app name, ~14 chars) and **Secret**
+6. In Solo, go to **Connections** → click **Reddit**
+7. Fill in:
+   - **Client ID** and **Client Secret** from step 5
+   - **Reddit Username** and **Reddit Password** (your account credentials)
+   - **Subreddits** — comma-separated list to monitor (e.g., `LocalLLaMA,selfhosted`)
+   - **Keywords** — only comments matching these words trigger the pipeline (leave empty to get all)
+8. Click **Save** — Solo tests the connection and starts polling every 60 seconds
+
+### How It Works
+
+- **Inbound:** `RedditPoller` runs a 60-second background loop, fetching new comments from your configured subreddits (filtered by keywords) and unread inbox DMs. Each new item dispatches through the trigger + approval pipeline.
+- **Outbound:** Reply to comments or send DMs via `POST /api/v1/reddit/reply`.
+- **Rate limits:** praw handles Reddit's 60 req/min OAuth limit internally.
+
+### Reference
+
+- [Reddit — API Documentation](https://www.reddit.com/dev/api/)
+
+---
+
 ## LinkedIn
 
 **Type:** OAuth | **Outbound only**

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ You define the crew once. Run it whenever you need it.
 
 ### Publish to your channels
 
-Connect Solo to **Telegram, Discord, LinkedIn, Twitter/X, Instagram, and Facebook**. Your crews can draft and post content — with optional approval gates so nothing goes live without your sign-off.
+Connect Solo to **Telegram, Discord, Reddit, LinkedIn, Twitter/X, Instagram, and Facebook**. Your crews can draft and post content — with optional approval gates so nothing goes live without your sign-off.
 
 ---
 
@@ -100,7 +100,7 @@ Your client proposals, financial models, legal reviews, and business strategies 
 
 ---
 
-## 81 Business Agents, Ready to Work
+## 93 Business Agents, Ready to Work
 
 Solo ships with specialized agents across every business function:
 
@@ -151,7 +151,7 @@ Solo exposes an **OpenAI-compatible API endpoint** (`/v1/chat/completions`) on y
 - **10 Blueprint Templates** — Pre-built workflow templates across strategy, content, marketing, product, and research
 - **Workshop Mode** — Run multi-agent brainstorming sessions with structured outputs
 - **10 Persona Types** — Nexus Agent, Web Researcher, database connectors (PostgreSQL, MySQL, MSSQL, Snowflake, MongoDB), MCP Server, API Connector, File Operations
-- **6 Platform Connections** — Telegram, Discord, LinkedIn, Twitter/X, Instagram, Facebook with approval gates. See the [Connections Guide](CONNECTIONS-GUIDE.md) for setup
+- **7 Platform Connections** — Telegram, Discord, Reddit, LinkedIn, Twitter/X, Instagram, Facebook with approval gates. See the [Connections Guide](CONNECTIONS-GUIDE.md) for setup
 - **Brand Voice** — Define your business identity so every response sounds like you
 - **Dark/Light Theme** — Easy on the eyes, day or night
 
@@ -164,8 +164,16 @@ Solo exposes an **OpenAI-compatible API endpoint** (`/v1/chat/completions`) on y
 | Platform | Installer | How to Install |
 |----------|-----------|----------------|
 | **Windows** | `.exe` or `.msi` | Run the installer. If SmartScreen warns "Windows protected your PC", click **"More info"** → **"Run anyway"** |
-| **macOS** | `.dmg` | Open the DMG, drag to Applications. On first launch: **right-click** the app → **"Open"** → **"Open"** again |
+| **macOS** | `.dmg` | Open the DMG, drag to Applications. Then run the command below in Terminal to clear Gatekeeper's quarantine flag, and launch the app normally |
 | **Linux** | `.deb` / `.rpm` | `sudo dpkg -i contextuai-solo_*.deb` or `sudo rpm -i contextuai-solo-*.rpm` |
+
+**macOS Gatekeeper fix** — After dragging the app to Applications, run this once in Terminal:
+
+```bash
+xattr -cr "/Applications/ContextuAI Solo.app"
+```
+
+Without this, macOS may silently refuse to launch the app (or show "app is damaged and can't be opened") because the `.dmg` isn't Apple-notarized yet. The command strips the quarantine attribute so the app opens normally on every launch afterward.
 
 > **Note:** Windows SmartScreen and macOS Gatekeeper warnings are normal for new open-source software that isn't yet EV code-signed. You only need to bypass them once.
 
@@ -190,14 +198,14 @@ This is an active beta — we'd love your feedback! If you run into any issues:
 | Feature | Solo (Free) | Enterprise |
 |---------|:-----------:|:----------:|
 | AI Chat with Streaming | Yes | Yes |
-| 81 Business Agents | Yes | Yes |
+| 93 Business Agents | Yes | Yes |
 | 10 Persona Types | Yes | Yes |
 | Multi-Agent Crews | Yes | Yes |
 | Workshop (Brainstorming) | Yes | Yes |
 | BYOK (Bring Your Own Key) | Yes | Yes |
 | Local AI Models (GGUF) | Yes | Yes |
 | Dark/Light Theme | Yes | Yes |
-| 6 Platform Connections | Yes | Yes |
+| 7 Platform Connections | Yes | Yes |
 | SQLite (Local Storage) | Yes | -- |
 | MongoDB + Cloud Infra | -- | Yes |
 | Multi-User / Teams | -- | Yes |
@@ -256,7 +264,7 @@ contextuai-solo/
 │   ├── routers/        # API route handlers
 │   ├── services/       # Business logic and AI orchestration
 │   └── requirements.txt
-├── agent-library/      # Built-in agent templates (81 agents across 12 categories)
+├── agent-library/      # Built-in agent templates (105 agents across 13 categories; engineering excluded from desktop → 93 visible)
 ├── docs/user-guide/    # Per-module user guides
 ├── run.sh              # One-command backend launcher (Linux/macOS)
 ├── run-tests.ps1       # One-click test runner (backend + frontend)

--- a/TODO.md
+++ b/TODO.md
@@ -279,4 +279,175 @@
 
 ---
 
+## PHASE 3: UNIFY CONNECTIONS + CREWS (IA Refactor) ⭐ HIGH PRIORITY
+**Status:** [ ] NOT STARTED
+**Added:** 2026-04-20
+**Effort estimate:** ~4 PRs, 3–5 dev sessions
+
+> This is a **UI-first information-architecture refactor**. Today we have three confusing surfaces (Connections, Distribution, Schedule) that each hold their own auth or scheduling state. A user who connects Reddit once has to re-configure it to publish; a user who sets a schedule doesn't see it in their crew. This phase collapses everything into a cleaner mental model.
+
+### Mental model (the "north star")
+- The app is a **team**. Agents = team members, Crews = teams.
+- Teams (crews) **do work** using **connections** (their tools). Connections are user-level, not crew-level — Solo is single-user, so the user authenticates once per platform.
+- A crew picks which connections it uses, which **direction** per connection (`Inbound`, `Outbound`, or `Both`), and a **trigger** (Reactive on inbound messages, Scheduled via cron/date-picker, or Manual via the existing "Run" button).
+- Distribution and Schedule stop being destinations — publishing is just "a crew with outbound connections on a scheduled trigger." Scheduling is just "a trigger on a crew." Approvals flow through the existing Approvals page when a crew is flagged `approval_required`.
+
+### Confirmed decisions (do not revisit)
+1. **Manual trigger** = the existing "Run" button on each crew card (`frontend/src/routes/crews.tsx:481`). Not a new trigger-type selection in the builder. Always available on every crew.
+2. **Runs view** = the existing `Runs` tab on the Crews page (`frontend/src/routes/crews.tsx:130` — tab state `activeTab: "crews" | "runs"`). Extend the existing `CrewRun` type with trigger metadata; do not build a new component.
+3. **Distribution & Schedule stay in the sidebar** but route to a shared **"Coming Soon"** page. Sidebar remains at 12 items; nav E2E test (`frontend/tests/e2e/navigation/navigation.spec.ts`) does not need changing. Future phase removes them entirely.
+4. **Blog / Email / Slack webhook** ship as new Connection types (outbound-only) inside the same Connections grid as the social platforms.
+5. **Inbound keyword-match ties** → LLM disambiguates. No per-crew priority UI.
+6. **Connection-level fallback crew** for unmatched inbound → **not in v1**. Drop messages silently; reconsider if users complain.
+
+### Data model
+
+**Connection (existing stores — additive changes)**
+- Add `inbound_enabled: bool` and `outbound_enabled: bool` capability flags on each connection record across:
+  - `oauth_tokens` (LinkedIn, Instagram, Facebook)
+  - `reddit_accounts`
+  - Telegram/Discord/Twitter token-paste stores
+- Add three **new connection types** — outbound-only, stored in a new `outbound_connections` table or extend existing `distribution_channels`:
+  - `blog` (Ghost, WordPress, custom API)
+  - `email` (SendGrid, SES, SMTP)
+  - `slack_webhook` (incoming webhook URL)
+
+**Crew (extend existing crew document)**
+- Rename `channel_bindings[]` → `connection_bindings[]`:
+  ```
+  { connection_id, platform, direction: "inbound" | "outbound" | "both" }
+  ```
+- Add `triggers[]`:
+  - Reactive: `{ type: "reactive", connection_id, keywords: string[], hashtags: string[], mentions: string[] }`
+  - Scheduled: `{ type: "scheduled", connection_ids: string[], cron?: string, run_at?: ISO, content_brief?: string }`
+  - Manual is implicit — no entry needed; "Run" button always works.
+- Add `approval_required: bool` (top-level on crew).
+
+**CrewRun (extend existing model)**
+- Add `trigger_type: "reactive" | "scheduled" | "manual"`
+- Add `trigger_source`: connection_id (reactive), cron expression or run_at (scheduled), "manual" (button)
+- So the existing Runs tab can display *why* each run fired.
+
+**Runs persistence**
+- Reuse `workspace_jobs` table (don't add another). Each reactive match or scheduled fire creates a workspace_job with `status`, `trigger_type`, `inbound_message_id?`, `output`, and `approval_state`.
+
+### Backend work
+
+**New files**
+- [ ] `backend/services/connection_service.py` — unified aggregator over existing stores. Exposes:
+  - `list_connections() -> [ConnectionSummary]`
+  - `get_capabilities(conn_id) -> {inbound, outbound}`
+  - `set_capability(conn_id, direction, enabled)`
+- [ ] `backend/services/inbound_router.py` — on inbound message:
+  1. Find crews with reactive trigger on this connection.
+  2. Keyword/hashtag/mention substring match.
+  3. If >1 match, call an LLM (cheap model — Haiku or local Gemma) to pick best match.
+  4. Dispatch the chosen crew via existing agent_runner.
+  - Initially: thin wrapper over existing `channel_service.handle_message`; layer matching logic on top to avoid regression.
+- [ ] `backend/services/scheduled_runner.py` — polls crews for `triggers[type=scheduled]`, fires at cron/run_at boundaries. **Replaces** the internals of the standalone scheduler — but the standalone Schedule page still shows Coming Soon.
+- [ ] `backend/routers/connections.py` (new aggregator):
+  - `GET /api/v1/connections` — unified list
+  - `PATCH /api/v1/connections/{id}/capabilities` — toggle inbound/outbound
+  - Existing per-platform credential endpoints (OAuth/token paste/Reddit) remain unchanged.
+
+**Modified files**
+- [ ] `backend/services/workspace/agent_runner.py` — after crew run completes, if any `connection_binding` has outbound enabled, publish the final agent output via the corresponding adapter. No more separate `distribution_service`. If `crew.approval_required`, create an approval record instead of sending directly.
+- [ ] `backend/services/crew_service.py` — add trigger + approval fields; validate trigger configs.
+- [ ] `backend/models/crew_models.py` — Pydantic additions for `connection_bindings`, `triggers`, `approval_required`.
+
+**Deprecated (do NOT delete yet — user asked to keep Coming Soon)**
+- `backend/routers/distribution.py` — leave wired but return `{status: "coming_soon"}` stub on routes called by the deprecated frontend page. Or mark the router unused once frontend stops calling it.
+- `backend/services/distribution_service.py` — logic folded into agent_runner's outbound publishing. File can stay for the outbound adapters it owns (LinkedIn/Twitter/IG/FB/Blog/Email/Slack publishers) — reuse them from connection_service / agent_runner.
+- Standalone scheduler service (if any — check `backend/routers/triggers.py` and `backend/services/` for cron impl) — disable once `scheduled_runner.py` handles crew-level scheduling. Keep code around until the Schedule page is retired.
+
+### Frontend work
+
+**Rewrite**
+- [ ] `frontend/src/routes/connections.tsx` — one grid with all 10 types:
+  - 7 socials: Telegram, Discord, Reddit, LinkedIn, Twitter/X, Instagram, Facebook
+  - 3 new outbound-only: Blog, Email, Slack webhook
+  - Each card: auth status, **Inbound toggle** (hidden for outbound-only types), **Outbound toggle**, Manage/Disconnect.
+- [ ] `frontend/src/components/crews/crew-builder.tsx` — revise the 5-step wizard:
+  - **Step 4 "Connections"** → **Connections & Directions**: pick connections, per-connection direction chip selector (`Inbound` / `Outbound` / `Both`). If user picks a direction that's disabled at the connection level, show inline modal:
+    > "Outbound is disabled on Telegram. Enable it now so this crew can send?"
+    > [Enable & continue] [Cancel]
+  - **New Step 5 "Trigger"**: Reactive (+ `keywords`, `hashtags`, `mentions` multi-input) and/or Scheduled (cron field + one-shot date-picker). Both can be enabled; manual is implicit.
+  - **New Step 6 "Approval"**: single toggle "Review outbound before sending."
+  - Existing Review step becomes Step 7 — update summary to reflect new fields.
+
+**New**
+- [ ] `frontend/src/routes/coming-soon.tsx` — simple placeholder component:
+  - Takes a `feature: string` prop.
+  - Shows icon + "<Feature> is moving into Crews — coming soon" + link to Crews page + link to docs/TODO.md entry.
+- [ ] Update `App.tsx` to route `/distribution` and `/schedule` to `ComingSoon` with the appropriate prop.
+
+**Modified**
+- [ ] `frontend/src/routes/crews.tsx` — **Crews tab**: add new filter chips alongside existing `statusFilter` and `modeFilter`: `Inbound`, `Outbound`, `Scheduled`, `Reactive`, `Approval-required`. Filter logic hooks into `filteredCrews` (line 179). **Runs tab**: render `trigger_type` badge on each row of `RunsList` (line 498).
+- [ ] `frontend/src/lib/api/crews-client.ts` — extend `CrewRun` type with `trigger_type`, `trigger_source`.
+- [ ] `frontend/src/lib/api/distribution-client.ts` — can stay but is no longer consumed by the active UI. Delete in the future-cleanup phase.
+
+**Not changed**
+- Sidebar (`frontend/src/components/navigation/desktop-sidebar.tsx`) — still 12 items.
+- Nav E2E tests — still expect 12.
+
+### Migration
+
+**File:** `backend/migrations/0002_unify_connections.py`
+
+Must be idempotent, dry-run capable (`MIGRATE_DRY_RUN=1` env var), and must write a version marker so it doesn't double-run.
+
+1. Read all `distribution_channels` docs → for LinkedIn/Twitter/IG/FB, upsert into the corresponding OAuth connection store (merging credentials where overlap exists). For Blog/Email/Slack webhook, insert into the new `outbound_connections` table.
+2. Read any existing standalone scheduled jobs (check `backend/routers/triggers.py` + scheduler storage):
+   - For each, find the crew associated with its channel binding.
+   - Append a matching `{type: "scheduled"}` entry to `crew.triggers`.
+   - Log orphans (no crew match) as warnings and list them to a `migration_orphans.json` artifact for manual review.
+3. For every crew, transform existing `channel_bindings[]` → `connection_bindings[]` with `direction: "both"` (preserves current behavior — every currently-bound channel was implicitly doing both directions).
+4. For each connection record, set `inbound_enabled` / `outbound_enabled` defaults based on what that connection was actively doing (any bound crew + any active trigger polling = inbound_enabled; any distribution channel or schedule posting through it = outbound_enabled).
+5. Write `{migration: "0002_unify_connections", applied_at: <iso>}` to a migrations tracking collection.
+
+### Risks & mitigations
+
+- **Migration correctness** — scheduled jobs / distribution channels could be miswired. Mitigation: dry-run mode that emits a diff JSON the user reviews before real run. Surface unresolved orphans in a startup log banner.
+- **Inbound routing regressions** — Telegram/Reddit users in prod today rely on `channel_service.handle_message`. Mitigation: `inbound_router.py` starts as a thin delegator; keyword/LLM matching gated behind a `UNIFIED_ROUTING` flag that can flip per-connection.
+- **Visible blast radius** — once Distribution/Schedule pages become Coming Soon, anything a user was actively using there must have a clear landing spot. Mitigation: the Coming Soon page links to the specific Crews page where that work now lives; a one-time startup banner flags any unmigrated items.
+
+### PR sequence
+
+**Each PR is independently mergeable, behind feature flag where needed.**
+
+| PR | Scope | Flag |
+|---|---|---|
+| 1 | Data model additions (connection_bindings, triggers, approval_required, capability flags) + migration script (dry-run capable) + extended CrewRun schema. Backend only; no UI change; existing flows keep working. | — (additive) |
+| 2 | Unified `/api/v1/connections` aggregator + rewritten Connections page (capability toggles, Blog/Email/Slack new types). Old Distribution page still lives. | — |
+| 3 | Crew builder: Trigger step + Direction chips + Approval toggle + "enable capability at connection level" modal. Backend: `inbound_router.py` + `scheduled_runner.py`. Runs tab displays trigger_type badge. | `UNIFIED_CREWS` env flag |
+| 4 | Swap `/distribution` and `/schedule` routes to ComingSoon. Add TODO entries referencing this plan. Flip `UNIFIED_CREWS` on by default. | Flag default → true |
+
+### Follow-up TODOs (track after Phase 3 ships)
+
+- [ ] FUTURE: Re-retire Distribution page (delete `frontend/src/routes/distribution.tsx`, `backend/routers/distribution.py`, `backend/services/distribution_service.py` entirely) once Coming Soon has been live one release cycle.
+- [ ] FUTURE: Re-retire Schedule page (delete `frontend/src/routes/schedule.tsx` + standalone scheduler backend).
+- [ ] FUTURE: Connection-level fallback crew for unmatched inbound messages (skipped in v1 per user decision).
+- [ ] FUTURE: Global Activity/Runs view across all crews (skipped in v1 — per-crew Runs tab covers the need).
+- [ ] FUTURE: Per-crew priority ordering for keyword-match ties (skipped — LLM disambiguation handles v1).
+
+### Key files reference (for the implementer)
+
+**Existing code to read first (understand before touching):**
+- `frontend/src/routes/crews.tsx` — already has tabs (`Crews`/`Runs`) and manual Run button. Line 130 (tab state), 179 (filter logic), 481 (Run button), 498 (RunsList).
+- `frontend/src/routes/connections.tsx` — current 7-platform grid with OAuth + token-paste flows.
+- `frontend/src/routes/distribution.tsx` — current publish-focused page; patterns to preserve (multi-select, delivery log).
+- `frontend/src/components/crews/crew-builder.tsx` — current 5-step wizard to extend.
+- `backend/services/channels/channel_service.py` — current inbound `handle_message()` — the thing `inbound_router.py` delegates to initially.
+- `backend/services/distribution_service.py` — existing outbound adapters (LinkedIn/Twitter/IG/FB/Blog/Email/Slack) — reuse, don't rewrite.
+- `backend/services/workspace/agent_runner.py` — where outbound publishing hooks in after crew execution.
+
+**Acceptance criteria**
+- User flow: Connect Reddit once in Connections → enable Inbound + Outbound capabilities → create Crew A (reactive on Reddit with keywords `pricing, demo`) and Crew B (scheduled daily post to Reddit) → both work, same single Reddit auth, no duplicate configuration anywhere.
+- Distribution and Schedule sidebar items click through to Coming Soon pages.
+- Existing Crews from before migration continue to work (channel_bindings auto-converted to direction="both").
+- Migrated distribution channels appear in Connections with Outbound enabled.
+- Manual "Run" button still works on every crew.
+
+---
+
 *This document is excluded from git. For internal planning only.*

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 # TODO — ContextuAI Solo Moonshot
 
 > Master task list. Prioritized by phases. Check off as completed.
-> **Created:** 2026-03-19 | **Last synced with code:** 2026-04-14
+> **Created:** 2026-03-19 | **Last synced with code:** 2026-04-15
 
 ---
 
@@ -108,21 +108,27 @@
 
 ## PHASE 2.5: DIFFERENTIATORS (Next Up — Before Launch)
 
-### P2.5-1: Reddit Connection ⭐ NEXT
-**Status:** [ ] Not Started
-**Effort:** 2-3 days
+### P2.5-1: Reddit Connection ⭐
+**Status:** [x] COMPLETE (2026-04-15)
+**Effort:** 2-3 days → done in 1 session
 **Why:** r/LocalLLaMA + r/selfhosted are the exact ICP. Same trigger+approval pipeline as Telegram/Discord. Highest-signal inbound channel for a local-AI product.
 
-- [ ] Reddit OAuth2 integration (script-type app → refresh token)
-- [ ] Add to `backend/routers/desktop_oauth.py` providers dict
-- [ ] Add to Connections UI (`frontend/src/routes/connections.tsx`)
-- [ ] Inbound: `backend/services/reddit_poller.py` — background poll subreddits + keyword mentions + inbox DMs every 60s
-- [ ] Store `last_seen_id` per subreddit to dedupe
-- [ ] Outbound: `POST /api/comment`, `POST /api/compose` for DMs
-- [ ] Wire into trigger system (`channel_service.handle_message()`)
-- [ ] Trigger example: "When someone mentions 'local LLM' in r/LocalLLaMA → run Crew"
-- [ ] Distribution service: outbound post/comment publishing
-- [ ] Respect Reddit rate limits (60 req/min OAuth)
+**What was built:**
+- [x] Reddit script-app auth via praw (token-paste flow, not browser OAuth)
+- [x] `backend/models/reddit_models.py` — Pydantic v2 models (account, update, reply)
+- [x] `backend/repositories/reddit_repository.py` — CRUD + `get_active()` + `update_last_seen()`
+- [x] `backend/services/reddit_client.py` — async praw wrapper (comments, inbox, reply, DM)
+- [x] `backend/services/reddit_poller.py` — 60s background poll subreddits + keyword filter + inbox DMs
+- [x] `backend/routers/reddit.py` — REST API: account CRUD, test connection, reply
+- [x] `ChannelType.REDDIT` added to `channel_service.py`
+- [x] Poller dispatches through `channel_service.handle_message()` → triggers + approval pipeline
+- [x] `last_seen_ids` per subreddit + inbox for dedupe
+- [x] Outbound: `POST /api/v1/reddit/reply` (comment + DM)
+- [x] Frontend: Reddit card in Connections UI (orange Flame icon, token-paste)
+- [x] `frontend/src/lib/api/reddit-client.ts` — full API client
+- [x] `backend/tests/test_reddit.py` — 6 passing tests
+- [x] praw==7.8.1 added to requirements.txt
+- [x] Respects Reddit rate limits (praw handles 60 req/min internally)
 
 ### P2.5-2: Knowledge Base (Local RAG) ⭐⭐ MAJOR DIFFERENTIATOR
 **Status:** [ ] Not Started
@@ -257,7 +263,7 @@
 
 ## QUICK REFERENCE
 
-**Total models in catalog:** 37 (6 families: Qwen 2.5, Qwen 3, Qwen 3.5, Gemma, Llama, Mistral, Phi, DeepSeek)
+**Total models in catalog:** 41 (8 families: Qwen 2.5, Qwen 3, Qwen 3.5, Gemma 3, Gemma 4, Llama, Mistral, Phi, DeepSeek)
 **Total agents:** 105 markdown files across 13 categories (incl. 12/15 social in `social-engagement/`)
 **Moonshot pick model:** Qwen 3.5 35B-A3B (MoE) — 35B brain, 3B speed, thinking + vision + 256K context
 **Backend port:** 18741
@@ -275,8 +281,8 @@
 - `frontend/src/routes/knowledge.tsx` (new)
 
 **Next up order:**
-1. Merge `feat/crew-channel-wiring` → main + cut `v1.0.0-beta.4` (8 commits unreleased)
-2. P2.5-1 Reddit Connection
+1. ~~Merge `feat/crew-channel-wiring` → main + cut `v1.0.0-beta.4`~~ DONE (#17 merged, beta.6 tagged)
+2. ~~P2.5-1 Reddit Connection~~ DONE (2026-04-15)
 3. P2.5-2 Knowledge Base (RAG) — reuse existing `embedding_service.py`
 4. Phase 2 remainder: Twitter inbound poller, IG/FB publishing fixes, Distribution UI, 3 missing social agents, crew template seeding
 5. Phase 3 Launch

--- a/TODO.md
+++ b/TODO.md
@@ -169,53 +169,41 @@
 ## PHASE 2: EXPAND REACH
 
 ### P2-1: Twitter/X Inbound Polling (GAP 3)
-**Status:** [ ] Not Started
-**Effort:** 1 day
-- [ ] `backend/services/twitter_poller.py` — background polling `GET /2/users/:id/mentions` every 60s
-- [ ] Store `last_seen_id` to avoid duplicate processing
-- [ ] Feed new mentions into trigger system
-- [ ] Also poll `GET /2/dm_events` for DM auto-reply
+**Status:** [x] COMPLETE (2026-04-19)
+- [x] `backend/services/twitter_poller.py` — 90s poll cycle (tighter than Twitter free-tier cap)
+- [x] `backend/models/twitter_models.py`, `backend/repositories/twitter_repository.py`, `backend/services/twitter_client.py` (OAuth 1.0a HMAC-SHA1 signing reused from distribution_service)
+- [x] `backend/routers/twitter.py` — REST CRUD + `/test` + `/reply`
+- [x] `ChannelType.TWITTER` added; poller dispatches through `channel_service.handle_message()`
+- [x] `frontend/src/lib/api/twitter-client.ts`
 
 ### P2-2: Fix Instagram Publishing (GAP 4)
-**Status:** [ ] Not Started
-**Effort:** 0.5 day
-- [ ] After Facebook OAuth, call Instagram Graph API to get `instagram_business_account`
-- [ ] Store correct `instagram_user_id` (not `profile_id`) — currently still reads profile_id in `distribution_service.py:443`
-- [ ] File: `backend/routers/desktop_oauth.py`
+**Status:** [x] COMPLETE (2026-04-19)
+- [x] OAuth callback now calls `GET /me/accounts` → `GET /{page_id}?fields=instagram_business_account`
+- [x] Stores `instagram_user_id`, `page_access_token`, `page_id` in the auto-created distribution channel
+- [x] Graceful no-op + warning if user has no IG-linked pages
 
 ### P2-3: Fix Facebook Publishing (GAP 4)
-**Status:** [ ] Not Started
-**Effort:** 0.5 day
-- [ ] Auto-populate `page_id` from OAuth token (no population currently in `desktop_oauth.py`)
-- [ ] Or add page selection step in connection flow
+**Status:** [x] COMPLETE (2026-04-19)
+- [x] OAuth callback calls `GET /me/accounts`, stores `page_id` + `page_access_token` (first page)
+- [x] TODO: multi-page selection UI (future)
 
 ### P2-4: Distribution UI (GAP 5)
-**Status:** [ ] Not Started
-**Effort:** 1 day
-- [ ] New frontend route `/distribution` (no route exists yet)
-- [ ] List distribution channels, manual publish button
-- [ ] Publish history view
-- [ ] Backend API already exists: `POST /api/v1/distribution/publish`
+**Status:** [x] COMPLETE (2026-04-19)
+- [x] `frontend/src/routes/distribution.tsx` — Channels list + Delivery history tabs
+- [x] Dynamic per-type config fields (LinkedIn / Twitter OAuth1+bearer / IG / FB / Blog / Email / Slack)
+- [x] Multi-channel Publish dialog with per-channel success/fail summary
+- [x] Enable/disable toggle, edit/delete, masked credentials on edit
+- [x] Route + sidebar (Send icon) wired
 
 ### P2-5: Add 15 Social Media Agents
-**Status:** [~] 12/15 DONE (folder: `agent-library/social-engagement/`)
-**Effort:** 0.2 day remaining
-
-**Already present:** social-media-responder, sentiment-analyzer, triage-agent, brand-voice-guardian, troll-detector, lead-qualifier, faq-auto-responder, engagement-strategist, content-repurposer, crisis-monitor, competitor-watcher, hashtag-optimizer
-
-**Missing (add these):**
-- [ ] `thread-composer.md`
-- [ ] `dm-closer.md`
-- [ ] `community-manager.md`
+**Status:** [x] COMPLETE 15/15 (2026-04-19)
+- [x] Added: `thread-composer.md`, `dm-closer.md`, `community-manager.md`
 
 ### P2-6: Pre-built Crew Templates
-**Status:** [ ] Not Started (only a frontend helper exists at `frontend/src/lib/crews/marketing-crew-template.ts` — no DB seeding)
-**Effort:** 0.5 day
-- [ ] Seed 4 crew templates on startup (like agent seeding)
-- [ ] Auto-Reply Crew (3 agents, sequential)
-- [ ] Sales DM Crew (3 agents, sequential)
-- [ ] Content Distribution Crew (2 agents, sequential)
-- [ ] Crisis Response Crew (3 agents, sequential)
+**Status:** [x] COMPLETE (2026-04-19)
+- [x] 4 JSON templates in `backend/crew-templates/`: auto-reply, sales-dm, content-distribution, crisis-response
+- [x] `backend/services/crew_template_seeder.py` — seeds into separate `crew_templates` collection on startup
+- [x] Re-seed via `POST /api/v1/desktop/reseed` (includes crew_templates_seeded count)
 
 ---
 
@@ -227,12 +215,14 @@
 - [ ] Code Reviewer, Bug Analyzer, Test Writer, Doc Generator, Refactoring Advisor
 - [ ] Crew template: Code Review Crew (sequential)
 
-### BL-3: Scheduled Crews (Cron-style)
-**Status:** [ ] Not Started
-**Effort:** 2-3 days
-- [ ] `crew_scheduler_service.py` with APScheduler
-- [ ] UI: cron picker in crew config
-- [ ] "Run this crew every morning at 9am"
+### BL-3: Scheduled Crews + Scheduled Posts (Cron-style)
+**Status:** [x] COMPLETE (2026-04-19)
+- [x] `backend/services/scheduler_service.py` — APScheduler-backed, supports `job_type=post` (via DistributionService) and `job_type=crew` (via CrewService.start_run)
+- [x] `backend/models/scheduled_job.py`, `backend/repositories/scheduled_job_repository.py`, `backend/routers/scheduled_jobs.py`
+- [x] REST: CRUD + `/run-now` + `/toggle` + `/validate-cron` (returns next 5 fire times)
+- [x] Frontend `/schedule` route — cron picker with presets (daily 9am, weekdays, hourly, Monday), timezone select, live preview of next runs
+- [x] Publishes on behalf of user to LinkedIn / Twitter / Instagram / Facebook / Slack / Blog / Email via existing DistributionService
+- [x] Survives restarts (APScheduler SQLite jobstore)
 
 ### BL-4: Crew Templates Marketplace
 **Status:** [ ] Not Started
@@ -283,8 +273,8 @@
 **Next up order:**
 1. ~~Merge `feat/crew-channel-wiring` → main + cut `v1.0.0-beta.4`~~ DONE (#17 merged, beta.6 tagged)
 2. ~~P2.5-1 Reddit Connection~~ DONE (2026-04-15)
-3. P2.5-2 Knowledge Base (RAG) — reuse existing `embedding_service.py`
-4. Phase 2 remainder: Twitter inbound poller, IG/FB publishing fixes, Distribution UI, 3 missing social agents, crew template seeding
+3. ~~Phase 2 remainder (P2-1…P2-6) + BL-3 Scheduler~~ DONE (2026-04-19)
+4. P2.5-2 Knowledge Base (RAG) — reuse existing `embedding_service.py`
 5. Phase 3 Launch
 
 ---

--- a/agent-library/social-engagement/community-manager.md
+++ b/agent-library/social-engagement/community-manager.md
@@ -1,0 +1,39 @@
+# Community Manager
+
+## Role Definition
+
+You are a Community Manager with 8+ years of experience building and nurturing online communities across Discord, Reddit, Facebook Groups, Slack, Telegram groups, and Circle-style platforms. You have grown communities from zero members to tens of thousands of active participants for SaaS products, creator brands, and open-source projects. You understand that a community is not a marketing channel or a support queue -- it is a living system of relationships, rituals, and shared identity that collapses the moment it is treated transactionally. Your job is to set the tone, facilitate belonging, resolve friction, and turn first-time visitors into long-term contributors.
+
+## Core Expertise
+
+- **Tone & Culture Setting**: Establishing and reinforcing the norms, voice, and values that define how members talk to each other -- through welcome messages, pinned posts, moderator behavior, and the first-week experience of every new joiner
+- **Event & Ritual Design**: Running recurring events (weekly AMAs, show-and-tell threads, monthly challenges, office hours) that give members predictable reasons to return, meet each other, and form bonds beyond one-off interactions
+- **Conflict Resolution & Moderation**: De-escalating heated discussions, mediating disputes, enforcing community guidelines consistently, and making hard calls on warnings, timeouts, and bans without eroding trust in the moderation system
+- **Retention & Re-Engagement**: Identifying members showing signs of drift (decreased posting, missed events, cold-shouldering newcomers) and designing light-touch interventions to bring them back before they churn silently
+- **Onboarding & First-Week Experience**: Designing the path from "just joined" to "first meaningful interaction" -- the single highest-leverage moment in community retention, where most communities lose members permanently
+- **Platform-Specific Fluency**: Operating natively across platform norms -- Discord's channel-and-role architecture, Reddit's voting and flair systems, Facebook Groups' feed-based discovery, Slack's thread-heavy conversation model -- each requires a different community-shaping toolkit
+
+## Community Operating Frameworks
+
+- **Welcome → First Post → First Reply**: The critical 72-hour journey where new members either bond with the community or ghost -- every community needs explicit design for each of these three moments
+- **90-9-1 Awareness**: Accept that most members will lurk, some will comment, and few will create -- design for lurkers to feel belonging, commenters to feel heard, and creators to feel celebrated, without forcing everyone into the same engagement shape
+- **Moderation Ladder**: Private nudge → public clarification → formal warning → temporary mute → ban -- escalate progressively and document every step so the process feels fair, not arbitrary
+- **Ritual Cadence**: Daily (low-effort prompts), weekly (recurring themed threads), monthly (events or challenges), quarterly (community retros) -- a healthy community has activity at every timescale
+- **Conflict Triage**: Identify whether the friction is a disagreement (let it breathe), a misunderstanding (clarify), a guideline violation (act visibly), or a bad-faith actor (remove) -- the worst mistake is treating all four the same way
+
+## Deliverables
+
+- Community health reports tracking active member count, new-member retention, messages-per-active-member, and ritual participation trends over time
+- Welcome-flow scripts, role-based onboarding sequences, and first-week nudge templates calibrated to the platform
+- Moderation guidelines with clear, enumerated examples of what each severity tier looks like in practice
+- Event playbooks for AMAs, launches, challenges, and office hours with pre-event hype, day-of facilitation, and post-event recap templates
+- Monthly community retros summarizing what worked, what broke, which members stepped up, and which rituals need rethinking
+
+## Operating Principles
+
+1. **Belonging beats features**: People stay in communities where they feel known, not where the bots are fancy -- invest in member-to-member bonds before anything else
+2. **Consistency builds trust**: Show up on the same rituals on the same cadence -- unreliable community presence signals that the community is not a priority, and members mirror that signal
+3. **Moderate visibly but sparingly**: Enforce guidelines clearly when you must, but over-moderation kills spontaneity -- the goal is a room that self-polices because members have internalized the norms
+4. **Celebrate members, not the brand**: The community exists to serve its members, not to serve the brand -- the moment that flips, engagement collapses
+5. **Small signals matter more than big campaigns**: A moderator replying to a lurker's first post does more for retention than a launch event -- invest in the many small touches
+6. **Design for graceful exit**: Members leave for legitimate reasons -- career changes, life phases, interest shifts -- and communities that farewell them warmly gain referrals and returning alumni, while those that guilt-trip or ignore departures burn goodwill

--- a/agent-library/social-engagement/dm-closer.md
+++ b/agent-library/social-engagement/dm-closer.md
@@ -1,0 +1,39 @@
+# DM Closer
+
+## Role Definition
+
+You are a DM Closer with 8+ years of experience converting inbound direct-message conversations into booked meetings, demo calls, and paying customers across Twitter/X, LinkedIn, Instagram, Telegram, and Discord. You have closed six- and seven-figure pipelines sourced entirely from DMs for consumer brands, SaaS startups, and high-ticket coaches. You understand that DMs are a fundamentally different sales surface than email or cold outbound -- the messages are shorter, the reply windows tighter, and the line between helpful and pushy is razor-thin. Your job is to move a warm conversation toward a real business outcome without burning the relationship.
+
+## Core Expertise
+
+- **Conversational Qualification**: Uncovering fit, budget, timeline, and decision authority through natural back-and-forth rather than discovery-call checklists -- asking one sharp question at a time and reading between the lines of the reply
+- **Objection Handling in Short Form**: Addressing concerns (price, timing, trust, authority, competing options) in 2-3 sentence replies that acknowledge the objection, reframe it, and move the conversation forward without sounding defensive or scripted
+- **Call-to-Action Calibration**: Matching the ask to the conversation temperature -- a curious prospect gets a soft invite to a resource, a warm prospect gets a 15-minute call offer, a hot prospect gets a direct booking link
+- **Push/Pull Rhythm**: Knowing when to lean in with a next step and when to pull back with a thoughtful question or space, avoiding the two deadliest DM failure modes: ghosting from pressure and drifting from disinterest
+- **Platform-Specific Etiquette**: Adapting cadence, formality, and CTA style to each platform -- LinkedIn tolerates slightly more business framing, Instagram rewards casual warmth, Twitter DMs favor concision, Telegram invites rapid-fire exchange
+- **Pipeline Discipline**: Tracking each conversation's stage, last-touch date, and next step so prospects do not slip through the cracks -- and knowing when a conversation has stalled long enough to re-open with a pattern interrupt
+
+## Closing Frameworks
+
+- **Question-Question-Invite**: Two clarifying questions that qualify while building rapport, then a low-friction invite (short call, resource share, or demo link) calibrated to the answers
+- **Pain-Echo-Solution**: Mirror the prospect's own stated problem back in their language, confirm alignment, then introduce the specific solution path -- never lead with the pitch
+- **Option A/B Close**: When a prospect is warm but stalling, offer two concrete next steps rather than one -- the choice architecture increases commitment and surfaces which path they prefer
+- **Graceful Exit Ramp**: If a prospect is not a fit, release them warmly with a genuine referral, resource, or parting thought -- closed-lost today becomes closed-won next quarter or a referral source
+- **Re-Engagement Pattern Interrupt**: For stalled conversations, break state with a short, specific, non-salesy message -- a relevant resource, a question tied to their recent post, or a brief check-in tied to new information
+
+## Deliverables
+
+- Qualified DM conversation transcripts with clearly-tagged stages (new → qualified → proposal → booked → closed) and next-step recommendations
+- Objection-response playbooks mapping the top 10 objections per buyer persona to tested reply variations
+- Calendar-booking conversion metrics (DM-to-booked-call ratio, DM-to-close ratio, average conversation length before booking)
+- CTA-ladder templates ranging from soft (share resource) to firm (booking link) calibrated by conversation temperature
+- Lost-deal reviews tagging the conversation turn where engagement dropped, used to refine future playbooks
+
+## Operating Principles
+
+1. **Qualify before you close**: A booked call with the wrong prospect is worse than no call -- spend the first two or three messages confirming fit before pushing any CTA
+2. **One ask per message**: Stacking a question, a pitch, and a CTA into a single DM overwhelms and repels -- advance the conversation by one move at a time
+3. **Speak like a human, sell like a pro**: Casual tone, specific details, and genuine curiosity beat polished sales-speak in every DM channel -- formality kills conversion on social DMs
+4. **Respect the silence**: If a prospect goes quiet, wait at least 48 hours before nudging, and when you do, bring something new -- never just "following up"
+5. **Match temperature, do not skip stages**: A prospect who asked a casual question is not ready for a 30-minute demo booking -- earn each stage with a smaller CTA first
+6. **Know when to walk**: Not every DM is a deal -- disqualifying quickly frees energy for prospects who will actually convert, and preserves the brand relationship with the ones who will not

--- a/agent-library/social-engagement/thread-composer.md
+++ b/agent-library/social-engagement/thread-composer.md
@@ -1,0 +1,39 @@
+# Thread Composer
+
+## Role Definition
+
+You are a Thread Composer with 8+ years of experience crafting long-form narrative content optimized for social platforms that reward depth -- Twitter/X threads, LinkedIn longform posts, and Instagram carousels. You have written threads that have reached millions of readers, turning complex ideas, founder stories, and technical teardowns into scroll-stopping narrative sequences. You understand that a great thread is not a single post chopped into pieces -- it is a deliberately paced story engineered for the scroll, with each unit earning the reader's attention to continue.
+
+## Core Expertise
+
+- **Hook Engineering**: Writing opening posts that stop the scroll -- counter-intuitive claims, curiosity gaps, bold promises, or pattern-interrupt statements that make continuation feel inevitable rather than optional
+- **Narrative Pacing**: Structuring multi-unit content with deliberate rhythm -- setup, tension, reveal, payoff -- so readers feel forward momentum and reach the call-to-action rather than dropping off mid-thread
+- **Platform-Native Formatting**: Tailoring each unit to platform norms -- tight 280-character tweets with single ideas, LinkedIn paragraphs with generous line breaks and business framing, Instagram carousel slides with visual hierarchy and one concept per card
+- **Idea Atomization**: Breaking complex arguments, frameworks, or stories into discrete atomic units that each stand alone while also serving the larger arc -- no wasted real estate, no filler posts
+- **Retention Levers**: Applying proven engagement patterns like open loops, cliffhangers at unit boundaries, numbered lists with teased totals, and contrarian reveals to keep readers moving down the thread
+- **Cross-Platform Adaptation**: Rewriting the same core idea for the voice and constraint of each platform -- a Twitter thread reads differently than the LinkedIn version of the same story, and neither maps cleanly to an Instagram carousel
+
+## Composition Frameworks
+
+- **Hook-Promise-Payoff**: Post 1 hooks attention and promises value, middle posts deliver the promised content in sequence, final post delivers the payoff and a clear next step
+- **Story Arc**: Setup (who/what/when) → Inciting event (the problem or tension) → Escalation (complications) → Resolution (what changed) → Lesson (transferable insight)
+- **Framework Teardown**: Introduce the framework by name → break it into N numbered components → give each component its own unit with example → close with how to apply it
+- **Before/After/Bridge**: Describe the painful before-state → paint the desirable after-state → bridge with the specific actions or insight that moves reader from one to the other
+- **Contrarian Thread**: Open with widely-held belief → flip it with evidence → explain why the consensus is wrong → offer the replacement mental model → end with implication for the reader
+
+## Deliverables
+
+- Complete multi-unit threads formatted for the target platform with numbered posts, character counts, and recommended pacing
+- Alternative hook variations (3-5 openings per thread) for A/B testing which cold-start works best
+- LinkedIn longform drafts with paragraph breaks, bolding suggestions, and engagement-optimized CTAs
+- Instagram carousel storyboards specifying slide count, one-line headline per slide, and visual direction notes
+- Thread performance post-mortems analyzing drop-off points and suggesting structural revisions for future threads
+
+## Operating Principles
+
+1. **The hook is 80% of the outcome**: Spend disproportionate effort on post 1 -- if it fails, nothing that follows matters, no matter how good the content is
+2. **Each unit must earn the next scroll**: Every post should either open a loop, deliver a payoff, or do both -- never coast on the strength of previous posts
+3. **Respect platform DNA**: Do not paste a Twitter thread into LinkedIn verbatim or vice versa -- each platform rewards a different voice, rhythm, and density
+4. **One idea per unit**: Resist cramming -- if two ideas fight for the same post, split them; clarity compounds across the thread
+5. **End with a destination**: Every thread should close with a specific CTA -- follow, save, reply, click, buy -- never leave the reader wondering what to do with what they just read
+6. **Write for the skimmer first**: Readers scan before they commit -- bold hooks, clear structure, and scannable formatting win more attention than dense prose, no matter how good the prose is

--- a/backend/adapters/apscheduler_adapter.py
+++ b/backend/adapters/apscheduler_adapter.py
@@ -75,6 +75,17 @@ class APSchedulerAdapter(SchedulerAdapter):
             self._scheduler = None
             logger.info("APSchedulerAdapter stopped")
 
+    def scheduler(self):
+        """Return the underlying AsyncIOScheduler for advanced use.
+
+        Services that need richer APScheduler features (cron triggers,
+        interval triggers, job introspection) can obtain the live
+        scheduler through this helper instead of reaching into the
+        private ``_scheduler`` attribute.
+        """
+        self._require_running()
+        return self._scheduler
+
     # ------------------------------------------------------------------
     # Task scheduling
     # ------------------------------------------------------------------

--- a/backend/app.py
+++ b/backend/app.py
@@ -42,6 +42,7 @@ from routers.openai_compat import router as openai_compat_router
 from routers.triggers import router as triggers_router
 from routers.approvals import router as approvals_router
 from routers.blueprints import router as blueprints_router
+from routers.reddit import router as reddit_router
 
 # ---------------------------------------------------------------------------
 # Logging
@@ -90,6 +91,7 @@ app.include_router(openai_compat_router)
 app.include_router(triggers_router)
 app.include_router(approvals_router)
 app.include_router(blueprints_router)
+app.include_router(reddit_router)
 
 
 # ---------------------------------------------------------------------------
@@ -437,6 +439,12 @@ async def startup_event():
         # Seed model configs for any already-downloaded local GGUF models
         await _seed_local_models(proxy)
 
+        # Start Reddit poller (runs only when a Reddit account is configured)
+        from services.reddit_poller import get_poller
+
+        app.state.reddit_poller = get_poller(proxy)
+        await app.state.reddit_poller.start()
+
         logger.info("ContextuAI Solo backend ready")
 
     except Exception:
@@ -458,6 +466,13 @@ async def shutdown_event():
         logger.info("Scheduler adapter closed")
     except Exception:
         logger.exception("Error closing scheduler adapter")
+
+    try:
+        poller = getattr(app.state, "reddit_poller", None)
+        if poller:
+            await poller.stop()
+    except Exception:
+        logger.exception("Error stopping Reddit poller")
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app.py
+++ b/backend/app.py
@@ -43,6 +43,8 @@ from routers.triggers import router as triggers_router
 from routers.approvals import router as approvals_router
 from routers.blueprints import router as blueprints_router
 from routers.reddit import router as reddit_router
+from routers.twitter import router as twitter_router
+from routers.scheduled_jobs import router as scheduled_jobs_router
 
 # ---------------------------------------------------------------------------
 # Logging
@@ -92,6 +94,8 @@ app.include_router(triggers_router)
 app.include_router(approvals_router)
 app.include_router(blueprints_router)
 app.include_router(reddit_router)
+app.include_router(twitter_router)
+app.include_router(scheduled_jobs_router)
 
 
 # ---------------------------------------------------------------------------
@@ -391,6 +395,28 @@ async def _seed_local_models(db):
         logger.exception("Failed to seed local model configs")
 
 
+async def _seed_crew_templates(db):
+    """
+    Seed crew templates from the on-disk JSON library into the
+    ``crew_templates`` collection (separate from user-created ``crews``).
+    """
+    try:
+        from services.crew_template_seeder import CrewTemplateSeeder
+        seeder = CrewTemplateSeeder()
+
+        from pathlib import Path as _Path
+        library_path = _Path(os.environ.get("CREW_TEMPLATE_LIBRARY_PATH", seeder.LIBRARY_PATH))
+        if not library_path.exists():
+            logger.warning("Crew template library not found at %s — skipping seed", library_path)
+            return
+
+        collection = db["crew_templates"]
+        seeded = await seeder.sync_library_to_db(collection)
+        logger.info("Crew template library: seeded %d new template(s)", seeded)
+    except Exception:
+        logger.exception("Failed to seed crew template library")
+
+
 # ---------------------------------------------------------------------------
 # Lifecycle events
 # ---------------------------------------------------------------------------
@@ -404,6 +430,8 @@ async def startup_event():
             os.environ["AGENT_LIBRARY_PATH"] = os.path.join(_repo_root, "agent-library")
         if "BLUEPRINT_LIBRARY_PATH" not in os.environ:
             os.environ["BLUEPRINT_LIBRARY_PATH"] = os.path.join(_repo_root, "blueprints")
+        if "CREW_TEMPLATE_LIBRARY_PATH" not in os.environ:
+            os.environ["CREW_TEMPLATE_LIBRARY_PATH"] = os.path.join(_repo_root, "backend", "crew-templates")
 
         # Database adapter (SQLite)
         adapter = await get_database_adapter()
@@ -436,6 +464,9 @@ async def startup_event():
         # Seed blueprint library
         await _seed_blueprints(proxy)
 
+        # Seed crew templates library
+        await _seed_crew_templates(proxy)
+
         # Seed model configs for any already-downloaded local GGUF models
         await _seed_local_models(proxy)
 
@@ -444,6 +475,18 @@ async def startup_event():
 
         app.state.reddit_poller = get_poller(proxy)
         await app.state.reddit_poller.start()
+
+        # Start Twitter poller (runs only when a Twitter account is configured)
+        from services.twitter_poller import get_poller as get_twitter_poller
+
+        app.state.twitter_poller = get_twitter_poller(proxy)
+        await app.state.twitter_poller.start()
+
+        # Scheduled jobs (cron-based posts + crew runs)
+        from services.scheduler_service import SchedulerService
+        scheduler_service = SchedulerService(proxy, scheduler)
+        await scheduler_service.load_all()
+        app.state.scheduler_service = scheduler_service
 
         logger.info("ContextuAI Solo backend ready")
 
@@ -473,6 +516,13 @@ async def shutdown_event():
             await poller.stop()
     except Exception:
         logger.exception("Error stopping Reddit poller")
+
+    try:
+        poller = getattr(app.state, "twitter_poller", None)
+        if poller:
+            await poller.stop()
+    except Exception:
+        logger.exception("Error stopping Twitter poller")
 
 
 # ---------------------------------------------------------------------------
@@ -563,15 +613,22 @@ async def reseed_data():
         await bp_collection.delete_many({})
         await _seed_blueprints(db)
 
+        # Clear and re-seed crew templates library
+        ct_collection = db["crew_templates"]
+        await ct_collection.delete_many({})
+        await _seed_crew_templates(db)
+
         pt_count = await pt_collection.count_documents({})
         agent_count = await agent_collection.count_documents({})
         bp_count = await bp_collection.count_documents({})
+        ct_count = await ct_collection.count_documents({})
 
         return {
             "status": "success",
             "persona_types_seeded": pt_count,
             "agents_seeded": agent_count,
             "blueprints_seeded": bp_count,
+            "crew_templates_seeded": ct_count,
         }
     except Exception as e:
         logger.exception("Reseed failed")

--- a/backend/crew-templates/auto-reply-crew.json
+++ b/backend/crew-templates/auto-reply-crew.json
@@ -1,0 +1,20 @@
+{
+  "id": "auto-reply-crew",
+  "name": "Auto-Reply Crew",
+  "description": "Sequential triage-to-response pipeline for inbound messages across Telegram, Discord, Reddit, and Twitter/X. Classifies each incoming message, drafts a brand-voice reply, and scores the outgoing sentiment before dispatch so complaints never slip past and responses never miss the mark.",
+  "execution_mode": "sequential",
+  "agents": [
+    "social_engagement-triage-agent",
+    "social_engagement-social-media-responder",
+    "social_engagement-sentiment-analyzer"
+  ],
+  "channel_bindings": [
+    { "channel_type": "telegram", "enabled": true, "approval_required": false },
+    { "channel_type": "discord", "enabled": true, "approval_required": false },
+    { "channel_type": "reddit", "enabled": true, "approval_required": true },
+    { "channel_type": "twitter", "enabled": true, "approval_required": true }
+  ],
+  "tags": ["social", "inbound", "auto-reply", "triage"],
+  "is_template": true,
+  "is_system": true
+}

--- a/backend/crew-templates/content-distribution-crew.json
+++ b/backend/crew-templates/content-distribution-crew.json
@@ -1,0 +1,18 @@
+{
+  "id": "content-distribution-crew",
+  "name": "Content Distribution Crew",
+  "description": "Takes a single source piece of content and distributes it across LinkedIn, Twitter/X, and Instagram in platform-native formats. The repurposer adapts the core idea for each surface; the thread composer structures the long-form narrative sequence. Runs in parallel so all channels publish together.",
+  "execution_mode": "parallel",
+  "agents": [
+    "social_engagement-content-repurposer",
+    "social_engagement-thread-composer"
+  ],
+  "channel_bindings": [
+    { "channel_type": "linkedin", "enabled": true, "approval_required": false },
+    { "channel_type": "twitter", "enabled": true, "approval_required": false },
+    { "channel_type": "instagram", "enabled": true, "approval_required": false }
+  ],
+  "tags": ["content", "distribution", "cross-post", "outbound"],
+  "is_template": true,
+  "is_system": true
+}

--- a/backend/crew-templates/crisis-response-crew.json
+++ b/backend/crew-templates/crisis-response-crew.json
@@ -1,0 +1,21 @@
+{
+  "id": "crisis-response-crew",
+  "name": "Crisis Response Crew",
+  "description": "Triggered by negative sentiment spikes or brand-safety events. Detects the crisis signal, enforces brand voice and legal-safe language on every outgoing message, and drafts calibrated responses for each affected channel. Approval-gated by default so nothing ships without a human in the loop.",
+  "execution_mode": "sequential",
+  "agents": [
+    "social_engagement-crisis-monitor",
+    "social_engagement-brand-voice-guardian",
+    "social_engagement-social-media-responder"
+  ],
+  "channel_bindings": [
+    { "channel_type": "twitter", "enabled": true, "approval_required": true },
+    { "channel_type": "linkedin", "enabled": true, "approval_required": true },
+    { "channel_type": "instagram", "enabled": true, "approval_required": true },
+    { "channel_type": "facebook", "enabled": true, "approval_required": true },
+    { "channel_type": "reddit", "enabled": true, "approval_required": true }
+  ],
+  "tags": ["crisis", "brand-safety", "escalation", "approval-required"],
+  "is_template": true,
+  "is_system": true
+}

--- a/backend/crew-templates/sales-dm-crew.json
+++ b/backend/crew-templates/sales-dm-crew.json
@@ -1,0 +1,19 @@
+{
+  "id": "sales-dm-crew",
+  "name": "Sales DM Crew",
+  "description": "Converts inbound direct messages into qualified pipeline on LinkedIn, Instagram, and Twitter/X. Qualifies the lead's fit and intent, moves the conversation toward a booked call or purchase, and covers predictable FAQs without losing the warm thread.",
+  "execution_mode": "sequential",
+  "agents": [
+    "social_engagement-lead-qualifier",
+    "social_engagement-dm-closer",
+    "social_engagement-faq-auto-responder"
+  ],
+  "channel_bindings": [
+    { "channel_type": "linkedin", "enabled": true, "approval_required": true },
+    { "channel_type": "instagram", "enabled": true, "approval_required": true },
+    { "channel_type": "twitter", "enabled": true, "approval_required": true }
+  ],
+  "tags": ["sales", "dm", "qualification", "closing"],
+  "is_template": true,
+  "is_system": true
+}

--- a/backend/models/reddit_models.py
+++ b/backend/models/reddit_models.py
@@ -1,0 +1,55 @@
+"""Pydantic v2 models for the Reddit connection."""
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class RedditAccount(BaseModel):
+    """Stored Reddit account credentials + poll configuration."""
+
+    model_config = {"protected_namespaces": ()}
+
+    id: Optional[str] = Field(default=None, alias="_id")
+    client_id: str = Field(..., min_length=1)
+    client_secret: str = Field(..., min_length=1)
+    username: str = Field(..., min_length=1)
+    password: str = Field(..., min_length=1)
+    user_agent: str = Field(default="ContextuAI-Solo/1.0")
+
+    subreddits: List[str] = Field(default_factory=list)
+    keywords: List[str] = Field(default_factory=list)
+    poll_inbox: bool = Field(default=True)
+
+    enabled: bool = Field(default=True)
+    last_seen_ids: dict = Field(default_factory=dict)
+
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class RedditAccountCreate(BaseModel):
+    client_id: str = Field(..., min_length=1)
+    client_secret: str = Field(..., min_length=1)
+    username: str = Field(..., min_length=1)
+    password: str = Field(..., min_length=1)
+    user_agent: Optional[str] = None
+    subreddits: List[str] = Field(default_factory=list)
+    keywords: List[str] = Field(default_factory=list)
+    poll_inbox: bool = True
+
+
+class RedditAccountUpdate(BaseModel):
+    subreddits: Optional[List[str]] = None
+    keywords: Optional[List[str]] = None
+    poll_inbox: Optional[bool] = None
+    enabled: Optional[bool] = None
+
+
+class RedditPostReply(BaseModel):
+    """Outbound comment or DM."""
+
+    target_type: str = Field(..., pattern="^(comment|submission|dm)$")
+    target_id: str = Field(..., min_length=1)
+    text: str = Field(..., min_length=1, max_length=10000)
+    recipient: Optional[str] = None

--- a/backend/models/scheduled_job.py
+++ b/backend/models/scheduled_job.py
@@ -1,0 +1,100 @@
+"""
+Scheduled Job Models — Pydantic v2 models for cron-based recurring jobs.
+
+A ScheduledJob represents a cron-scheduled task that either publishes
+content to a distribution channel (``job_type="post"``) or triggers a
+crew run (``job_type="crew"``). Managed by SchedulerService on top of
+the APScheduler adapter.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ScheduledJob(BaseModel):
+    """A persisted cron-scheduled job."""
+
+    model_config = {"protected_namespaces": (), "populate_by_name": True}
+
+    id: Optional[str] = Field(default=None, alias="_id")
+    name: str = Field(..., min_length=1, max_length=200)
+    job_type: Literal["post", "crew"]
+    cron: str = Field(..., description='Standard 5-field cron, e.g. "0 9 * * *"')
+    timezone: str = "UTC"
+    enabled: bool = True
+
+    # For job_type=post
+    channel_id: Optional[str] = None
+    content: Optional[str] = None
+    title: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+
+    # For job_type=crew
+    crew_id: Optional[str] = None
+    crew_input: Optional[Dict[str, Any]] = None
+
+    # Tracking
+    last_run_at: Optional[str] = None
+    last_run_status: Optional[str] = None  # "success" | "failed"
+    last_run_error: Optional[str] = None
+    next_run_at: Optional[str] = None
+    run_count: int = 0
+
+    created_at: datetime
+    updated_at: datetime
+
+
+class ScheduledJobCreate(BaseModel):
+    """Request body to create a new scheduled job."""
+
+    model_config = {"protected_namespaces": ()}
+
+    name: str = Field(..., min_length=1, max_length=200)
+    job_type: Literal["post", "crew"]
+    cron: str = Field(..., description='Standard 5-field cron, e.g. "0 9 * * *"')
+    timezone: str = "UTC"
+    enabled: bool = True
+
+    # post
+    channel_id: Optional[str] = None
+    content: Optional[str] = None
+    title: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+
+    # crew
+    crew_id: Optional[str] = None
+    crew_input: Optional[Dict[str, Any]] = None
+
+
+class ScheduledJobUpdate(BaseModel):
+    """Partial update for an existing scheduled job."""
+
+    model_config = {"protected_namespaces": ()}
+
+    name: Optional[str] = Field(default=None, min_length=1, max_length=200)
+    cron: Optional[str] = None
+    timezone: Optional[str] = None
+    enabled: Optional[bool] = None
+
+    channel_id: Optional[str] = None
+    content: Optional[str] = None
+    title: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+
+    crew_id: Optional[str] = None
+    crew_input: Optional[Dict[str, Any]] = None
+
+
+class ScheduledJobRunResult(BaseModel):
+    """Result of an immediate or scheduled job execution."""
+
+    model_config = {"protected_namespaces": ()}
+
+    job_id: str
+    job_type: Literal["post", "crew"]
+    status: Literal["success", "failed", "skipped"]
+    ran_at: str
+    error: Optional[str] = None
+    details: Optional[Dict[str, Any]] = None

--- a/backend/models/twitter_models.py
+++ b/backend/models/twitter_models.py
@@ -1,0 +1,69 @@
+"""Pydantic v2 models for the Twitter/X connection."""
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class TwitterAccount(BaseModel):
+    """Stored Twitter/X account credentials + poll configuration.
+
+    Either OAuth 1.0a user-context creds (api_key/api_secret/access_token/
+    access_token_secret) or a bearer_token may be supplied. OAuth 1.0a is
+    required for posting replies and DMs; bearer_token is sufficient for
+    read-only polling.
+    """
+
+    model_config = {"protected_namespaces": ()}
+
+    id: Optional[str] = Field(default=None, alias="_id")
+
+    # OAuth 1.0a user-context
+    api_key: Optional[str] = Field(default=None)
+    api_secret: Optional[str] = Field(default=None)
+    access_token: Optional[str] = Field(default=None)
+    access_token_secret: Optional[str] = Field(default=None)
+
+    # App-only bearer token (for read endpoints)
+    bearer_token: Optional[str] = Field(default=None)
+
+    # Numeric Twitter user id for mention polling
+    user_id: str = Field(..., min_length=1)
+
+    keywords: List[str] = Field(default_factory=list)
+    poll_mentions: bool = Field(default=True)
+    poll_dms: bool = Field(default=True)
+
+    enabled: bool = Field(default=True)
+    last_seen_ids: dict = Field(default_factory=dict)
+
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class TwitterAccountCreate(BaseModel):
+    api_key: Optional[str] = None
+    api_secret: Optional[str] = None
+    access_token: Optional[str] = None
+    access_token_secret: Optional[str] = None
+    bearer_token: Optional[str] = None
+    user_id: str = Field(..., min_length=1)
+    keywords: List[str] = Field(default_factory=list)
+    poll_mentions: bool = True
+    poll_dms: bool = True
+
+
+class TwitterAccountUpdate(BaseModel):
+    keywords: Optional[List[str]] = None
+    poll_mentions: Optional[bool] = None
+    poll_dms: Optional[bool] = None
+    enabled: Optional[bool] = None
+
+
+class TwitterPostReply(BaseModel):
+    """Outbound tweet reply or DM."""
+
+    target_type: str = Field(..., pattern="^(tweet|dm)$")
+    target_id: str = Field(..., min_length=1)
+    text: str = Field(..., min_length=1, max_length=10000)
+    recipient: Optional[str] = None

--- a/backend/repositories/reddit_repository.py
+++ b/backend/repositories/reddit_repository.py
@@ -1,0 +1,26 @@
+"""Persistence for Reddit account config + poll state."""
+from typing import Any, Dict, List, Optional
+
+from motor.motor_asyncio import AsyncIOMotorDatabase
+
+from repositories.base_repository import BaseRepository
+
+
+class RedditRepository(BaseRepository):
+    """Stores one Reddit account config per user (single-user desktop = 1 doc)."""
+
+    def __init__(self, db: AsyncIOMotorDatabase):
+        super().__init__(db, "reddit_accounts")
+
+    async def get_active(self) -> Optional[Dict[str, Any]]:
+        """Return the single enabled Reddit account (desktop = 1 user)."""
+        cursor = self.collection.find({"enabled": True})
+        docs = await cursor.to_list(length=1)
+        return docs[0] if docs else None
+
+    async def update_last_seen(self, account_id: str, source: str, last_id: str) -> None:
+        """Track last seen comment/submission id per subreddit (or 'inbox')."""
+        await self.collection.update_one(
+            {"_id": account_id},
+            {"$set": {f"last_seen_ids.{source}": last_id}},
+        )

--- a/backend/repositories/scheduled_job_repository.py
+++ b/backend/repositories/scheduled_job_repository.py
@@ -1,0 +1,151 @@
+"""
+ScheduledJob Repository — CRUD for cron-scheduled jobs.
+
+Follows the BaseRepository pattern used by other repositories. Documents
+are persisted in the ``scheduled_jobs`` collection. The ``_id`` column
+holds the same UUID as the ``id`` response field; this keeps it simple
+to correlate DB docs with APScheduler job IDs.
+"""
+
+import uuid
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from motor.motor_asyncio import AsyncIOMotorDatabase
+
+from repositories.base_repository import BaseRepository
+
+
+class ScheduledJobRepository(BaseRepository):
+    """Repository for scheduled job documents."""
+
+    def __init__(self, db: AsyncIOMotorDatabase):
+        super().__init__(db, "scheduled_jobs")
+
+    # ------------------------------------------------------------------
+    # Create
+    # ------------------------------------------------------------------
+
+    async def create_job(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Create a new scheduled job with tracking defaults."""
+        job_id = data.get("id") or str(uuid.uuid4())
+        now = datetime.utcnow().isoformat()
+        doc = {
+            "_id": job_id,
+            "name": data["name"],
+            "job_type": data["job_type"],
+            "cron": data["cron"],
+            "timezone": data.get("timezone", "UTC"),
+            "enabled": data.get("enabled", True),
+            "channel_id": data.get("channel_id"),
+            "content": data.get("content"),
+            "title": data.get("title"),
+            "metadata": data.get("metadata"),
+            "crew_id": data.get("crew_id"),
+            "crew_input": data.get("crew_input"),
+            "last_run_at": None,
+            "last_run_status": None,
+            "last_run_error": None,
+            "next_run_at": data.get("next_run_at"),
+            "run_count": 0,
+            "created_at": now,
+            "updated_at": now,
+        }
+        await self.collection.insert_one(doc)
+        doc["id"] = doc.pop("_id")
+        return doc
+
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
+
+    async def get_job(self, job_id: str) -> Optional[Dict[str, Any]]:
+        """Fetch a single scheduled job by ID."""
+        doc = await self.collection.find_one({"_id": job_id})
+        if doc:
+            doc["id"] = doc.pop("_id")
+        return doc
+
+    async def list_jobs(
+        self,
+        skip: int = 0,
+        limit: int = 100,
+    ) -> List[Dict[str, Any]]:
+        """List all scheduled jobs (most recent first)."""
+        cursor = (
+            self.collection.find({})
+            .sort("created_at", -1)
+            .skip(skip)
+            .limit(limit)
+        )
+        docs: List[Dict[str, Any]] = []
+        async for doc in cursor:
+            doc["id"] = doc.pop("_id")
+            docs.append(doc)
+        return docs
+
+    async def list_enabled(self) -> List[Dict[str, Any]]:
+        """List all enabled scheduled jobs (used on startup to rehydrate)."""
+        cursor = self.collection.find({"enabled": True})
+        docs: List[Dict[str, Any]] = []
+        async for doc in cursor:
+            doc["id"] = doc.pop("_id")
+            docs.append(doc)
+        return docs
+
+    async def count_all(self) -> int:
+        return await self.collection.count_documents({})
+
+    # ------------------------------------------------------------------
+    # Update
+    # ------------------------------------------------------------------
+
+    async def update_job(
+        self, job_id: str, updates: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        """Partial update for a scheduled job."""
+        clean = {k: v for k, v in updates.items() if v is not None}
+        if not clean:
+            return await self.get_job(job_id)
+        clean["updated_at"] = datetime.utcnow().isoformat()
+        await self.collection.update_one({"_id": job_id}, {"$set": clean})
+        return await self.get_job(job_id)
+
+    async def record_run(
+        self,
+        job_id: str,
+        status: str,
+        error: Optional[str] = None,
+        next_run_at: Optional[str] = None,
+    ) -> None:
+        """Record the result of an execution and bump ``run_count``."""
+        now = datetime.utcnow().isoformat()
+        set_fields: Dict[str, Any] = {
+            "last_run_at": now,
+            "last_run_status": status,
+            "last_run_error": error,
+            "updated_at": now,
+        }
+        if next_run_at is not None:
+            set_fields["next_run_at"] = next_run_at
+        await self.collection.update_one(
+            {"_id": job_id},
+            {"$set": set_fields, "$inc": {"run_count": 1}},
+        )
+
+    async def set_next_run_at(
+        self, job_id: str, next_run_at: Optional[str]
+    ) -> None:
+        await self.collection.update_one(
+            {"_id": job_id},
+            {"$set": {"next_run_at": next_run_at}},
+        )
+
+    # ------------------------------------------------------------------
+    # Delete
+    # ------------------------------------------------------------------
+
+    async def delete_job(self, job_id: str) -> bool:
+        """Delete a scheduled job. Returns True if removed."""
+        result = await self.collection.delete_one({"_id": job_id})
+        return result.deleted_count > 0

--- a/backend/repositories/twitter_repository.py
+++ b/backend/repositories/twitter_repository.py
@@ -1,0 +1,26 @@
+"""Persistence for Twitter/X account config + poll state."""
+from typing import Any, Dict, Optional
+
+from motor.motor_asyncio import AsyncIOMotorDatabase
+
+from repositories.base_repository import BaseRepository
+
+
+class TwitterRepository(BaseRepository):
+    """Stores one Twitter account config per user (single-user desktop = 1 doc)."""
+
+    def __init__(self, db: AsyncIOMotorDatabase):
+        super().__init__(db, "twitter_accounts")
+
+    async def get_active(self) -> Optional[Dict[str, Any]]:
+        """Return the single enabled Twitter account (desktop = 1 user)."""
+        cursor = self.collection.find({"enabled": True})
+        docs = await cursor.to_list(length=1)
+        return docs[0] if docs else None
+
+    async def update_last_seen(self, account_id: str, source: str, last_id: str) -> None:
+        """Track last seen tweet/DM id per source ('mentions' or 'dms')."""
+        await self.collection.update_one(
+            {"_id": account_id},
+            {"$set": {f"last_seen_ids.{source}": last_id}},
+        )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,6 +15,9 @@ aiofiles==24.1.0
 requests==2.32.3
 httpx==0.28.1
 
+# Reddit connection
+praw==7.8.1
+
 # AI frameworks
 strands-agents==1.7.0
 strands-agents-tools==0.2.6

--- a/backend/routers/desktop_oauth.py
+++ b/backend/routers/desktop_oauth.py
@@ -395,6 +395,86 @@ async def oauth_callback(
 
         logger.info("OAuth connected: %s (profile: %s)", provider, profile_name)
 
+        # Resolve provider-specific channel config extras (Meta pages, IG biz id)
+        extra_config: dict = {}
+        if provider in ("instagram", "facebook"):
+            try:
+                async with httpx.AsyncClient(timeout=15.0) as mc:
+                    pages_resp = await mc.get(
+                        "https://graph.facebook.com/v21.0/me/accounts",
+                        params={"access_token": access_token},
+                    )
+                if pages_resp.status_code == 200:
+                    pages = (pages_resp.json().get("data") or [])
+                    if pages:
+                        # TODO: multi-page selection UI — for now pick the first page
+                        first_page = pages[0]
+                        page_id = first_page.get("id")
+                        page_access_token = first_page.get("access_token")
+
+                        if provider == "facebook":
+                            if page_id:
+                                extra_config["page_id"] = page_id
+                            if page_access_token:
+                                extra_config["page_access_token"] = page_access_token
+                            if not page_id or not page_access_token:
+                                logger.warning(
+                                    "Facebook page info incomplete (page_id=%s, token=%s)",
+                                    bool(page_id), bool(page_access_token),
+                                )
+
+                        elif provider == "instagram":
+                            # IG business account is linked to a FB page;
+                            # fetch it via the page-level token.
+                            if page_id and page_access_token:
+                                try:
+                                    async with httpx.AsyncClient(timeout=15.0) as mc2:
+                                        ig_resp = await mc2.get(
+                                            f"https://graph.facebook.com/v21.0/{page_id}",
+                                            params={
+                                                "fields": "instagram_business_account",
+                                                "access_token": page_access_token,
+                                            },
+                                        )
+                                    if ig_resp.status_code == 200:
+                                        ig_biz = (ig_resp.json() or {}).get(
+                                            "instagram_business_account"
+                                        )
+                                        if ig_biz and ig_biz.get("id"):
+                                            extra_config["instagram_user_id"] = ig_biz["id"]
+                                            extra_config["page_access_token"] = page_access_token
+                                            extra_config["page_id"] = page_id
+                                        else:
+                                            logger.warning(
+                                                "Facebook page %s has no linked Instagram "
+                                                "business account — IG publishing disabled",
+                                                page_id,
+                                            )
+                                    else:
+                                        logger.warning(
+                                            "Failed to fetch IG business account from page %s: "
+                                            "%s %s",
+                                            page_id, ig_resp.status_code, ig_resp.text[:200],
+                                        )
+                                except Exception as ig_err:
+                                    logger.warning(
+                                        "IG business-account lookup failed: %s", ig_err
+                                    )
+                    else:
+                        logger.warning(
+                            "%s OAuth: user has no Facebook pages (required for publishing)",
+                            provider,
+                        )
+                else:
+                    logger.warning(
+                        "%s OAuth: /me/accounts call failed %s: %s",
+                        provider, pages_resp.status_code, pages_resp.text[:200],
+                    )
+            except Exception as meta_err:
+                logger.warning(
+                    "%s OAuth: page-info lookup failed: %s", provider, meta_err
+                )
+
         # Auto-register a distribution channel so crew publishing works
         # without the user having to register credentials in two places
         try:
@@ -402,7 +482,7 @@ async def oauth_callback(
             existing = await dist_coll.find_one({"channel_type": provider})
             if not existing:
                 import uuid
-                channel_config = {"access_token": access_token}
+                channel_config = {"access_token": access_token, **extra_config}
                 if provider == "linkedin" and profile_id:
                     # Use org_id for company page, profile_id for personal
                     org_id = doc.get("org_id")
@@ -437,6 +517,8 @@ async def oauth_callback(
                         update_set["config.author_urn"] = f"urn:li:organization:{org_id}"
                     elif profile_id:
                         update_set["config.author_urn"] = f"urn:li:person:{profile_id}"
+                for k, v in extra_config.items():
+                    update_set[f"config.{k}"] = v
                 await dist_coll.update_one(
                     {"channel_type": provider},
                     {"$set": update_set},

--- a/backend/routers/reddit.py
+++ b/backend/routers/reddit.py
@@ -1,0 +1,137 @@
+"""Reddit connection REST API.
+
+Endpoints:
+- GET  /api/v1/reddit/account        — current config (password redacted)
+- POST /api/v1/reddit/account        — create/replace config
+- PUT  /api/v1/reddit/account/{id}   — update subreddits/keywords/enabled
+- DELETE /api/v1/reddit/account/{id}
+- POST /api/v1/reddit/test           — verify creds against Reddit API
+- POST /api/v1/reddit/reply          — manual reply to a comment or DM
+"""
+import uuid
+from datetime import datetime
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from database import get_database
+from models.reddit_models import (
+    RedditAccountCreate,
+    RedditAccountUpdate,
+    RedditPostReply,
+)
+from repositories.reddit_repository import RedditRepository
+from services.reddit_client import RedditClient
+
+router = APIRouter(prefix="/api/v1/reddit", tags=["reddit"])
+
+
+def _repo(db=Depends(get_database)) -> RedditRepository:
+    return RedditRepository(db)
+
+
+def _redact(doc: Dict[str, Any]) -> Dict[str, Any]:
+    if not doc:
+        return doc
+    out = {**doc}
+    out["password"] = "***"
+    out["client_secret"] = "***"
+    return out
+
+
+@router.get("/account")
+async def get_account(repo: RedditRepository = Depends(_repo)) -> Dict[str, Any]:
+    doc = await repo.get_active()
+    return {"account": _redact(doc) if doc else None}
+
+
+@router.post("/account")
+async def create_account(
+    payload: RedditAccountCreate, repo: RedditRepository = Depends(_repo)
+) -> Dict[str, Any]:
+    existing = await repo.get_active()
+    if existing:
+        await repo.delete(existing["_id"])
+
+    doc = {
+        "_id": str(uuid.uuid4()),
+        **payload.model_dump(exclude_none=True),
+        "enabled": True,
+        "last_seen_ids": {},
+        "created_at": datetime.utcnow().isoformat(),
+        "updated_at": datetime.utcnow().isoformat(),
+    }
+    doc.setdefault("user_agent", "ContextuAI-Solo/1.0")
+    await repo.create(doc)
+    return {"account": _redact(doc)}
+
+
+@router.put("/account/{account_id}")
+async def update_account(
+    account_id: str,
+    payload: RedditAccountUpdate,
+    repo: RedditRepository = Depends(_repo),
+) -> Dict[str, Any]:
+    updated = await repo.update(
+        account_id,
+        {**payload.model_dump(exclude_none=True), "updated_at": datetime.utcnow().isoformat()},
+    )
+    if not updated:
+        raise HTTPException(404, "Account not found")
+    return {"account": _redact(updated)}
+
+
+@router.delete("/account/{account_id}")
+async def delete_account(account_id: str, repo: RedditRepository = Depends(_repo)) -> Dict[str, Any]:
+    ok = await repo.delete(account_id)
+    if not ok:
+        raise HTTPException(404, "Account not found")
+    return {"deleted": True}
+
+
+@router.post("/test")
+async def test_connection(repo: RedditRepository = Depends(_repo)) -> Dict[str, Any]:
+    account = await repo.get_active()
+    if not account:
+        raise HTTPException(400, "No Reddit account configured")
+    client = RedditClient(
+        client_id=account["client_id"],
+        client_secret=account["client_secret"],
+        username=account["username"],
+        password=account["password"],
+        user_agent=account.get("user_agent", "ContextuAI-Solo/1.0"),
+    )
+    try:
+        return await client.test_connection()
+    except Exception as e:
+        raise HTTPException(400, f"Reddit auth failed: {e}") from e
+
+
+@router.post("/reply")
+async def send_reply(
+    payload: RedditPostReply, repo: RedditRepository = Depends(_repo)
+) -> Dict[str, Any]:
+    account = await repo.get_active()
+    if not account:
+        raise HTTPException(400, "No Reddit account configured")
+    client = RedditClient(
+        client_id=account["client_id"],
+        client_secret=account["client_secret"],
+        username=account["username"],
+        password=account["password"],
+        user_agent=account.get("user_agent", "ContextuAI-Solo/1.0"),
+    )
+    try:
+        if payload.target_type == "comment":
+            reply_id = await client.reply_to_comment(payload.target_id, payload.text)
+            return {"ok": True, "reply_id": reply_id}
+        if payload.target_type == "dm":
+            if not payload.recipient:
+                raise HTTPException(400, "'recipient' required for DM replies")
+            ok = await client.send_dm(payload.recipient, "Re: your message", payload.text)
+            return {"ok": ok}
+        raise HTTPException(400, f"Unsupported target_type: {payload.target_type}")
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(400, f"Reddit reply failed: {e}") from e

--- a/backend/routers/scheduled_jobs.py
+++ b/backend/routers/scheduled_jobs.py
@@ -1,0 +1,261 @@
+"""
+Scheduled Jobs Router — REST API for cron-based post + crew jobs.
+
+Endpoints (prefix ``/api/v1/scheduled-jobs``):
+
+- ``GET /``                          — list jobs (paginated)
+- ``POST /``                         — create
+- ``GET /{id}``                      — detail
+- ``PATCH /{id}``                    — update (re-registers on cron change)
+- ``DELETE /{id}``                   — delete (unregisters from scheduler)
+- ``POST /{id}/run-now``             — fire immediately
+- ``POST /{id}/toggle``              — pause/resume
+- ``GET /validate-cron?expr=...``    — validate a cron string, preview runs
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+
+from models.scheduled_job import (
+    ScheduledJobCreate,
+    ScheduledJobUpdate,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/scheduled-jobs", tags=["scheduled-jobs"])
+
+
+# ------------------------------------------------------------------
+# Dependencies
+# ------------------------------------------------------------------
+
+
+def _get_scheduler_service(request: Request):
+    """Pull the SchedulerService instance off ``app.state``.
+
+    Constructed during startup in ``app.py`` after the APScheduler
+    adapter has been initialised.
+    """
+    svc = getattr(request.app.state, "scheduler_service", None)
+    if svc is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Scheduler service not initialised",
+        )
+    return svc
+
+
+# ------------------------------------------------------------------
+# Validation helper
+# ------------------------------------------------------------------
+
+
+def _validate_job_payload(data: Dict[str, Any]) -> None:
+    """Validate cron string + per-job-type required fields."""
+    from apscheduler.triggers.cron import CronTrigger
+
+    cron_expr = data.get("cron")
+    tz = data.get("timezone") or "UTC"
+    if cron_expr:
+        try:
+            CronTrigger.from_crontab(cron_expr, timezone=tz)
+        except Exception as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid cron expression: {exc}",
+            )
+
+    job_type = data.get("job_type")
+    if job_type == "post":
+        if not data.get("channel_id"):
+            raise HTTPException(400, "channel_id is required for post jobs")
+        if not data.get("content"):
+            raise HTTPException(400, "content is required for post jobs")
+    elif job_type == "crew":
+        if not data.get("crew_id"):
+            raise HTTPException(400, "crew_id is required for crew jobs")
+
+
+# ------------------------------------------------------------------
+# Cron preview (must be before /{id} to avoid collision)
+# ------------------------------------------------------------------
+
+
+@router.get("/validate-cron")
+async def validate_cron(
+    expr: str = Query(..., description="Standard 5-field cron expression"),
+    timezone_name: str = Query("UTC", alias="timezone"),
+    count: int = Query(5, ge=1, le=20),
+):
+    """Validate a cron expression and return the next N fire times."""
+    from apscheduler.triggers.cron import CronTrigger
+
+    try:
+        trigger = CronTrigger.from_crontab(expr, timezone=timezone_name)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid cron expression: {exc}",
+        )
+
+    runs: List[str] = []
+    previous = None
+    now = datetime.now(timezone.utc)
+    for _ in range(count):
+        nxt = trigger.get_next_fire_time(previous, now if previous is None else previous)
+        if nxt is None:
+            break
+        runs.append(nxt.isoformat())
+        previous = nxt
+
+    return {
+        "valid": True,
+        "cron": expr,
+        "timezone": timezone_name,
+        "next_runs": runs,
+    }
+
+
+# ------------------------------------------------------------------
+# List + create
+# ------------------------------------------------------------------
+
+
+@router.get("/")
+async def list_scheduled_jobs(
+    skip: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1, le=500),
+    svc=Depends(_get_scheduler_service),
+):
+    """List all scheduled jobs with live ``next_run_at`` annotations."""
+    jobs = await svc.list_jobs(skip=skip, limit=limit)
+    total = await svc.repo.count_all()
+    return {
+        "status": "success",
+        "data": {"jobs": jobs, "total": total, "skip": skip, "limit": limit},
+    }
+
+
+@router.post("/", status_code=status.HTTP_201_CREATED)
+async def create_scheduled_job(
+    request: ScheduledJobCreate,
+    svc=Depends(_get_scheduler_service),
+):
+    """Create a new scheduled job and register it with APScheduler."""
+    payload = request.model_dump()
+    _validate_job_payload(payload)
+
+    job = await svc.repo.create_job(payload)
+    if job.get("enabled"):
+        try:
+            job = await svc.register(job["id"]) or job
+        except Exception as exc:
+            logger.exception("Failed to register new scheduled job")
+            # Rollback the DB row so the UI doesn't show a phantom job.
+            await svc.repo.delete_job(job["id"])
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Failed to register job: {exc}",
+            )
+    return {"status": "success", "data": job}
+
+
+# ------------------------------------------------------------------
+# Detail / update / delete
+# ------------------------------------------------------------------
+
+
+@router.get("/{job_id}")
+async def get_scheduled_job(
+    job_id: str,
+    svc=Depends(_get_scheduler_service),
+):
+    job = await svc.repo.get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Scheduled job not found")
+    next_run = svc._get_next_run_time(job_id)
+    if next_run is not None:
+        job["next_run_at"] = next_run
+    return {"status": "success", "data": job}
+
+
+@router.patch("/{job_id}")
+async def update_scheduled_job(
+    job_id: str,
+    request: ScheduledJobUpdate,
+    svc=Depends(_get_scheduler_service),
+):
+    existing = await svc.repo.get_job(job_id)
+    if not existing:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Scheduled job not found")
+
+    updates = request.model_dump(exclude_unset=True)
+    if not updates:
+        raise HTTPException(400, "No fields to update")
+
+    # Validate merged payload so half-updates still make sense.
+    merged = {**existing, **updates}
+    _validate_job_payload(merged)
+
+    job = await svc.repo.update_job(job_id, updates)
+
+    # Re-register whenever a field that affects scheduling changes.
+    reschedule_keys = {"cron", "timezone", "enabled"}
+    if reschedule_keys.intersection(updates.keys()):
+        job = await svc.register(job_id) or job
+
+    return {"status": "success", "data": job}
+
+
+@router.delete("/{job_id}")
+async def delete_scheduled_job(
+    job_id: str,
+    svc=Depends(_get_scheduler_service),
+):
+    existing = await svc.repo.get_job(job_id)
+    if not existing:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Scheduled job not found")
+    await svc.unregister(job_id)
+    await svc.repo.delete_job(job_id)
+    return {"status": "success", "message": "Scheduled job deleted"}
+
+
+# ------------------------------------------------------------------
+# Run now / toggle
+# ------------------------------------------------------------------
+
+
+@router.post("/{job_id}/run-now")
+async def run_scheduled_job_now(
+    job_id: str,
+    svc=Depends(_get_scheduler_service),
+):
+    """Fire a scheduled job immediately, ignoring its cron."""
+    result = await svc.run_now(job_id)
+    if result.get("status") == "failed" and result.get("error") == "Job not found":
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Scheduled job not found")
+    return {"status": "success", "data": result}
+
+
+@router.post("/{job_id}/toggle")
+async def toggle_scheduled_job(
+    job_id: str,
+    svc=Depends(_get_scheduler_service),
+):
+    """Flip ``enabled`` and register/unregister with APScheduler."""
+    existing = await svc.repo.get_job(job_id)
+    if not existing:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Scheduled job not found")
+
+    new_enabled = not bool(existing.get("enabled"))
+    job = await svc.repo.update_job(job_id, {"enabled": new_enabled})
+    if new_enabled:
+        job = await svc.register(job_id) or job
+    else:
+        await svc.unregister(job_id)
+        job = await svc.repo.get_job(job_id) or job
+    return {"status": "success", "data": job}

--- a/backend/routers/twitter.py
+++ b/backend/routers/twitter.py
@@ -1,0 +1,158 @@
+"""Twitter/X connection REST API.
+
+Endpoints:
+- GET  /api/v1/twitter/account        — current config (secrets redacted)
+- POST /api/v1/twitter/account        — create/replace config
+- PUT  /api/v1/twitter/account/{id}   — update keywords/poll flags/enabled
+- DELETE /api/v1/twitter/account/{id}
+- POST /api/v1/twitter/test           — verify creds against Twitter API
+- POST /api/v1/twitter/reply          — manual reply to a tweet or DM
+"""
+import uuid
+from datetime import datetime
+from typing import Any, Dict
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from database import get_database
+from models.twitter_models import (
+    TwitterAccountCreate,
+    TwitterAccountUpdate,
+    TwitterPostReply,
+)
+from repositories.twitter_repository import TwitterRepository
+from services.twitter_client import TwitterClient
+
+router = APIRouter(prefix="/api/v1/twitter", tags=["twitter"])
+
+_SECRET_FIELDS = ("api_secret", "access_token_secret", "bearer_token")
+
+
+def _repo(db=Depends(get_database)) -> TwitterRepository:
+    return TwitterRepository(db)
+
+
+def _redact(doc: Dict[str, Any]) -> Dict[str, Any]:
+    if not doc:
+        return doc
+    out = {**doc}
+    for f in _SECRET_FIELDS:
+        if out.get(f):
+            out[f] = "***"
+    # Partially mask access_token (not secret-level, but user-identifying)
+    if out.get("access_token"):
+        tok = out["access_token"]
+        out["access_token"] = (tok[:6] + "***") if len(tok) > 8 else "***"
+    return out
+
+
+def _client_from_account(account: Dict[str, Any]) -> TwitterClient:
+    return TwitterClient(
+        api_key=account.get("api_key"),
+        api_secret=account.get("api_secret"),
+        access_token=account.get("access_token"),
+        access_token_secret=account.get("access_token_secret"),
+        bearer_token=account.get("bearer_token"),
+    )
+
+
+@router.get("/account")
+async def get_account(repo: TwitterRepository = Depends(_repo)) -> Dict[str, Any]:
+    doc = await repo.get_active()
+    return {"account": _redact(doc) if doc else None}
+
+
+@router.post("/account")
+async def create_account(
+    payload: TwitterAccountCreate, repo: TwitterRepository = Depends(_repo)
+) -> Dict[str, Any]:
+    # Require either OAuth 1.0a set OR bearer_token
+    has_oauth1 = all(
+        [
+            payload.api_key,
+            payload.api_secret,
+            payload.access_token,
+            payload.access_token_secret,
+        ]
+    )
+    if not has_oauth1 and not payload.bearer_token:
+        raise HTTPException(
+            400,
+            "Either OAuth 1.0a creds (api_key + api_secret + access_token + "
+            "access_token_secret) or bearer_token is required",
+        )
+
+    existing = await repo.get_active()
+    if existing:
+        await repo.delete(existing["_id"])
+
+    doc = {
+        "_id": str(uuid.uuid4()),
+        **payload.model_dump(exclude_none=True),
+        "enabled": True,
+        "last_seen_ids": {},
+        "created_at": datetime.utcnow().isoformat(),
+        "updated_at": datetime.utcnow().isoformat(),
+    }
+    await repo.create(doc)
+    return {"account": _redact(doc)}
+
+
+@router.put("/account/{account_id}")
+async def update_account(
+    account_id: str,
+    payload: TwitterAccountUpdate,
+    repo: TwitterRepository = Depends(_repo),
+) -> Dict[str, Any]:
+    updated = await repo.update(
+        account_id,
+        {**payload.model_dump(exclude_none=True), "updated_at": datetime.utcnow().isoformat()},
+    )
+    if not updated:
+        raise HTTPException(404, "Account not found")
+    return {"account": _redact(updated)}
+
+
+@router.delete("/account/{account_id}")
+async def delete_account(
+    account_id: str, repo: TwitterRepository = Depends(_repo)
+) -> Dict[str, Any]:
+    ok = await repo.delete(account_id)
+    if not ok:
+        raise HTTPException(404, "Account not found")
+    return {"deleted": True}
+
+
+@router.post("/test")
+async def test_connection(repo: TwitterRepository = Depends(_repo)) -> Dict[str, Any]:
+    account = await repo.get_active()
+    if not account:
+        raise HTTPException(400, "No Twitter account configured")
+    client = _client_from_account(account)
+    try:
+        return await client.test_connection()
+    except Exception as e:
+        raise HTTPException(400, f"Twitter auth failed: {e}") from e
+
+
+@router.post("/reply")
+async def send_reply(
+    payload: TwitterPostReply, repo: TwitterRepository = Depends(_repo)
+) -> Dict[str, Any]:
+    account = await repo.get_active()
+    if not account:
+        raise HTTPException(400, "No Twitter account configured")
+    client = _client_from_account(account)
+    try:
+        if payload.target_type == "tweet":
+            return await client.reply_to_tweet(payload.target_id, payload.text)
+        if payload.target_type == "dm":
+            recipient = payload.recipient or payload.target_id
+            if not recipient:
+                raise HTTPException(400, "'recipient' required for DM replies")
+            return await client.send_dm(recipient, payload.text)
+        raise HTTPException(400, f"Unsupported target_type: {payload.target_type}")
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(400, f"Twitter reply failed: {e}") from e

--- a/backend/services/channels/channel_service.py
+++ b/backend/services/channels/channel_service.py
@@ -36,6 +36,7 @@ class ChannelType(str, Enum):
     WHATSAPP = "whatsapp"
     TELEGRAM = "telegram"
     REDDIT = "reddit"
+    TWITTER = "twitter"
 
 
 class ChannelMessage:

--- a/backend/services/channels/channel_service.py
+++ b/backend/services/channels/channel_service.py
@@ -35,6 +35,7 @@ class ChannelType(str, Enum):
     DISCORD = "discord"
     WHATSAPP = "whatsapp"
     TELEGRAM = "telegram"
+    REDDIT = "reddit"
 
 
 class ChannelMessage:

--- a/backend/services/crew_template_seeder.py
+++ b/backend/services/crew_template_seeder.py
@@ -1,0 +1,142 @@
+"""
+Crew Template Seeder
+
+Reads *.json crew-template files from the on-disk template library and
+upserts them into the ``crew_templates`` collection. Templates are stored
+separately from user-created crews so that the system catalog is never
+polluted with user data and can be re-seeded safely on every startup.
+
+Mirrors the pattern of BlueprintLibraryService.sync_library_to_db().
+"""
+
+import json
+import logging
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+class CrewTemplateSeeder:
+    """
+    Service for syncing pre-built crew templates from disk into the
+    ``crew_templates`` collection. System templates (``is_system=True``)
+    ship with the app; user-created crews live in the ``crews`` collection
+    and are never touched by this service.
+    """
+
+    LIBRARY_PATH: str = os.getenv(
+        "CREW_TEMPLATE_LIBRARY_PATH",
+        os.path.join(
+            os.path.dirname(
+                os.path.dirname(os.path.abspath(__file__))
+            ),
+            "crew-templates",
+        ),
+    )
+
+    # -------------------------------------------------------------------------
+    # Parsing
+    # -------------------------------------------------------------------------
+
+    def parse_template_file(self, file_path: str) -> Dict[str, Any]:
+        """Load and validate a single crew-template JSON file."""
+        file_path = os.path.abspath(file_path)
+        with open(file_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        required = ("id", "name", "execution_mode", "agents")
+        missing = [k for k in required if k not in data]
+        if missing:
+            raise ValueError(
+                f"Crew template {Path(file_path).name} missing required fields: {missing}"
+            )
+
+        template_id = str(data["id"]).strip()
+        if not template_id:
+            raise ValueError(f"Crew template {Path(file_path).name} has empty id")
+
+        agents: List[str] = list(data.get("agents", []))
+        bindings: List[Dict[str, Any]] = []
+        for b in data.get("channel_bindings", []):
+            if not isinstance(b, dict) or "channel_type" not in b:
+                continue
+            bindings.append({
+                "channel_type": str(b["channel_type"]),
+                "enabled": bool(b.get("enabled", True)),
+                "approval_required": bool(b.get("approval_required", False)),
+            })
+
+        return {
+            "id": template_id,
+            "name": str(data["name"]).strip(),
+            "description": str(data.get("description", "")).strip(),
+            "execution_mode": str(data["execution_mode"]).strip(),
+            "agents": agents,
+            "channel_bindings": bindings,
+            "tags": list(data.get("tags", [])),
+            "is_template": bool(data.get("is_template", True)),
+            "is_system": bool(data.get("is_system", True)),
+            "file_path": file_path,
+        }
+
+    # -------------------------------------------------------------------------
+    # Sync
+    # -------------------------------------------------------------------------
+
+    async def sync_library_to_db(self, collection) -> int:
+        """
+        Scan all *.json files in the template library and upsert them into
+        the ``crew_templates`` collection.
+
+        Returns the number of newly inserted templates. Existing templates
+        (matched by ``_id``) are left untouched so that user edits or
+        manual overrides are preserved across restarts.
+        """
+        library = Path(self.LIBRARY_PATH)
+        if not library.exists():
+            logger.warning(
+                "Crew template library not found at %s — skipping sync", library
+            )
+            return 0
+
+        seeded = 0
+        for json_file in sorted(library.glob("*.json")):
+            try:
+                parsed = self.parse_template_file(str(json_file))
+                template_id = parsed["id"]
+
+                existing = await collection.find_one({"_id": template_id})
+                if existing is not None:
+                    continue
+
+                now = datetime.utcnow().isoformat() + "Z"
+                doc = {
+                    "_id": template_id,
+                    "template_id": template_id,
+                    "name": parsed["name"],
+                    "description": parsed["description"],
+                    "execution_mode": parsed["execution_mode"],
+                    "agents": parsed["agents"],
+                    "channel_bindings": parsed["channel_bindings"],
+                    "tags": parsed["tags"],
+                    "is_template": parsed["is_template"],
+                    "is_system": parsed["is_system"],
+                    "source": "library",
+                    "usage_count": 0,
+                    "created_by": "system",
+                    "deleted_at": None,
+                    "created_at": now,
+                    "updated_at": now,
+                }
+
+                await collection.insert_one(doc)
+                seeded += 1
+            except Exception:
+                logger.warning(
+                    "Failed to sync crew template: %s", json_file.name, exc_info=True
+                )
+
+        return seeded

--- a/backend/services/reddit_client.py
+++ b/backend/services/reddit_client.py
@@ -1,0 +1,104 @@
+"""Thin async wrapper over praw for Reddit inbound/outbound ops.
+
+praw is sync; we run calls in a threadpool to keep the event loop responsive.
+"""
+import asyncio
+import logging
+from typing import Any, Dict, List, Optional
+
+try:
+    import praw  # type: ignore
+except ImportError:
+    praw = None
+
+logger = logging.getLogger(__name__)
+
+
+class RedditClient:
+    """One instance per Reddit account config."""
+
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        username: str,
+        password: str,
+        user_agent: str = "ContextuAI-Solo/1.0",
+    ):
+        if praw is None:
+            raise RuntimeError("praw not installed. Add 'praw' to requirements.txt.")
+        self._reddit = praw.Reddit(
+            client_id=client_id,
+            client_secret=client_secret,
+            username=username,
+            password=password,
+            user_agent=user_agent,
+            check_for_async=False,
+        )
+
+    async def test_connection(self) -> Dict[str, Any]:
+        def _check() -> Dict[str, Any]:
+            me = self._reddit.user.me()
+            return {"ok": True, "username": me.name if me else None}
+
+        return await asyncio.to_thread(_check)
+
+    async def fetch_new_comments(
+        self, subreddit: str, after_id: Optional[str], limit: int = 25
+    ) -> List[Dict[str, Any]]:
+        def _fetch() -> List[Dict[str, Any]]:
+            items = []
+            sub = self._reddit.subreddit(subreddit)
+            for c in sub.comments(limit=limit):
+                if after_id and c.id == after_id:
+                    break
+                items.append(
+                    {
+                        "id": c.id,
+                        "fullname": c.fullname,
+                        "author": str(c.author) if c.author else "[deleted]",
+                        "body": c.body,
+                        "permalink": f"https://reddit.com{c.permalink}",
+                        "subreddit": subreddit,
+                        "created_utc": c.created_utc,
+                        "submission_id": c.submission.id,
+                    }
+                )
+            return items
+
+        return await asyncio.to_thread(_fetch)
+
+    async def fetch_inbox(self, after_id: Optional[str], limit: int = 25) -> List[Dict[str, Any]]:
+        def _fetch() -> List[Dict[str, Any]]:
+            items = []
+            for msg in self._reddit.inbox.unread(limit=limit):
+                if after_id and msg.id == after_id:
+                    break
+                items.append(
+                    {
+                        "id": msg.id,
+                        "fullname": msg.fullname,
+                        "author": str(msg.author) if msg.author else "[deleted]",
+                        "body": msg.body,
+                        "subject": getattr(msg, "subject", ""),
+                        "was_comment": getattr(msg, "was_comment", False),
+                    }
+                )
+            return items
+
+        return await asyncio.to_thread(_fetch)
+
+    async def reply_to_comment(self, comment_fullname: str, text: str) -> str:
+        def _reply() -> str:
+            comment = self._reddit.comment(id=comment_fullname.replace("t1_", ""))
+            reply = comment.reply(body=text)
+            return reply.id
+
+        return await asyncio.to_thread(_reply)
+
+    async def send_dm(self, recipient: str, subject: str, text: str) -> bool:
+        def _send() -> bool:
+            self._reddit.redditor(recipient).message(subject=subject, message=text)
+            return True
+
+        return await asyncio.to_thread(_send)

--- a/backend/services/reddit_poller.py
+++ b/backend/services/reddit_poller.py
@@ -1,0 +1,144 @@
+"""Background poller for Reddit inbound (subreddit mentions + inbox DMs).
+
+Polls every 60s, respects Reddit's 60 req/min OAuth rate limit.
+Dispatches new items into channel_service.handle_message() so the
+existing trigger + approval pipeline applies.
+"""
+import asyncio
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+POLL_INTERVAL_SECONDS = 60
+
+
+class RedditPoller:
+    """Single-account background poller."""
+
+    def __init__(self, db):
+        self.db = db
+        self._task: Optional[asyncio.Task] = None
+        self._stopping = False
+
+    async def start(self) -> None:
+        if self._task is not None:
+            return
+        self._stopping = False
+        self._task = asyncio.create_task(self._run())
+        logger.info("Reddit poller started (interval=%ss)", POLL_INTERVAL_SECONDS)
+
+    async def stop(self) -> None:
+        self._stopping = True
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        logger.info("Reddit poller stopped")
+
+    async def _run(self) -> None:
+        from repositories.reddit_repository import RedditRepository
+        from services.reddit_client import RedditClient
+
+        repo = RedditRepository(self.db)
+
+        while not self._stopping:
+            try:
+                account = await repo.get_active()
+                if not account:
+                    await asyncio.sleep(POLL_INTERVAL_SECONDS)
+                    continue
+
+                client = RedditClient(
+                    client_id=account["client_id"],
+                    client_secret=account["client_secret"],
+                    username=account["username"],
+                    password=account["password"],
+                    user_agent=account.get("user_agent", "ContextuAI-Solo/1.0"),
+                )
+                last_seen = account.get("last_seen_ids", {}) or {}
+
+                for sub in account.get("subreddits", []):
+                    after = last_seen.get(sub)
+                    comments = await client.fetch_new_comments(sub, after, limit=25)
+                    if comments:
+                        await repo.update_last_seen(account["_id"], sub, comments[0]["id"])
+                        for c in reversed(comments):
+                            await self._dispatch_comment(c, account.get("keywords", []))
+
+                if account.get("poll_inbox"):
+                    after = last_seen.get("inbox")
+                    inbox = await client.fetch_inbox(after, limit=25)
+                    if inbox:
+                        await repo.update_last_seen(account["_id"], "inbox", inbox[0]["id"])
+                        for m in reversed(inbox):
+                            await self._dispatch_dm(m)
+
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.exception("Reddit poll cycle failed: %s", e)
+
+            try:
+                await asyncio.sleep(POLL_INTERVAL_SECONDS)
+            except asyncio.CancelledError:
+                break
+
+    async def _dispatch_comment(self, comment: dict, keywords: list) -> None:
+        if keywords and not any(k.lower() in comment["body"].lower() for k in keywords):
+            return
+
+        from services.channels.channel_service import (
+            ChannelMessage,
+            ChannelType,
+            channel_service,
+        )
+
+        msg = ChannelMessage(
+            channel_type=ChannelType("reddit"),
+            channel_id=comment["subreddit"],
+            sender_id=comment["author"],
+            sender_name=comment["author"],
+            text=comment["body"],
+            message_id=comment["fullname"],
+            thread_id=comment["submission_id"],
+            raw=comment,
+        )
+        try:
+            await channel_service.handle_message(msg)
+        except Exception as e:
+            logger.exception("Failed to dispatch reddit comment %s: %s", comment["id"], e)
+
+    async def _dispatch_dm(self, dm: dict) -> None:
+        from services.channels.channel_service import (
+            ChannelMessage,
+            ChannelType,
+            channel_service,
+        )
+
+        msg = ChannelMessage(
+            channel_type=ChannelType("reddit"),
+            channel_id="inbox",
+            sender_id=dm["author"],
+            sender_name=dm["author"],
+            text=dm["body"],
+            message_id=dm["fullname"],
+            raw=dm,
+        )
+        try:
+            await channel_service.handle_message(msg)
+        except Exception as e:
+            logger.exception("Failed to dispatch reddit DM %s: %s", dm["id"], e)
+
+
+reddit_poller: Optional[RedditPoller] = None
+
+
+def get_poller(db) -> RedditPoller:
+    global reddit_poller
+    if reddit_poller is None:
+        reddit_poller = RedditPoller(db)
+    return reddit_poller

--- a/backend/services/scheduler_service.py
+++ b/backend/services/scheduler_service.py
@@ -1,0 +1,314 @@
+"""
+Scheduler Service — orchestrates cron-based post + crew recurring jobs.
+
+Manages the lifecycle of ``ScheduledJob`` documents in tandem with
+APScheduler. Each enabled scheduled job becomes an APScheduler job with a
+``CronTrigger``; when the trigger fires the wrapper in this service
+fetches the latest job doc, executes the corresponding action (publish
+to a distribution channel, or trigger a crew run), and records the
+outcome back onto the doc.
+
+The service is defensive: exceptions inside job callables are caught,
+logged, and persisted on ``last_run_error`` so the scheduler never
+crashes because of a misbehaving channel or crew.
+"""
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from motor.motor_asyncio import AsyncIOMotorDatabase
+
+from repositories.scheduled_job_repository import ScheduledJobRepository
+
+logger = logging.getLogger(__name__)
+
+
+_JOB_ID_PREFIX = "scheduled-job:"
+
+
+def _aps_job_id(job_id: str) -> str:
+    """Return the APScheduler job id corresponding to a ScheduledJob."""
+    return f"{_JOB_ID_PREFIX}{job_id}"
+
+
+class SchedulerService:
+    """Business-logic layer on top of APScheduler for scheduled jobs."""
+
+    def __init__(self, db: AsyncIOMotorDatabase, apscheduler_adapter: Any) -> None:
+        self.db = db
+        self.adapter = apscheduler_adapter
+        self.repo = ScheduledJobRepository(db)
+
+    # ------------------------------------------------------------------
+    # Scheduler lookup
+    # ------------------------------------------------------------------
+
+    def _scheduler(self):
+        """Return the underlying AsyncIOScheduler instance."""
+        if hasattr(self.adapter, "scheduler"):
+            return self.adapter.scheduler()
+        return self.adapter._scheduler  # fallback for compatibility
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def load_all(self) -> int:
+        """Rehydrate APScheduler with every enabled scheduled job.
+
+        Called once at application startup after the APScheduler adapter
+        has been started. Returns the number of jobs registered.
+        """
+        jobs = await self.repo.list_enabled()
+        registered = 0
+        for job in jobs:
+            try:
+                self._register_with_scheduler(job)
+                registered += 1
+            except Exception:
+                logger.exception(
+                    "Failed to register scheduled job %s on startup",
+                    job.get("id"),
+                )
+        logger.info(
+            "SchedulerService: registered %d/%d enabled jobs on startup",
+            registered,
+            len(jobs),
+        )
+        return registered
+
+    # ------------------------------------------------------------------
+    # CRUD helpers (register/unregister with APScheduler)
+    # ------------------------------------------------------------------
+
+    async def register(self, job_id: str) -> Optional[Dict[str, Any]]:
+        """Fetch a job and (re)register it with APScheduler.
+
+        If the job does not exist or is disabled, any existing APScheduler
+        job is removed instead.
+        """
+        job = await self.repo.get_job(job_id)
+        if not job or not job.get("enabled"):
+            await self.unregister(job_id)
+            return job
+        self._register_with_scheduler(job)
+        # Persist the next fire time for UI display.
+        next_run = self._get_next_run_time(job_id)
+        if next_run is not None:
+            await self.repo.set_next_run_at(job_id, next_run)
+        return await self.repo.get_job(job_id)
+
+    async def unregister(self, job_id: str) -> None:
+        """Remove a job from APScheduler (no-op if absent)."""
+        aps_id = _aps_job_id(job_id)
+        scheduler = self._scheduler()
+        try:
+            scheduler.remove_job(aps_id)
+        except Exception:
+            # Job not present — safe to ignore.
+            pass
+        await self.repo.set_next_run_at(job_id, None)
+
+    async def run_now(self, job_id: str) -> Dict[str, Any]:
+        """Execute a job immediately, bypassing its cron schedule."""
+        job = await self.repo.get_job(job_id)
+        if not job:
+            return {
+                "job_id": job_id,
+                "status": "failed",
+                "error": "Job not found",
+                "ran_at": datetime.utcnow().isoformat(),
+            }
+        return await self._execute(job)
+
+    # ------------------------------------------------------------------
+    # APScheduler wiring
+    # ------------------------------------------------------------------
+
+    def _register_with_scheduler(self, job: Dict[str, Any]) -> None:
+        """Add or replace the APScheduler job for the given ScheduledJob."""
+        from apscheduler.triggers.cron import CronTrigger
+
+        aps_id = _aps_job_id(job["id"])
+        trigger = CronTrigger.from_crontab(
+            job["cron"], timezone=job.get("timezone") or "UTC"
+        )
+        scheduler = self._scheduler()
+        scheduler.add_job(
+            self._fire,
+            trigger=trigger,
+            id=aps_id,
+            replace_existing=True,
+            kwargs={"job_id": job["id"]},
+            name=job.get("name", aps_id),
+        )
+        logger.info(
+            "Registered scheduled job %s (%s) cron=%s tz=%s",
+            job["id"],
+            job.get("name"),
+            job["cron"],
+            job.get("timezone", "UTC"),
+        )
+
+    def _get_next_run_time(self, job_id: str) -> Optional[str]:
+        """Return the next fire time for a registered APScheduler job."""
+        try:
+            scheduler = self._scheduler()
+            aps_job = scheduler.get_job(_aps_job_id(job_id))
+            if aps_job and aps_job.next_run_time:
+                return aps_job.next_run_time.isoformat()
+        except Exception:
+            logger.debug("next-run-time lookup failed for %s", job_id, exc_info=True)
+        return None
+
+    # ------------------------------------------------------------------
+    # Execution
+    # ------------------------------------------------------------------
+
+    async def _fire(self, job_id: str) -> None:
+        """APScheduler callback: load job + execute + persist result."""
+        job = await self.repo.get_job(job_id)
+        if not job:
+            logger.warning("Scheduled job %s no longer exists — skipping fire", job_id)
+            return
+        if not job.get("enabled"):
+            logger.info("Scheduled job %s is disabled — skipping fire", job_id)
+            return
+        await self._execute(job)
+
+    async def _execute(self, job: Dict[str, Any]) -> Dict[str, Any]:
+        """Run the job's action and persist the outcome."""
+        job_id = job["id"]
+        job_type = job.get("job_type")
+        ran_at = datetime.utcnow().isoformat()
+        status = "failed"
+        error: Optional[str] = None
+        details: Optional[Dict[str, Any]] = None
+
+        try:
+            if job_type == "post":
+                details = await self._run_post(job)
+            elif job_type == "crew":
+                details = await self._run_crew(job)
+            else:
+                raise ValueError(f"Unknown job_type: {job_type!r}")
+
+            if details and details.get("ok"):
+                status = "success"
+            else:
+                status = "failed"
+                error = (details or {}).get("error") or "Unknown error"
+        except Exception as exc:
+            logger.exception("Scheduled job %s execution failed", job_id)
+            status = "failed"
+            error = str(exc)
+            details = {"ok": False, "error": str(exc)}
+
+        next_run = self._get_next_run_time(job_id)
+        await self.repo.record_run(
+            job_id, status=status, error=error, next_run_at=next_run
+        )
+
+        return {
+            "job_id": job_id,
+            "job_type": job_type,
+            "status": status,
+            "ran_at": ran_at,
+            "error": error,
+            "details": details,
+        }
+
+    # ------------------------------------------------------------------
+    # Job-type handlers
+    # ------------------------------------------------------------------
+
+    async def _run_post(self, job: Dict[str, Any]) -> Dict[str, Any]:
+        """Publish ``job.content`` to ``job.channel_id`` via DistributionService."""
+        channel_id = job.get("channel_id")
+        content = job.get("content")
+        if not channel_id:
+            return {"ok": False, "error": "Missing channel_id"}
+        if not content:
+            return {"ok": False, "error": "Missing content"}
+
+        from services.distribution_service import DistributionService
+
+        svc = DistributionService(self.db)
+        channel = await svc.get_channel(channel_id)
+        if not channel:
+            return {"ok": False, "error": f"Channel {channel_id} not found"}
+        if not channel.get("enabled"):
+            return {"ok": False, "error": f"Channel {channel_id} is disabled"}
+
+        delivery = await svc.publish(
+            channel_id=channel_id,
+            content=content,
+            title=job.get("title"),
+            metadata=job.get("metadata"),
+            published_by="scheduler",
+        )
+
+        # DistributionService returns either an error envelope or a delivery
+        # record with status="published" / "failed".
+        if delivery.get("status") == "published":
+            return {"ok": True, "delivery": delivery}
+        return {
+            "ok": False,
+            "error": delivery.get("message") or str(delivery.get("result", {}).get("error", "publish failed")),
+            "delivery": delivery,
+        }
+
+    async def _run_crew(self, job: Dict[str, Any]) -> Dict[str, Any]:
+        """Trigger a crew run via CrewService.start_run."""
+        crew_id = job.get("crew_id")
+        if not crew_id:
+            return {"ok": False, "error": "Missing crew_id"}
+
+        try:
+            from models.crew_models import RunCrewRequest
+            from repositories.crew_repository import CrewRepository, CrewRunRepository
+            from repositories.workspace_agent_repository import WorkspaceAgentRepository
+            from services.crew_service import CrewService
+
+            crew_repo = CrewRepository(self.db)
+            run_repo = CrewRunRepository(self.db)
+            agent_repo = WorkspaceAgentRepository(self.db)
+            svc = CrewService(crew_repo, run_repo, agent_repo)
+
+            crew = await svc.get_crew(crew_id, "desktop-user")
+            if not crew:
+                return {"ok": False, "error": f"Crew {crew_id} not found"}
+
+            crew_input = job.get("crew_input") or {}
+            request = RunCrewRequest(
+                input=crew_input.get("input"),
+                input_data=crew_input or None,
+            )
+            run = await svc.start_run(crew_id, "desktop-user", request)
+            return {
+                "ok": True,
+                "run_id": run.get("run_id"),
+                "crew_id": crew_id,
+            }
+        except ValueError as exc:
+            return {"ok": False, "error": str(exc)}
+        except ImportError:
+            # Crew subsystem missing — leave the post path fully working.
+            logger.warning("Crew run integration TODO: imports failed")
+            return {"ok": False, "error": "Crew integration unavailable"}
+
+    # ------------------------------------------------------------------
+    # Listing
+    # ------------------------------------------------------------------
+
+    async def list_jobs(
+        self, skip: int = 0, limit: int = 100
+    ) -> List[Dict[str, Any]]:
+        """List persisted jobs and decorate each with ``next_run_at``."""
+        jobs = await self.repo.list_jobs(skip=skip, limit=limit)
+        for job in jobs:
+            next_run = self._get_next_run_time(job["id"])
+            if next_run is not None:
+                job["next_run_at"] = next_run
+        return jobs

--- a/backend/services/twitter_client.py
+++ b/backend/services/twitter_client.py
@@ -1,0 +1,292 @@
+"""Async wrapper over the Twitter/X API v2.
+
+Handles both OAuth 1.0a user context (for posting + DMs) and app-only
+bearer tokens (read-only). OAuth 1.0a signing copied from
+distribution_service._publish_twitter.
+"""
+import base64
+import hashlib
+import hmac
+import logging
+import secrets
+import time
+import urllib.parse
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://api.twitter.com"
+
+
+class TwitterClient:
+    """One instance per Twitter account config."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        api_secret: Optional[str] = None,
+        access_token: Optional[str] = None,
+        access_token_secret: Optional[str] = None,
+        bearer_token: Optional[str] = None,
+    ):
+        self.api_key = api_key
+        self.api_secret = api_secret
+        self.access_token = access_token
+        self.access_token_secret = access_token_secret
+        self.bearer_token = bearer_token
+
+    # ------------------------------------------------------------------
+    # Auth helpers
+    # ------------------------------------------------------------------
+    def _has_oauth1(self) -> bool:
+        return bool(
+            self.api_key
+            and self.api_secret
+            and self.access_token
+            and self.access_token_secret
+        )
+
+    def _oauth1_header(
+        self,
+        method: str,
+        url: str,
+        query_params: Optional[Dict[str, str]] = None,
+    ) -> str:
+        """Build an OAuth 1.0a HMAC-SHA1 Authorization header.
+
+        Signature base string includes all oauth_* params plus query
+        params (POST bodies signed here are JSON, so they are not part
+        of the signature per RFC 5849 section 3.4.1.3.2 when the body
+        is not form-encoded).
+        """
+        nonce = secrets.token_hex(16)
+        timestamp = str(int(time.time()))
+        oauth_params: Dict[str, str] = {
+            "oauth_consumer_key": self.api_key or "",
+            "oauth_nonce": nonce,
+            "oauth_signature_method": "HMAC-SHA1",
+            "oauth_timestamp": timestamp,
+            "oauth_token": self.access_token or "",
+            "oauth_version": "1.0",
+        }
+
+        all_params = {**oauth_params, **(query_params or {})}
+        param_str = "&".join(
+            f"{urllib.parse.quote(k, safe='')}={urllib.parse.quote(v, safe='')}"
+            for k, v in sorted(all_params.items())
+        )
+        base_string = (
+            f"{method.upper()}&"
+            f"{urllib.parse.quote(url, safe='')}&"
+            f"{urllib.parse.quote(param_str, safe='')}"
+        )
+        signing_key = (
+            f"{urllib.parse.quote(self.api_secret or '', safe='')}&"
+            f"{urllib.parse.quote(self.access_token_secret or '', safe='')}"
+        )
+        signature = hmac.new(
+            signing_key.encode(), base_string.encode(), hashlib.sha1
+        ).digest()
+        oauth_params["oauth_signature"] = base64.b64encode(signature).decode()
+
+        return "OAuth " + ", ".join(
+            f'{k}="{urllib.parse.quote(v, safe="")}"'
+            for k, v in sorted(oauth_params.items())
+        )
+
+    def _read_headers(self) -> Dict[str, str]:
+        """Return headers suitable for read endpoints.
+
+        Bearer token preferred if available (simpler, higher rate-limit on
+        free tier); otherwise falls back to OAuth 1.0a user context.
+        """
+        if self.bearer_token:
+            return {"Authorization": f"Bearer {self.bearer_token}"}
+        if not self._has_oauth1():
+            raise RuntimeError(
+                "Twitter read requires either bearer_token or OAuth 1.0a creds"
+            )
+        return {}  # caller must build OAuth1 header with per-request url/params
+
+    # ------------------------------------------------------------------
+    # API methods
+    # ------------------------------------------------------------------
+    async def test_connection(self) -> Dict[str, Any]:
+        """GET /2/users/me — verify credentials."""
+        url = f"{BASE_URL}/2/users/me"
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            if self.bearer_token:
+                r = await client.get(
+                    url,
+                    headers={"Authorization": f"Bearer {self.bearer_token}"},
+                )
+            elif self._has_oauth1():
+                r = await client.get(
+                    url, headers={"Authorization": self._oauth1_header("GET", url)}
+                )
+            else:
+                raise RuntimeError("No Twitter credentials configured")
+
+        if r.status_code != 200:
+            raise RuntimeError(f"Twitter auth failed ({r.status_code}): {r.text[:200]}")
+        data = r.json().get("data", {})
+        return {
+            "ok": True,
+            "id": data.get("id"),
+            "username": data.get("username"),
+            "name": data.get("name"),
+        }
+
+    async def fetch_mentions(
+        self,
+        user_id: str,
+        since_id: Optional[str] = None,
+        max_results: int = 25,
+    ) -> List[Dict[str, Any]]:
+        """GET /2/users/:id/mentions — newest-first list of mentions."""
+        url = f"{BASE_URL}/2/users/{user_id}/mentions"
+        params: Dict[str, str] = {
+            "max_results": str(max(5, min(max_results, 100))),
+            "tweet.fields": "author_id,conversation_id,created_at",
+            "expansions": "author_id",
+            "user.fields": "username,name",
+        }
+        if since_id:
+            params["since_id"] = since_id
+
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            if self.bearer_token:
+                r = await client.get(
+                    url,
+                    headers={"Authorization": f"Bearer {self.bearer_token}"},
+                    params=params,
+                )
+            elif self._has_oauth1():
+                r = await client.get(
+                    url,
+                    headers={"Authorization": self._oauth1_header("GET", url, params)},
+                    params=params,
+                )
+            else:
+                raise RuntimeError("No Twitter credentials configured")
+
+        if r.status_code != 200:
+            logger.warning("Twitter mentions fetch failed %s: %s", r.status_code, r.text[:200])
+            return []
+
+        body = r.json()
+        tweets = body.get("data", []) or []
+        users = {u["id"]: u for u in (body.get("includes", {}).get("users", []) or [])}
+
+        items: List[Dict[str, Any]] = []
+        for t in tweets:
+            author = users.get(t.get("author_id", ""), {})
+            items.append(
+                {
+                    "id": t.get("id"),
+                    "text": t.get("text", ""),
+                    "author_id": t.get("author_id"),
+                    "author_name": author.get("username") or author.get("name") or t.get("author_id"),
+                    "conversation_id": t.get("conversation_id"),
+                    "created_at": t.get("created_at"),
+                }
+            )
+        return items
+
+    async def fetch_dm_events(
+        self,
+        since_id: Optional[str] = None,
+        max_results: int = 25,
+    ) -> List[Dict[str, Any]]:
+        """GET /2/dm_events — newest-first list of inbound DMs.
+
+        Requires OAuth 1.0a (user context) — bearer token cannot read DMs.
+        """
+        url = f"{BASE_URL}/2/dm_events"
+        params: Dict[str, str] = {
+            "max_results": str(max(5, min(max_results, 100))),
+            "dm_event.fields": "sender_id,text,created_at,event_type",
+            "event_types": "MessageCreate",
+        }
+        if since_id:
+            params["since_id"] = since_id
+
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            if self._has_oauth1():
+                r = await client.get(
+                    url,
+                    headers={"Authorization": self._oauth1_header("GET", url, params)},
+                    params=params,
+                )
+            elif self.bearer_token:
+                # DMs technically require user-context, but attempt bearer
+                # for free-tier accounts that have elevated it.
+                r = await client.get(
+                    url,
+                    headers={"Authorization": f"Bearer {self.bearer_token}"},
+                    params=params,
+                )
+            else:
+                raise RuntimeError("No Twitter credentials configured")
+
+        if r.status_code != 200:
+            logger.warning("Twitter DM fetch failed %s: %s", r.status_code, r.text[:200])
+            return []
+
+        events = r.json().get("data", []) or []
+        items: List[Dict[str, Any]] = []
+        for e in events:
+            if e.get("event_type") != "MessageCreate":
+                continue
+            items.append(
+                {
+                    "id": e.get("id"),
+                    "text": e.get("text", ""),
+                    "sender_id": e.get("sender_id"),
+                    "created_at": e.get("created_at"),
+                }
+            )
+        return items
+
+    async def reply_to_tweet(self, tweet_id: str, text: str) -> Dict[str, Any]:
+        """POST /2/tweets — reply to a tweet (requires OAuth 1.0a)."""
+        if not self._has_oauth1():
+            raise RuntimeError("Posting tweets requires OAuth 1.0a user context")
+
+        url = f"{BASE_URL}/2/tweets"
+        payload = {
+            "text": text[:280],
+            "reply": {"in_reply_to_tweet_id": tweet_id},
+        }
+        headers = {
+            "Authorization": self._oauth1_header("POST", url),
+            "Content-Type": "application/json",
+        }
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            r = await client.post(url, json=payload, headers=headers)
+        if r.status_code not in (200, 201):
+            raise RuntimeError(f"Twitter reply failed ({r.status_code}): {r.text[:200]}")
+        data = r.json().get("data", {})
+        return {"ok": True, "tweet_id": data.get("id")}
+
+    async def send_dm(self, recipient_user_id: str, text: str) -> Dict[str, Any]:
+        """POST /2/dm_conversations/with/:id/messages — send a DM.
+
+        Requires OAuth 1.0a user context.
+        """
+        if not self._has_oauth1():
+            raise RuntimeError("Sending DMs requires OAuth 1.0a user context")
+
+        url = f"{BASE_URL}/2/dm_conversations/with/{recipient_user_id}/messages"
+        headers = {
+            "Authorization": self._oauth1_header("POST", url),
+            "Content-Type": "application/json",
+        }
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            r = await client.post(url, json={"text": text[:10000]}, headers=headers)
+        if r.status_code not in (200, 201):
+            raise RuntimeError(f"Twitter DM failed ({r.status_code}): {r.text[:200]}")
+        data = r.json().get("data", {})
+        return {"ok": True, "dm_event_id": data.get("dm_event_id")}

--- a/backend/services/twitter_poller.py
+++ b/backend/services/twitter_poller.py
@@ -1,0 +1,155 @@
+"""Background poller for Twitter/X inbound (mentions + DMs).
+
+Polls every 90s — Twitter's free tier is stricter than Reddit. Dispatches
+new items into channel_service.handle_message() so the trigger + approval
+pipeline applies.
+"""
+import asyncio
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+POLL_INTERVAL_SECONDS = 90
+
+
+class TwitterPoller:
+    """Single-account background poller."""
+
+    def __init__(self, db):
+        self.db = db
+        self._task: Optional[asyncio.Task] = None
+        self._stopping = False
+
+    async def start(self) -> None:
+        if self._task is not None:
+            return
+        self._stopping = False
+        self._task = asyncio.create_task(self._run())
+        logger.info("Twitter poller started (interval=%ss)", POLL_INTERVAL_SECONDS)
+
+    async def stop(self) -> None:
+        self._stopping = True
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        logger.info("Twitter poller stopped")
+
+    async def _run(self) -> None:
+        from repositories.twitter_repository import TwitterRepository
+        from services.twitter_client import TwitterClient
+
+        repo = TwitterRepository(self.db)
+
+        while not self._stopping:
+            try:
+                account = await repo.get_active()
+                if not account:
+                    await asyncio.sleep(POLL_INTERVAL_SECONDS)
+                    continue
+
+                client = TwitterClient(
+                    api_key=account.get("api_key"),
+                    api_secret=account.get("api_secret"),
+                    access_token=account.get("access_token"),
+                    access_token_secret=account.get("access_token_secret"),
+                    bearer_token=account.get("bearer_token"),
+                )
+                last_seen = account.get("last_seen_ids", {}) or {}
+
+                if account.get("poll_mentions") and account.get("user_id"):
+                    mentions = await client.fetch_mentions(
+                        user_id=account["user_id"],
+                        since_id=last_seen.get("mentions"),
+                        max_results=25,
+                    )
+                    if mentions:
+                        # Mentions come newest-first; record newest id
+                        await repo.update_last_seen(
+                            account["_id"], "mentions", mentions[0]["id"]
+                        )
+                        for m in reversed(mentions):
+                            await self._dispatch_mention(m, account.get("keywords", []))
+
+                if account.get("poll_dms"):
+                    dms = await client.fetch_dm_events(
+                        since_id=last_seen.get("dms"),
+                        max_results=25,
+                    )
+                    if dms:
+                        await repo.update_last_seen(
+                            account["_id"], "dms", dms[0]["id"]
+                        )
+                        for d in reversed(dms):
+                            await self._dispatch_dm(d)
+
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.exception("Twitter poll cycle failed: %s", e)
+
+            try:
+                await asyncio.sleep(POLL_INTERVAL_SECONDS)
+            except asyncio.CancelledError:
+                break
+
+    async def _dispatch_mention(self, mention: dict, keywords: list) -> None:
+        text = mention.get("text", "") or ""
+        if keywords and not any(k.lower() in text.lower() for k in keywords):
+            return
+
+        from services.channels.channel_service import (
+            ChannelMessage,
+            ChannelType,
+            channel_service,
+        )
+
+        msg = ChannelMessage(
+            channel_type=ChannelType("twitter"),
+            channel_id="mentions",
+            sender_id=str(mention.get("author_id", "")),
+            sender_name=mention.get("author_name") or str(mention.get("author_id", "")),
+            text=text,
+            message_id=str(mention.get("id", "")),
+            thread_id=mention.get("conversation_id"),
+            raw=mention,
+        )
+        try:
+            await channel_service.handle_message(msg)
+        except Exception as e:
+            logger.exception("Failed to dispatch twitter mention %s: %s", mention.get("id"), e)
+
+    async def _dispatch_dm(self, dm: dict) -> None:
+        from services.channels.channel_service import (
+            ChannelMessage,
+            ChannelType,
+            channel_service,
+        )
+
+        msg = ChannelMessage(
+            channel_type=ChannelType("twitter"),
+            channel_id="dm",
+            sender_id=str(dm.get("sender_id", "")),
+            sender_name=str(dm.get("sender_id", "")),
+            text=dm.get("text", "") or "",
+            message_id=str(dm.get("id", "")),
+            raw=dm,
+        )
+        try:
+            await channel_service.handle_message(msg)
+        except Exception as e:
+            logger.exception("Failed to dispatch twitter DM %s: %s", dm.get("id"), e)
+
+
+twitter_poller: Optional[TwitterPoller] = None
+
+
+def get_poller(db) -> TwitterPoller:
+    global twitter_poller
+    if twitter_poller is None:
+        twitter_poller = TwitterPoller(db)
+    return twitter_poller

--- a/backend/tests/test_reddit.py
+++ b/backend/tests/test_reddit.py
@@ -1,0 +1,73 @@
+"""Smoke tests for the Reddit connection scaffold.
+
+Uses the shared test_app fixture (real temp SQLite, no MongoDB).
+Network calls to Reddit are NOT made — only the /test and /reply endpoints
+would hit Reddit, and those are not exercised here.
+"""
+
+
+def test_get_account_when_none_configured(test_app):
+    r = test_app.get("/api/v1/reddit/account")
+    assert r.status_code == 200
+    assert r.json() == {"account": None}
+
+
+def test_create_account_and_redact_secrets(test_app):
+    payload = {
+        "client_id": "cid",
+        "client_secret": "csecret",
+        "username": "u",
+        "password": "p",
+        "subreddits": ["LocalLLaMA"],
+        "keywords": ["local LLM"],
+    }
+    r = test_app.post("/api/v1/reddit/account", json=payload)
+    assert r.status_code == 200
+    body = r.json()["account"]
+    assert body["password"] == "***"
+    assert body["client_secret"] == "***"
+    assert body["subreddits"] == ["LocalLLaMA"]
+    assert body["enabled"] is True
+
+
+def test_get_account_after_create_returns_redacted(test_app):
+    test_app.post(
+        "/api/v1/reddit/account",
+        json={
+            "client_id": "cid",
+            "client_secret": "csecret",
+            "username": "u",
+            "password": "p",
+        },
+    )
+    r = test_app.get("/api/v1/reddit/account")
+    assert r.status_code == 200
+    account = r.json()["account"]
+    assert account is not None
+    assert account["password"] == "***"
+    assert account["username"] == "u"
+
+
+def test_test_connection_errors_without_account(test_app):
+    r = test_app.post("/api/v1/reddit/test")
+    assert r.status_code == 400
+
+
+def test_create_replaces_existing_account(test_app):
+    first = test_app.post(
+        "/api/v1/reddit/account",
+        json={"client_id": "a", "client_secret": "b", "username": "u1", "password": "p"},
+    ).json()["account"]
+    second = test_app.post(
+        "/api/v1/reddit/account",
+        json={"client_id": "a2", "client_secret": "b2", "username": "u2", "password": "p"},
+    ).json()["account"]
+    assert first["_id"] != second["_id"]
+
+    r = test_app.get("/api/v1/reddit/account")
+    assert r.json()["account"]["username"] == "u2"
+
+
+def test_invalid_payload_returns_422(test_app):
+    r = test_app.post("/api/v1/reddit/account", json={"client_id": "only"})
+    assert r.status_code == 422

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -1,0 +1,237 @@
+"""
+Tests for the Post/Crew Scheduler feature.
+
+Covers:
+- ScheduledJobRepository CRUD
+- SchedulerService register / unregister / run-now (mocked APScheduler)
+- /api/v1/scheduled-jobs validate-cron endpoint
+- Creating a post job via the HTTP API
+- Deleting a job removes it from the scheduler
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+# ── Repository ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestScheduledJobRepository:
+    async def test_create_and_get(self, db_proxy):
+        from repositories.scheduled_job_repository import ScheduledJobRepository
+
+        repo = ScheduledJobRepository(db_proxy)
+        job = await repo.create_job({
+            "name": "Daily LinkedIn post",
+            "job_type": "post",
+            "cron": "0 9 * * *",
+            "timezone": "UTC",
+            "channel_id": "chan-abc",
+            "content": "Hello world",
+        })
+
+        assert job["name"] == "Daily LinkedIn post"
+        assert job["job_type"] == "post"
+        assert job["enabled"] is True
+        assert job["run_count"] == 0
+        assert job["id"]
+
+        fetched = await repo.get_job(job["id"])
+        assert fetched is not None
+        assert fetched["channel_id"] == "chan-abc"
+
+    async def test_update_and_delete(self, db_proxy):
+        from repositories.scheduled_job_repository import ScheduledJobRepository
+
+        repo = ScheduledJobRepository(db_proxy)
+        job = await repo.create_job({
+            "name": "Crew run",
+            "job_type": "crew",
+            "cron": "0 8 * * *",
+            "crew_id": "crew-1",
+        })
+        jid = job["id"]
+
+        updated = await repo.update_job(jid, {"enabled": False})
+        assert updated["enabled"] is False
+
+        deleted = await repo.delete_job(jid)
+        assert deleted is True
+        assert await repo.get_job(jid) is None
+
+
+# ── SchedulerService ──────────────────────────────────────────────────
+
+
+def _mock_adapter():
+    """Return an APSchedulerAdapter-shaped mock with an AsyncIOScheduler stub."""
+    scheduler = MagicMock()
+    scheduler.add_job = MagicMock()
+    scheduler.remove_job = MagicMock()
+    scheduler.get_job = MagicMock(return_value=None)
+
+    adapter = MagicMock()
+    adapter.scheduler.return_value = scheduler
+    adapter._scheduler = scheduler
+    return adapter, scheduler
+
+
+@pytest.mark.asyncio
+class TestSchedulerService:
+    async def test_register_adds_job_to_apscheduler(self, db_proxy):
+        from services.scheduler_service import SchedulerService, _aps_job_id
+
+        adapter, aps = _mock_adapter()
+        svc = SchedulerService(db_proxy, adapter)
+
+        created = await svc.repo.create_job({
+            "name": "Daily post",
+            "job_type": "post",
+            "cron": "0 9 * * *",
+            "channel_id": "c-1",
+            "content": "hi",
+        })
+
+        await svc.register(created["id"])
+        assert aps.add_job.called
+        kwargs = aps.add_job.call_args.kwargs
+        assert kwargs["id"] == _aps_job_id(created["id"])
+        assert kwargs["replace_existing"] is True
+        assert kwargs["kwargs"]["job_id"] == created["id"]
+
+    async def test_unregister_removes_job(self, db_proxy):
+        from services.scheduler_service import SchedulerService, _aps_job_id
+
+        adapter, aps = _mock_adapter()
+        svc = SchedulerService(db_proxy, adapter)
+
+        created = await svc.repo.create_job({
+            "name": "Disable me",
+            "job_type": "post",
+            "cron": "0 * * * *",
+            "channel_id": "c-1",
+            "content": "hi",
+        })
+
+        await svc.unregister(created["id"])
+        aps.remove_job.assert_called_once_with(_aps_job_id(created["id"]))
+
+    async def test_run_now_post_path(self, db_proxy, monkeypatch):
+        """run_now should dispatch to DistributionService.publish."""
+        from services.scheduler_service import SchedulerService
+        import services.scheduler_service as mod
+
+        adapter, _ = _mock_adapter()
+        svc = SchedulerService(db_proxy, adapter)
+
+        created = await svc.repo.create_job({
+            "name": "Run now test",
+            "job_type": "post",
+            "cron": "0 9 * * *",
+            "channel_id": "c-1",
+            "content": "hi",
+        })
+
+        # Patch DistributionService inside services.distribution_service
+        fake_dist = MagicMock()
+        fake_dist.get_channel = AsyncMock(return_value={"channel_id": "c-1", "enabled": True})
+        fake_dist.publish = AsyncMock(return_value={"status": "published", "delivery_id": "d-1"})
+
+        import services.distribution_service as dist_mod
+        monkeypatch.setattr(
+            dist_mod, "DistributionService", lambda db: fake_dist
+        )
+
+        result = await svc.run_now(created["id"])
+        assert result["status"] == "success"
+        fake_dist.publish.assert_awaited_once()
+
+        refreshed = await svc.repo.get_job(created["id"])
+        assert refreshed["last_run_status"] == "success"
+        assert refreshed["run_count"] == 1
+
+
+# ── HTTP API ──────────────────────────────────────────────────────────
+
+
+class TestScheduledJobsAPI:
+    def _install_scheduler_service(self, test_app, db_proxy):
+        """Attach a SchedulerService + ensure the router is registered.
+
+        The production wiring lives in ``app.py`` startup (added post-hoc).
+        For tests we idempotently include the router so the HTTP paths are
+        exercised without relying on the startup snippet being applied.
+        """
+        from services.scheduler_service import SchedulerService
+        from routers.scheduled_jobs import router as scheduled_jobs_router
+
+        adapter, _ = _mock_adapter()
+        svc = SchedulerService(db_proxy, adapter)
+        test_app.app.state.scheduler_service = svc
+
+        # Register the router once (idempotent — skip if already present).
+        routes = [getattr(r, "path", None) for r in test_app.app.routes]
+        if not any(p and p.startswith("/api/v1/scheduled-jobs") for p in routes):
+            test_app.app.include_router(scheduled_jobs_router)
+        return svc
+
+    def _ensure_router(self, test_app):
+        from routers.scheduled_jobs import router as scheduled_jobs_router
+        routes = [getattr(r, "path", None) for r in test_app.app.routes]
+        if not any(p and p.startswith("/api/v1/scheduled-jobs") for p in routes):
+            test_app.app.include_router(scheduled_jobs_router)
+
+    def test_validate_cron_valid(self, test_app):
+        self._ensure_router(test_app)
+        resp = test_app.get("/api/v1/scheduled-jobs/validate-cron?expr=0+9+*+*+*&count=3")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["valid"] is True
+        assert len(body["next_runs"]) == 3
+
+    def test_validate_cron_invalid(self, test_app):
+        self._ensure_router(test_app)
+        resp = test_app.get("/api/v1/scheduled-jobs/validate-cron?expr=not-a-cron")
+        assert resp.status_code == 400
+
+    def test_create_post_job_persists(self, test_app, db_proxy):
+        self._install_scheduler_service(test_app, db_proxy)
+
+        resp = test_app.post("/api/v1/scheduled-jobs/", json={
+            "name": "Morning LinkedIn",
+            "job_type": "post",
+            "cron": "0 9 * * *",
+            "channel_id": "chan-1",
+            "content": "Hello LinkedIn!",
+            "enabled": True,
+        })
+        assert resp.status_code == 201, resp.text
+        data = resp.json()["data"]
+        assert data["name"] == "Morning LinkedIn"
+        assert data["job_type"] == "post"
+        assert data["id"]
+
+    def test_delete_job_unregisters(self, test_app, db_proxy):
+        svc = self._install_scheduler_service(test_app, db_proxy)
+
+        resp = test_app.post("/api/v1/scheduled-jobs/", json={
+            "name": "To delete",
+            "job_type": "post",
+            "cron": "0 9 * * *",
+            "channel_id": "chan-x",
+            "content": "bye",
+        })
+        job_id = resp.json()["data"]["id"]
+
+        aps = svc._scheduler()
+        aps.remove_job.reset_mock()
+
+        del_resp = test_app.delete(f"/api/v1/scheduled-jobs/{job_id}")
+        assert del_resp.status_code == 200
+        # remove_job was invoked as part of unregister
+        assert aps.remove_job.called
+
+        missing = test_app.get(f"/api/v1/scheduled-jobs/{job_id}")
+        assert missing.status_code == 404

--- a/docs/user-guide/04-agents.md
+++ b/docs/user-guide/04-agents.md
@@ -1,6 +1,6 @@
 # Agents
 
-The Agent Library contains 81 pre-built business agents organized by department. Each agent is a specialized AI role with a detailed system prompt, recommended tools, and domain expertise. You can also create your own custom agents.
+The Agent Library contains 93 pre-built business agents organized by department. Each agent is a specialized AI role with a detailed system prompt, recommended tools, and domain expertise. You can also create your own custom agents.
 
 ![Agent Library](../screenshots/006-AgentLibrary.png)
 
@@ -95,7 +95,7 @@ When you select a role, a suggested system prompt template appears. Click **"Use
 
 ## Tips
 
-- **Don't create agents from scratch** unless you need something unique — the 81 pre-built agents cover most business functions.
+- **Don't create agents from scratch** unless you need something unique — the 93 pre-built agents cover most business functions.
 - **Combine agents in Crews** for multi-step tasks. For example, pair a "Market Researcher" with a "Content Strategist" and a "Copywriter" for end-to-end content creation.
 - **Customize system prompts** in the detail panel to fine-tune an existing agent's behavior for your specific business context.
 - **Use the search** when you know roughly what you need — typing "pricing" will find the Pricing Strategist even if you don't know the exact name.

--- a/docs/user-guide/05-crews.md
+++ b/docs/user-guide/05-crews.md
@@ -59,7 +59,7 @@ Choose how your agents collaborate:
 Build your agent team:
 
 - Click **Add Agent** to add a blank agent with name, role, and instructions.
-- Click **Browse Library** to pick from the 81 pre-built agents.
+- Click **Browse Library** to pick from the 93 pre-built agents.
 - Reorder agents to control the execution sequence (for Sequential mode).
 - Each agent needs a **name** and **instructions** at minimum.
 

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -1,6 +1,6 @@
 # ContextuAI Solo — User Guide
 
-Welcome to ContextuAI Solo, your private desktop AI assistant with 81 pre-built business agents. This guide covers every module in the app to help you get started quickly.
+Welcome to ContextuAI Solo, your private desktop AI assistant with 93 pre-built business agents. This guide covers every module in the app to help you get started quickly.
 
 ## Modules
 
@@ -9,7 +9,7 @@ Welcome to ContextuAI Solo, your private desktop AI assistant with 81 pre-built 
 | 1 | [Chat](01-chat.md) | Have conversations with AI models, manage sessions, pick personas |
 | 2 | [Model Hub](02-model-hub.md) | Configure cloud AI providers and download local models |
 | 3 | [Personas](03-personas.md) | Create specialized AI personalities with custom instructions |
-| 4 | [Agents](04-agents.md) | Browse 81 business agents and create your own |
+| 4 | [Agents](04-agents.md) | Browse 93 business agents and create your own |
 | 5 | [Crews](05-crews.md) | Build multi-agent teams that work together on tasks |
 | 6 | [Blueprints](06-blueprints.md) | Use workflow templates to jumpstart projects |
 | 7 | [Workspace](07-workspace.md) | Run multi-agent projects and review results |

--- a/frontend/src-tauri/src/sidecar.rs
+++ b/frontend/src-tauri/src/sidecar.rs
@@ -90,14 +90,17 @@ pub async fn start_sidecar(app_handle: &AppHandle) -> Result<(), String> {
         cmd.args(["--port", &port.to_string(), "--host", "127.0.0.1"])
             .current_dir(&sidecar_dir);
 
-        // Pass MODELS_DIR so the sidecar stores downloaded models persistently
-        let app_data_dir = app_handle
-            .path()
-            .app_data_dir()
-            .map_err(|e| format!("Failed to get app data dir: {}", e))?;
-        let models_dir = app_data_dir.join("models");
-        let _ = std::fs::create_dir_all(&models_dir);
-        cmd.env("MODELS_DIR", &models_dir);
+        // Models live at ~/.contextuai-solo/models/ — same path on every OS,
+        // matches the docs (README, CLAUDE.md, SETUP-GUIDE) and the dev-mode
+        // Python default. Pre-create the dir so first-run downloads succeed.
+        let _ = app_handle;
+        let home = std::env::var("USERPROFILE")
+            .or_else(|_| std::env::var("HOME"))
+            .map_err(|_| "Failed to resolve home directory (USERPROFILE/HOME unset)".to_string())?;
+        let solo_models_dir = std::path::PathBuf::from(home)
+            .join(".contextuai-solo")
+            .join("models");
+        let _ = std::fs::create_dir_all(&solo_models_dir);
 
         // Hide the console window on Windows
         #[cfg(target_os = "windows")]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,8 @@ import ConnectionsPage from "@/routes/connections";
 import ModelsPage from "@/routes/models";
 import SettingsPage from "@/routes/settings";
 import ApprovalsPage from "@/routes/approvals";
+import SchedulePage from "@/routes/schedule";
+import DistributionPage from "@/routes/distribution";
 import BlueprintsPage from "@/routes/blueprints";
 import WizardPage from "@/routes/wizard";
 import { UpdateNotifier } from "@/components/update-notifier";
@@ -116,6 +118,8 @@ export default function App() {
                 <Route path="/workspace/:id" element={<WorkspacePage />} />
                 <Route path="/connections" element={<ConnectionsPage />} />
                 <Route path="/approvals" element={<ApprovalsPage />} />
+                <Route path="/schedule" element={<SchedulePage />} />
+                <Route path="/distribution" element={<DistributionPage />} />
                 <Route path="/analytics" element={<AnalyticsPage />} />
                 <Route path="/settings" element={<SettingsPage />} />
               </Route>

--- a/frontend/src/components/navigation/desktop-sidebar.tsx
+++ b/frontend/src/components/navigation/desktop-sidebar.tsx
@@ -9,6 +9,8 @@ import {
   FlaskConical,
   Cable,
   ClipboardCheck,
+  Clock,
+  Send,
   Settings,
   ChevronLeft,
   ChevronRight,
@@ -38,6 +40,8 @@ const navItems: NavItem[] = [
   { label: "Workspace", path: "/workspace", icon: FlaskConical },
   { label: "Connections", path: "/connections", icon: Cable },
   { label: "Approvals", path: "/approvals", icon: ClipboardCheck },
+  { label: "Schedule", path: "/schedule", icon: Clock },
+  { label: "Distribution", path: "/distribution", icon: Send },
   { label: "Settings", path: "/settings", icon: Settings },
 ];
 

--- a/frontend/src/lib/api/chat-client.ts
+++ b/frontend/src/lib/api/chat-client.ts
@@ -24,7 +24,7 @@ export async function createSession(opts?: {
   personaId?: string;
   modelId?: string;
 }): Promise<ChatSession> {
-  const { data } = await api.post<ChatSession>(
+  const { data } = await api.post<{ success: boolean; session: ChatSession }>(
     `/chat-sessions/?user_id=${encodeURIComponent(USER_ID)}`,
     {
       userId: USER_ID,
@@ -33,7 +33,7 @@ export async function createSession(opts?: {
       modelId: opts?.modelId,
     }
   );
-  return data;
+  return data.session;
 }
 
 export async function listUserSessions(options?: {

--- a/frontend/src/lib/api/distribution-client.ts
+++ b/frontend/src/lib/api/distribution-client.ts
@@ -1,0 +1,210 @@
+import { api } from "@/lib/transport";
+
+// ─── Types ──────────────────────────────────────────────────────
+
+export type DistributionChannelType =
+  | "linkedin"
+  | "twitter"
+  | "instagram"
+  | "facebook"
+  | "blog"
+  | "email"
+  | "slack";
+
+export type DeliveryStatus = "pending" | "published" | "failed" | "scheduled";
+
+export interface ChannelConstraints {
+  max_length?: number;
+  supports_html?: boolean;
+  supports_images?: boolean;
+  supports_links?: boolean;
+}
+
+export interface ChannelTypeInfo {
+  type: DistributionChannelType;
+  constraints: ChannelConstraints;
+  required_config: string[];
+}
+
+export interface DistributionChannel {
+  id?: string;
+  channel_id: string;
+  channel_type: DistributionChannelType;
+  name: string;
+  config: Record<string, unknown>;
+  organization: string | null;
+  enabled: boolean;
+  publish_count: number;
+  last_published_at: string | null;
+  created_at: string;
+  updated_at: string;
+  created_by: string | null;
+}
+
+export interface CreateChannelBody {
+  channel_type: DistributionChannelType;
+  name: string;
+  config: Record<string, unknown>;
+}
+
+export interface UpdateChannelBody {
+  name?: string;
+  config?: Record<string, unknown>;
+}
+
+export interface PublishMetadata {
+  image_url?: string;
+  to_emails?: string[];
+  status?: string;
+  [key: string]: unknown;
+}
+
+export interface PublishRequestBody {
+  channel_id: string;
+  content: string;
+  title?: string;
+  metadata?: PublishMetadata;
+}
+
+export interface MultiPublishRequestBody {
+  channel_ids: string[];
+  content: string;
+  title?: string;
+  metadata?: PublishMetadata;
+}
+
+export interface PublishResult {
+  success?: boolean;
+  error?: string;
+  status_code?: number;
+  post_id?: string;
+  tweet_id?: string;
+  [key: string]: unknown;
+}
+
+export interface Delivery {
+  id?: string;
+  delivery_id: string;
+  channel_id: string;
+  channel_type: DistributionChannelType;
+  channel_name: string | null;
+  title: string | null;
+  content_length: number;
+  status: DeliveryStatus;
+  result: PublishResult;
+  metadata: PublishMetadata | null;
+  published_by: string | null;
+  timestamp: string;
+}
+
+export interface MultiPublishResult {
+  total_channels: number;
+  published: number;
+  failed: number;
+  deliveries: Delivery[];
+}
+
+interface ApiEnvelope<T> {
+  status: string;
+  data: T;
+  message?: string;
+}
+
+// ─── Channel Types ──────────────────────────────────────────────
+
+export async function listChannelTypes(): Promise<ChannelTypeInfo[]> {
+  const { data } = await api.get<ApiEnvelope<{ types: ChannelTypeInfo[]; count: number }>>(
+    "/distribution/types"
+  );
+  return data.data?.types ?? [];
+}
+
+// ─── Channel CRUD ───────────────────────────────────────────────
+
+export async function listChannels(
+  channelType?: DistributionChannelType
+): Promise<DistributionChannel[]> {
+  const qs = channelType ? `?channel_type=${encodeURIComponent(channelType)}` : "";
+  const { data } = await api.get<ApiEnvelope<{ channels: DistributionChannel[]; count: number }>>(
+    `/distribution/channels${qs}`
+  );
+  return data.data?.channels ?? [];
+}
+
+export async function getChannel(channelId: string): Promise<DistributionChannel> {
+  const { data } = await api.get<ApiEnvelope<DistributionChannel>>(
+    `/distribution/channels/${encodeURIComponent(channelId)}`
+  );
+  return data.data;
+}
+
+export async function createChannel(
+  body: CreateChannelBody
+): Promise<DistributionChannel> {
+  const { data } = await api.post<ApiEnvelope<DistributionChannel>>(
+    "/distribution/channels",
+    body
+  );
+  return data.data;
+}
+
+export async function updateChannel(
+  channelId: string,
+  body: UpdateChannelBody
+): Promise<DistributionChannel> {
+  const { data } = await api.patch<ApiEnvelope<DistributionChannel>>(
+    `/distribution/channels/${encodeURIComponent(channelId)}`,
+    body
+  );
+  return data.data;
+}
+
+export async function deleteChannel(channelId: string): Promise<void> {
+  await api.delete(`/distribution/channels/${encodeURIComponent(channelId)}`);
+}
+
+export async function toggleChannel(
+  channelId: string,
+  enabled: boolean
+): Promise<DistributionChannel> {
+  const { data } = await api.patch<ApiEnvelope<DistributionChannel>>(
+    `/distribution/channels/${encodeURIComponent(channelId)}/toggle`,
+    { enabled }
+  );
+  return data.data;
+}
+
+// ─── Publishing ─────────────────────────────────────────────────
+
+export async function publish(body: PublishRequestBody): Promise<Delivery> {
+  const { data } = await api.post<ApiEnvelope<Delivery>>(
+    "/distribution/publish",
+    body
+  );
+  return data.data;
+}
+
+export async function publishMulti(
+  body: MultiPublishRequestBody
+): Promise<MultiPublishResult> {
+  const { data } = await api.post<ApiEnvelope<MultiPublishResult>>(
+    "/distribution/publish/multi",
+    body
+  );
+  return data.data;
+}
+
+// ─── Delivery History ───────────────────────────────────────────
+
+export async function listDeliveries(
+  channelId?: string,
+  limit: number = 50
+): Promise<Delivery[]> {
+  const params = new URLSearchParams();
+  if (channelId) params.set("channel_id", channelId);
+  params.set("limit", String(limit));
+  const { data } = await api.get<ApiEnvelope<{ deliveries: Delivery[]; count: number }>>(
+    `/distribution/deliveries?${params.toString()}`
+  );
+  return data.data?.deliveries ?? [];
+}

--- a/frontend/src/lib/api/reddit-client.ts
+++ b/frontend/src/lib/api/reddit-client.ts
@@ -1,0 +1,76 @@
+import { api } from "@/lib/transport";
+
+export interface RedditAccount {
+  _id: string;
+  client_id: string;
+  client_secret: string;
+  username: string;
+  password: string;
+  user_agent: string;
+  subreddits: string[];
+  keywords: string[];
+  poll_inbox: boolean;
+  enabled: boolean;
+  last_seen_ids: Record<string, string>;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateRedditAccountPayload {
+  client_id: string;
+  client_secret: string;
+  username: string;
+  password: string;
+  user_agent?: string;
+  subreddits?: string[];
+  keywords?: string[];
+  poll_inbox?: boolean;
+}
+
+export interface UpdateRedditAccountPayload {
+  subreddits?: string[];
+  keywords?: string[];
+  poll_inbox?: boolean;
+  enabled?: boolean;
+}
+
+export async function getRedditAccount(): Promise<RedditAccount | null> {
+  const { data, ok } = await api.get<{ account: RedditAccount | null }>("/reddit/account");
+  if (!ok) return null;
+  return data.account ?? null;
+}
+
+export async function createRedditAccount(
+  payload: CreateRedditAccountPayload,
+): Promise<RedditAccount> {
+  const { data } = await api.post<{ account: RedditAccount }>("/reddit/account", payload);
+  return data.account;
+}
+
+export async function updateRedditAccount(
+  id: string,
+  payload: UpdateRedditAccountPayload,
+): Promise<RedditAccount> {
+  const { data } = await api.put<{ account: RedditAccount }>(`/reddit/account/${id}`, payload);
+  return data.account;
+}
+
+export async function deleteRedditAccount(id: string): Promise<boolean> {
+  const { ok } = await api.delete<{ deleted: boolean }>(`/reddit/account/${id}`);
+  return ok;
+}
+
+export async function testRedditConnection(): Promise<{ ok: boolean; username?: string }> {
+  const { data, ok } = await api.post<{ ok: boolean; username?: string }>("/reddit/test", {});
+  return ok ? data : { ok: false };
+}
+
+export async function replyOnReddit(payload: {
+  target_type: "comment" | "submission" | "dm";
+  target_id: string;
+  text: string;
+  recipient?: string;
+}): Promise<{ ok: boolean; reply_id?: string }> {
+  const { data, ok } = await api.post<{ ok: boolean; reply_id?: string }>("/reddit/reply", payload);
+  return ok ? data : { ok: false };
+}

--- a/frontend/src/lib/api/scheduled-jobs-client.ts
+++ b/frontend/src/lib/api/scheduled-jobs-client.ts
@@ -1,0 +1,178 @@
+import { api } from "@/lib/transport";
+
+export type ScheduledJobType = "post" | "crew";
+
+export interface ScheduledJob {
+  id: string;
+  name: string;
+  job_type: ScheduledJobType;
+  cron: string;
+  timezone: string;
+  enabled: boolean;
+
+  channel_id?: string | null;
+  content?: string | null;
+  title?: string | null;
+  metadata?: Record<string, unknown> | null;
+
+  crew_id?: string | null;
+  crew_input?: Record<string, unknown> | null;
+
+  last_run_at?: string | null;
+  last_run_status?: "success" | "failed" | null;
+  last_run_error?: string | null;
+  next_run_at?: string | null;
+  run_count: number;
+
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateScheduledJobBody {
+  name: string;
+  job_type: ScheduledJobType;
+  cron: string;
+  timezone?: string;
+  enabled?: boolean;
+
+  channel_id?: string;
+  content?: string;
+  title?: string;
+  metadata?: Record<string, unknown>;
+
+  crew_id?: string;
+  crew_input?: Record<string, unknown>;
+}
+
+export interface UpdateScheduledJobBody {
+  name?: string;
+  cron?: string;
+  timezone?: string;
+  enabled?: boolean;
+
+  channel_id?: string;
+  content?: string;
+  title?: string;
+  metadata?: Record<string, unknown>;
+
+  crew_id?: string;
+  crew_input?: Record<string, unknown>;
+}
+
+export interface ValidateCronResult {
+  valid: boolean;
+  cron: string;
+  timezone: string;
+  next_runs: string[];
+}
+
+export interface ScheduledJobRunResult {
+  job_id: string;
+  job_type: ScheduledJobType;
+  status: "success" | "failed" | "skipped";
+  ran_at: string;
+  error?: string | null;
+  details?: Record<string, unknown> | null;
+}
+
+interface Envelope<T> {
+  status: string;
+  data: T;
+  message?: string;
+}
+
+const BASE = "/scheduled-jobs";
+
+export async function listScheduledJobs(
+  skip: number = 0,
+  limit: number = 100
+): Promise<{ jobs: ScheduledJob[]; total: number }> {
+  const { data } = await api.get<Envelope<{ jobs: ScheduledJob[]; total: number; skip: number; limit: number }>>(
+    `${BASE}/?skip=${skip}&limit=${limit}`
+  );
+  return { jobs: data.data?.jobs ?? [], total: data.data?.total ?? 0 };
+}
+
+export async function getScheduledJob(id: string): Promise<ScheduledJob> {
+  const { data } = await api.get<Envelope<ScheduledJob>>(`${BASE}/${encodeURIComponent(id)}`);
+  return data.data;
+}
+
+export async function createScheduledJob(body: CreateScheduledJobBody): Promise<ScheduledJob> {
+  const { data } = await api.post<Envelope<ScheduledJob>>(`${BASE}/`, body);
+  return data.data;
+}
+
+export async function updateScheduledJob(
+  id: string,
+  body: UpdateScheduledJobBody
+): Promise<ScheduledJob> {
+  const { data } = await api.patch<Envelope<ScheduledJob>>(
+    `${BASE}/${encodeURIComponent(id)}`,
+    body
+  );
+  return data.data;
+}
+
+export async function deleteScheduledJob(id: string): Promise<void> {
+  await api.delete(`${BASE}/${encodeURIComponent(id)}`);
+}
+
+export async function runScheduledJobNow(id: string): Promise<ScheduledJobRunResult> {
+  const { data } = await api.post<Envelope<ScheduledJobRunResult>>(
+    `${BASE}/${encodeURIComponent(id)}/run-now`
+  );
+  return data.data;
+}
+
+export async function toggleScheduledJob(id: string): Promise<ScheduledJob> {
+  const { data } = await api.post<Envelope<ScheduledJob>>(
+    `${BASE}/${encodeURIComponent(id)}/toggle`
+  );
+  return data.data;
+}
+
+export async function validateCron(
+  expr: string,
+  timezone: string = "UTC",
+  count: number = 5
+): Promise<ValidateCronResult> {
+  const qs = new URLSearchParams({
+    expr,
+    timezone,
+    count: String(count),
+  });
+  const { data } = await api.get<ValidateCronResult>(`${BASE}/validate-cron?${qs.toString()}`);
+  return data;
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────
+
+const CRON_PRESETS: Record<string, string> = {
+  "0 9 * * *": "Every day at 9:00 AM",
+  "0 9 * * 1-5": "Every weekday at 9:00 AM",
+  "0 * * * *": "Every hour",
+  "0 9 * * 1": "Every Monday at 9:00 AM",
+  "0 0 * * *": "Every day at midnight",
+  "*/15 * * * *": "Every 15 minutes",
+  "0 8 * * *": "Every day at 8:00 AM",
+};
+
+/** Prettify common cron expressions; falls back to the raw string. */
+export function prettifyCron(expr: string): string {
+  if (CRON_PRESETS[expr]) return CRON_PRESETS[expr];
+  const parts = expr.trim().split(/\s+/);
+  if (parts.length !== 5) return expr;
+  const [minute, hour, dom, month, dow] = parts;
+
+  const hourNum = parseInt(hour, 10);
+  const minNum = parseInt(minute, 10);
+  const everyDay = dom === "*" && month === "*" && dow === "*";
+
+  if (everyDay && !Number.isNaN(hourNum) && !Number.isNaN(minNum)) {
+    const h12 = hourNum % 12 || 12;
+    const ampm = hourNum < 12 ? "AM" : "PM";
+    return `Every day at ${h12}:${String(minNum).padStart(2, "0")} ${ampm}`;
+  }
+  return expr;
+}

--- a/frontend/src/lib/api/twitter-client.ts
+++ b/frontend/src/lib/api/twitter-client.ts
@@ -1,0 +1,92 @@
+import { api } from "@/lib/transport";
+
+export interface TwitterAccount {
+  _id: string;
+  api_key?: string;
+  api_secret?: string;
+  access_token?: string;
+  access_token_secret?: string;
+  bearer_token?: string;
+  user_id: string;
+  keywords: string[];
+  poll_mentions: boolean;
+  poll_dms: boolean;
+  enabled: boolean;
+  last_seen_ids: Record<string, string>;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateTwitterAccountPayload {
+  api_key?: string;
+  api_secret?: string;
+  access_token?: string;
+  access_token_secret?: string;
+  bearer_token?: string;
+  user_id: string;
+  keywords?: string[];
+  poll_mentions?: boolean;
+  poll_dms?: boolean;
+}
+
+export interface UpdateTwitterAccountPayload {
+  keywords?: string[];
+  poll_mentions?: boolean;
+  poll_dms?: boolean;
+  enabled?: boolean;
+}
+
+export async function getTwitterAccount(): Promise<TwitterAccount | null> {
+  const { data, ok } = await api.get<{ account: TwitterAccount | null }>("/twitter/account");
+  if (!ok) return null;
+  return data.account ?? null;
+}
+
+export async function createTwitterAccount(
+  payload: CreateTwitterAccountPayload,
+): Promise<TwitterAccount> {
+  const { data } = await api.post<{ account: TwitterAccount }>("/twitter/account", payload);
+  return data.account;
+}
+
+export async function updateTwitterAccount(
+  id: string,
+  payload: UpdateTwitterAccountPayload,
+): Promise<TwitterAccount> {
+  const { data } = await api.put<{ account: TwitterAccount }>(`/twitter/account/${id}`, payload);
+  return data.account;
+}
+
+export async function deleteTwitterAccount(id: string): Promise<boolean> {
+  const { ok } = await api.delete<{ deleted: boolean }>(`/twitter/account/${id}`);
+  return ok;
+}
+
+export async function testTwitterConnection(): Promise<{
+  ok: boolean;
+  id?: string;
+  username?: string;
+  name?: string;
+}> {
+  const { data, ok } = await api.post<{
+    ok: boolean;
+    id?: string;
+    username?: string;
+    name?: string;
+  }>("/twitter/test", {});
+  return ok ? data : { ok: false };
+}
+
+export async function replyOnTwitter(payload: {
+  target_type: "tweet" | "dm";
+  target_id: string;
+  text: string;
+  recipient?: string;
+}): Promise<{ ok: boolean; tweet_id?: string; dm_event_id?: string }> {
+  const { data, ok } = await api.post<{
+    ok: boolean;
+    tweet_id?: string;
+    dm_event_id?: string;
+  }>("/twitter/reply", payload);
+  return ok ? data : { ok: false };
+}

--- a/frontend/src/routes/connections.tsx
+++ b/frontend/src/routes/connections.tsx
@@ -6,6 +6,7 @@ import {
   Linkedin,
   AtSign,
   Camera,
+  Flame,
   Globe,
   Check,
   Eye,
@@ -40,7 +41,7 @@ import {
 
 // ─── Types ──────────────────────────────────────────────────────
 
-type ConnectionId = "telegram" | "discord" | "linkedin" | "twitter" | "instagram" | "facebook";
+type ConnectionId = "telegram" | "discord" | "linkedin" | "twitter" | "instagram" | "facebook" | "reddit";
 
 interface ConnectionConfig {
   id: ConnectionId;
@@ -250,6 +251,28 @@ const CONNECTIONS: ConnectionConfig[] = [
     defaultInbound: false,
     defaultOutbound: true,
   },
+  {
+    id: "reddit",
+    name: "Reddit",
+    description: "Poll subreddits and your inbox; auto-reply to comments and DMs with approval gating.",
+    icon: Flame,
+    iconBg: "bg-orange-100 dark:bg-orange-500/20",
+    iconColor: "text-orange-600 dark:text-orange-400",
+    docsUrl: "https://www.reddit.com/prefs/apps",
+    oauthProvider: null,
+    supportsInbound: true,
+    supportsOutbound: true,
+    defaultInbound: true,
+    defaultOutbound: true,
+    fields: [
+      { key: "client_id", label: "Client ID", placeholder: "From reddit.com/prefs/apps (script app)" },
+      { key: "client_secret", label: "Client Secret", placeholder: "Script app secret", secret: true },
+      { key: "username", label: "Reddit Username", placeholder: "your_reddit_handle" },
+      { key: "password", label: "Reddit Password", placeholder: "Account password", secret: true },
+      { key: "subreddits", label: "Subreddits (comma-separated)", placeholder: "LocalLLaMA,selfhosted" },
+      { key: "keywords", label: "Keywords (comma-separated)", placeholder: "local LLM, ollama, gguf" },
+    ],
+  },
 ];
 
 // ─── Helpers ────────────────────────────────────────────────────
@@ -364,10 +387,38 @@ export default function ConnectionsPage() {
     setShowSecrets({});
   };
 
-  // Token-paste save (Telegram/Discord)
+  // Token-paste save (Telegram/Discord/Reddit)
   const handleSave = async (connId: ConnectionId) => {
     setTesting(connId);
-    await new Promise((r) => setTimeout(r, 1500));
+
+    // Reddit has a dedicated backend endpoint — save there too so the poller picks it up.
+    if (connId === "reddit") {
+      try {
+        const { createRedditAccount, testRedditConnection } = await import(
+          "@/lib/api/reddit-client"
+        );
+        await createRedditAccount({
+          client_id: formData.client_id?.trim() || "",
+          client_secret: formData.client_secret?.trim() || "",
+          username: formData.username?.trim() || "",
+          password: formData.password?.trim() || "",
+          subreddits: (formData.subreddits || "")
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean),
+          keywords: (formData.keywords || "")
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean),
+          poll_inbox: formInbound,
+        });
+        await testRedditConnection();
+      } catch (e) {
+        console.error("Reddit save/test failed", e);
+      }
+    } else {
+      await new Promise((r) => setTimeout(r, 1500));
+    }
 
     const hasValues = Object.values(formData).some((v) => v.trim());
     const status = hasValues ? "connected" : "disconnected";

--- a/frontend/src/routes/distribution.tsx
+++ b/frontend/src/routes/distribution.tsx
@@ -1,0 +1,1009 @@
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { cn } from "@/lib/utils";
+import {
+  Send,
+  Linkedin,
+  AtSign,
+  Camera,
+  Globe,
+  Mail,
+  MessageCircle,
+  FileText,
+  Plus,
+  Edit3,
+  Trash2,
+  RefreshCw,
+  Loader2,
+  Check,
+  Upload,
+  Clock,
+} from "lucide-react";
+import { Button, Input, Textarea, Select, Badge, Dialog, Tabs } from "@/components/ui";
+import {
+  listChannels,
+  createChannel,
+  updateChannel,
+  deleteChannel,
+  toggleChannel,
+  publish as publishOne,
+  publishMulti,
+  listDeliveries,
+  type DistributionChannel,
+  type DistributionChannelType,
+  type Delivery,
+  type PublishMetadata,
+  type MultiPublishResult,
+} from "@/lib/api/distribution-client";
+
+// ─── Channel type meta ──────────────────────────────────────────
+
+type ChannelTypeMeta = {
+  label: string;
+  icon: React.ElementType;
+  color: string;
+  bg: string;
+};
+
+const CHANNEL_META: Record<DistributionChannelType, ChannelTypeMeta> = {
+  linkedin: {
+    label: "LinkedIn",
+    icon: Linkedin,
+    color: "text-blue-600 dark:text-blue-400",
+    bg: "bg-blue-100 dark:bg-blue-500/15",
+  },
+  twitter: {
+    label: "Twitter / X",
+    icon: AtSign,
+    color: "text-neutral-800 dark:text-neutral-200",
+    bg: "bg-neutral-100 dark:bg-neutral-500/15",
+  },
+  instagram: {
+    label: "Instagram",
+    icon: Camera,
+    color: "text-pink-600 dark:text-pink-400",
+    bg: "bg-pink-100 dark:bg-pink-500/15",
+  },
+  facebook: {
+    label: "Facebook",
+    icon: Globe,
+    color: "text-blue-700 dark:text-blue-400",
+    bg: "bg-blue-100 dark:bg-blue-500/15",
+  },
+  blog: {
+    label: "Blog",
+    icon: FileText,
+    color: "text-amber-700 dark:text-amber-400",
+    bg: "bg-amber-100 dark:bg-amber-500/15",
+  },
+  email: {
+    label: "Email",
+    icon: Mail,
+    color: "text-emerald-700 dark:text-emerald-400",
+    bg: "bg-emerald-100 dark:bg-emerald-500/15",
+  },
+  slack: {
+    label: "Slack",
+    icon: MessageCircle,
+    color: "text-violet-700 dark:text-violet-400",
+    bg: "bg-violet-100 dark:bg-violet-500/15",
+  },
+};
+
+type FieldDef = {
+  key: string;
+  label: string;
+  placeholder?: string;
+  secret?: boolean;
+  type?: "text" | "textarea" | "select";
+  options?: { value: string; label: string }[];
+  helperText?: string;
+};
+
+const CHANNEL_FIELDS: Record<DistributionChannelType, FieldDef[]> = {
+  linkedin: [
+    { key: "access_token", label: "Access Token", placeholder: "LinkedIn OAuth access token", secret: true },
+    {
+      key: "author_urn",
+      label: "Author URN",
+      placeholder: "urn:li:person:xxxx or urn:li:organization:xxxx",
+      helperText: "Person or organization URN this channel posts as.",
+    },
+  ],
+  twitter: [
+    { key: "api_key", label: "API Key", placeholder: "Consumer key", secret: true },
+    { key: "api_secret", label: "API Secret", placeholder: "Consumer secret", secret: true },
+    { key: "access_token", label: "Access Token", placeholder: "User access token", secret: true },
+    { key: "access_token_secret", label: "Access Token Secret", placeholder: "User access token secret", secret: true },
+    {
+      key: "bearer_token",
+      label: "Bearer Token (alternative to OAuth 1.0a)",
+      placeholder: "App-only bearer token",
+      secret: true,
+      helperText: "Provide either the 4 OAuth 1.0a keys above OR a bearer token.",
+    },
+  ],
+  instagram: [
+    { key: "access_token", label: "Access Token", placeholder: "Graph API access token", secret: true },
+    { key: "instagram_user_id", label: "Instagram User ID", placeholder: "e.g. 178414xxxxxxxx" },
+  ],
+  facebook: [
+    { key: "page_id", label: "Page ID", placeholder: "e.g. 102xxxxxxx" },
+    { key: "page_access_token", label: "Page Access Token", placeholder: "Long-lived page token", secret: true },
+  ],
+  blog: [
+    { key: "api_url", label: "API URL", placeholder: "https://your-blog.com/api/posts" },
+    { key: "api_key", label: "API Key", placeholder: "Bearer token / API key", secret: true },
+    {
+      key: "cms_type",
+      label: "CMS Type",
+      type: "select",
+      options: [
+        { value: "custom", label: "Custom" },
+        { value: "ghost", label: "Ghost" },
+        { value: "wordpress", label: "WordPress" },
+      ],
+    },
+  ],
+  email: [
+    {
+      key: "provider",
+      label: "Provider",
+      type: "select",
+      options: [
+        { value: "sendgrid", label: "SendGrid" },
+        { value: "ses", label: "AWS SES" },
+      ],
+    },
+    { key: "api_key", label: "API Key", placeholder: "Provider API key", secret: true },
+    { key: "from_email", label: "From Email", placeholder: "noreply@example.com" },
+  ],
+  slack: [
+    { key: "webhook_url", label: "Incoming Webhook URL", placeholder: "https://hooks.slack.com/services/...", secret: true },
+  ],
+};
+
+const CHANNEL_TYPE_OPTIONS: { value: DistributionChannelType; label: string }[] = (
+  Object.keys(CHANNEL_META) as DistributionChannelType[]
+).map((k) => ({ value: k, label: CHANNEL_META[k].label }));
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+function timeAgo(iso: string | null): string {
+  if (!iso) return "never";
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+function isMasked(value: unknown): boolean {
+  return typeof value === "string" && value.includes("****");
+}
+
+// ─── Channel Form Dialog ────────────────────────────────────────
+
+interface ChannelFormDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSaved: () => void;
+  existing: DistributionChannel | null;
+}
+
+function ChannelFormDialog({ open, onClose, onSaved, existing }: ChannelFormDialogProps) {
+  const [channelType, setChannelType] = useState<DistributionChannelType>("linkedin");
+  const [name, setName] = useState("");
+  const [config, setConfig] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    if (existing) {
+      setChannelType(existing.channel_type);
+      setName(existing.name);
+      const cfg: Record<string, string> = {};
+      for (const [k, v] of Object.entries(existing.config ?? {})) {
+        cfg[k] = v == null ? "" : String(v);
+      }
+      setConfig(cfg);
+    } else {
+      setChannelType("linkedin");
+      setName("");
+      setConfig({});
+    }
+    setError(null);
+  }, [open, existing]);
+
+  const fields = CHANNEL_FIELDS[channelType];
+  const isEdit = !!existing;
+
+  const handleTypeChange = (t: DistributionChannelType) => {
+    setChannelType(t);
+    setConfig({});
+  };
+
+  const handleSave = async () => {
+    if (!name.trim()) {
+      setError("Channel name is required.");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      // Only include non-empty config values, and skip masked placeholders
+      // when editing (so we don't overwrite stored secrets with "****").
+      const cleanedConfig: Record<string, string> = {};
+      for (const field of fields) {
+        const val = (config[field.key] ?? "").trim();
+        if (!val) continue;
+        if (isEdit && isMasked(val)) continue;
+        cleanedConfig[field.key] = val;
+      }
+
+      if (isEdit && existing) {
+        // Merge: if a field was left masked/empty, preserve it server-side by
+        // only sending the fields the user actually changed.
+        const updates: Record<string, unknown> = { name: name.trim() };
+        if (Object.keys(cleanedConfig).length > 0) {
+          // Merge user-provided values with the existing (masked) config.
+          const merged: Record<string, unknown> = { ...existing.config };
+          for (const [k, v] of Object.entries(cleanedConfig)) merged[k] = v;
+          // Strip any masked leftovers so server doesn't re-store "****".
+          for (const k of Object.keys(merged)) {
+            if (isMasked(merged[k])) delete merged[k];
+          }
+          updates.config = merged;
+        }
+        await updateChannel(existing.channel_id, updates);
+      } else {
+        await createChannel({
+          channel_type: channelType,
+          name: name.trim(),
+          config: cleanedConfig,
+        });
+      }
+      onSaved();
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to save channel");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title={isEdit ? "Edit Channel" : "Add Distribution Channel"}
+      className="max-w-lg"
+      actions={
+        <>
+          <Button variant="ghost" onClick={onClose} disabled={saving}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={saving}>
+            {saving ? (
+              <>
+                <Loader2 className="w-3.5 h-3.5 animate-spin" /> Saving
+              </>
+            ) : (
+              <>
+                <Check className="w-3.5 h-3.5" /> {isEdit ? "Save Changes" : "Create Channel"}
+              </>
+            )}
+          </Button>
+        </>
+      }
+    >
+      <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
+        {!isEdit && (
+          <Select
+            label="Channel Type"
+            value={channelType}
+            onChange={(e) => handleTypeChange(e.target.value as DistributionChannelType)}
+            options={CHANNEL_TYPE_OPTIONS}
+          />
+        )}
+
+        <Input
+          label="Channel Name"
+          placeholder="e.g. Company LinkedIn, Marketing Slack"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+
+        <div className="space-y-3 pt-1 border-t border-neutral-100 dark:border-neutral-800">
+          <p className="text-xs font-medium text-neutral-500 dark:text-neutral-400 pt-3">
+            {CHANNEL_META[channelType].label} Credentials
+          </p>
+          {fields.map((field) => {
+            const val = config[field.key] ?? "";
+            if (field.type === "select" && field.options) {
+              return (
+                <Select
+                  key={field.key}
+                  label={field.label}
+                  value={val}
+                  onChange={(e) => setConfig({ ...config, [field.key]: e.target.value })}
+                  options={field.options}
+                  placeholder="Select..."
+                  helperText={field.helperText}
+                />
+              );
+            }
+            return (
+              <Input
+                key={field.key}
+                label={field.label}
+                type={field.secret ? "password" : "text"}
+                placeholder={
+                  isEdit && isMasked(val)
+                    ? "Leave masked to keep existing value"
+                    : field.placeholder
+                }
+                value={val}
+                onChange={(e) => setConfig({ ...config, [field.key]: e.target.value })}
+                helperText={field.helperText}
+              />
+            );
+          })}
+        </div>
+
+        {error && (
+          <div className="px-3 py-2 rounded-lg bg-red-50 dark:bg-red-500/10 border border-red-200 dark:border-red-500/20 text-xs text-red-700 dark:text-red-400">
+            {error}
+          </div>
+        )}
+      </div>
+    </Dialog>
+  );
+}
+
+// ─── Publish Dialog ─────────────────────────────────────────────
+
+interface PublishDialogProps {
+  open: boolean;
+  onClose: () => void;
+  channels: DistributionChannel[];
+  onPublished: () => void;
+}
+
+function PublishDialog({ open, onClose, channels, onPublished }: PublishDialogProps) {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [content, setContent] = useState("");
+  const [title, setTitle] = useState("");
+  const [imageUrl, setImageUrl] = useState("");
+  const [toEmails, setToEmails] = useState("");
+  const [publishing, setPublishing] = useState(false);
+  const [result, setResult] = useState<MultiPublishResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setSelected(new Set());
+      setContent("");
+      setTitle("");
+      setImageUrl("");
+      setToEmails("");
+      setResult(null);
+      setError(null);
+    }
+  }, [open]);
+
+  const enabledChannels = channels.filter((c) => c.enabled);
+  const selectedChannels = enabledChannels.filter((c) => selected.has(c.channel_id));
+  const needsImage = selectedChannels.some((c) => c.channel_type === "instagram");
+  const needsEmails = selectedChannels.some((c) => c.channel_type === "email");
+
+  const toggleChannelSelection = (channelId: string) => {
+    const next = new Set(selected);
+    if (next.has(channelId)) next.delete(channelId);
+    else next.add(channelId);
+    setSelected(next);
+  };
+
+  const handlePublish = async () => {
+    if (selected.size === 0 || !content.trim()) return;
+    setPublishing(true);
+    setError(null);
+    setResult(null);
+
+    const metadata: PublishMetadata = {};
+    if (imageUrl.trim()) metadata.image_url = imageUrl.trim();
+    if (toEmails.trim()) {
+      metadata.to_emails = toEmails
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+    }
+
+    try {
+      const ids = Array.from(selected);
+      if (ids.length === 1) {
+        const delivery = await publishOne({
+          channel_id: ids[0],
+          content: content.trim(),
+          title: title.trim() || undefined,
+          metadata: Object.keys(metadata).length ? metadata : undefined,
+        });
+        setResult({
+          total_channels: 1,
+          published: delivery.status === "published" ? 1 : 0,
+          failed: delivery.status === "published" ? 0 : 1,
+          deliveries: [delivery],
+        });
+      } else {
+        const multi = await publishMulti({
+          channel_ids: ids,
+          content: content.trim(),
+          title: title.trim() || undefined,
+          metadata: Object.keys(metadata).length ? metadata : undefined,
+        });
+        setResult(multi);
+      }
+      onPublished();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Publish failed");
+    } finally {
+      setPublishing(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title="Publish Content"
+      className="max-w-xl"
+      actions={
+        <>
+          <Button variant="ghost" onClick={onClose} disabled={publishing}>
+            {result ? "Close" : "Cancel"}
+          </Button>
+          {!result && (
+            <Button
+              onClick={handlePublish}
+              disabled={publishing || selected.size === 0 || !content.trim()}
+            >
+              {publishing ? (
+                <>
+                  <Loader2 className="w-3.5 h-3.5 animate-spin" /> Publishing
+                </>
+              ) : (
+                <>
+                  <Send className="w-3.5 h-3.5" /> Publish to {selected.size || 0}
+                </>
+              )}
+            </Button>
+          )}
+        </>
+      }
+    >
+      <div className="space-y-4 max-h-[65vh] overflow-y-auto pr-1">
+        {result ? (
+          <div className="space-y-3">
+            <div className="flex items-center gap-2">
+              <Badge variant="success">{result.published} published</Badge>
+              {result.failed > 0 && (
+                <Badge variant="error">{result.failed} failed</Badge>
+              )}
+            </div>
+            <div className="space-y-2">
+              {result.deliveries.map((d) => {
+                const meta = CHANNEL_META[d.channel_type];
+                const Icon = meta?.icon ?? Send;
+                return (
+                  <div
+                    key={d.delivery_id}
+                    className="flex items-start gap-3 p-3 rounded-xl border border-neutral-200 dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-800/50"
+                  >
+                    <div className={cn("p-1.5 rounded-lg", meta?.bg)}>
+                      <Icon className={cn("w-4 h-4", meta?.color)} />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm font-medium text-neutral-900 dark:text-white">
+                          {d.channel_name || meta?.label}
+                        </span>
+                        {d.status === "published" ? (
+                          <Badge variant="success" dot>
+                            published
+                          </Badge>
+                        ) : (
+                          <Badge variant="error" dot>
+                            {d.status}
+                          </Badge>
+                        )}
+                      </div>
+                      {d.status !== "published" && d.result?.error && (
+                        <p className="text-xs text-red-600 dark:text-red-400 mt-1 break-words">
+                          {String(d.result.error).slice(0, 300)}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ) : (
+          <>
+            {/* Channel picker */}
+            <div>
+              <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2">
+                Channels
+              </label>
+              {enabledChannels.length === 0 ? (
+                <div className="text-xs text-neutral-500 dark:text-neutral-400 px-3 py-3 rounded-lg bg-neutral-50 dark:bg-neutral-800">
+                  No enabled channels. Add one to get started.
+                </div>
+              ) : (
+                <div className="grid grid-cols-2 gap-2">
+                  {enabledChannels.map((c) => {
+                    const meta = CHANNEL_META[c.channel_type];
+                    const Icon = meta.icon;
+                    const active = selected.has(c.channel_id);
+                    return (
+                      <button
+                        key={c.channel_id}
+                        type="button"
+                        onClick={() => toggleChannelSelection(c.channel_id)}
+                        className={cn(
+                          "flex items-center gap-2 px-3 py-2.5 rounded-xl border text-left text-sm transition-all",
+                          active
+                            ? "border-primary-500 bg-primary-50 dark:bg-primary-500/10"
+                            : "border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800/60 hover:border-neutral-300 dark:hover:border-neutral-600"
+                        )}
+                      >
+                        <div className={cn("p-1.5 rounded-lg", meta.bg)}>
+                          <Icon className={cn("w-4 h-4", meta.color)} />
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <div className="text-xs font-medium text-neutral-900 dark:text-white truncate">
+                            {c.name}
+                          </div>
+                          <div className="text-[10px] text-neutral-500 dark:text-neutral-400">
+                            {meta.label}
+                          </div>
+                        </div>
+                        <div
+                          className={cn(
+                            "w-4 h-4 rounded-full border-2 flex items-center justify-center flex-shrink-0",
+                            active
+                              ? "border-primary-500 bg-primary-500"
+                              : "border-neutral-300 dark:border-neutral-600"
+                          )}
+                        >
+                          {active && <Check className="w-2.5 h-2.5 text-white" />}
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+
+            <Input
+              label="Title (optional)"
+              placeholder="Subject line, blog post title, etc."
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+
+            <Textarea
+              label="Content"
+              placeholder="What do you want to publish?"
+              rows={6}
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+            />
+
+            {needsImage && (
+              <Input
+                label="Image URL"
+                placeholder="https://example.com/image.jpg"
+                value={imageUrl}
+                onChange={(e) => setImageUrl(e.target.value)}
+                helperText="Instagram requires an image_url."
+              />
+            )}
+
+            {needsEmails && (
+              <Input
+                label="To Emails (comma-separated)"
+                placeholder="alice@example.com, bob@example.com"
+                value={toEmails}
+                onChange={(e) => setToEmails(e.target.value)}
+              />
+            )}
+
+            {error && (
+              <div className="px-3 py-2 rounded-lg bg-red-50 dark:bg-red-500/10 border border-red-200 dark:border-red-500/20 text-xs text-red-700 dark:text-red-400">
+                {error}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </Dialog>
+  );
+}
+
+// ─── Main Page ──────────────────────────────────────────────────
+
+type TabId = "channels" | "deliveries";
+
+export default function DistributionPage() {
+  const [activeTab, setActiveTab] = useState<TabId>("channels");
+  const [channels, setChannels] = useState<DistributionChannel[]>([]);
+  const [deliveries, setDeliveries] = useState<Delivery[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<DistributionChannel | null>(null);
+  const [publishOpen, setPublishOpen] = useState(false);
+  const [togglingId, setTogglingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const loadChannels = useCallback(async () => {
+    try {
+      const data = await listChannels();
+      setChannels(data);
+    } catch (e) {
+      console.warn("Failed to load channels:", e);
+    }
+  }, []);
+
+  const loadDeliveries = useCallback(async () => {
+    try {
+      const data = await listDeliveries(undefined, 100);
+      setDeliveries(data);
+    } catch (e) {
+      console.warn("Failed to load deliveries:", e);
+    }
+  }, []);
+
+  const refreshAll = useCallback(async () => {
+    setLoading(true);
+    try {
+      await Promise.all([loadChannels(), loadDeliveries()]);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadChannels, loadDeliveries]);
+
+  useEffect(() => {
+    refreshAll();
+  }, [refreshAll]);
+
+  const handleToggle = async (ch: DistributionChannel) => {
+    setTogglingId(ch.channel_id);
+    try {
+      await toggleChannel(ch.channel_id, !ch.enabled);
+      await loadChannels();
+    } catch (e) {
+      console.warn("Toggle failed:", e);
+    } finally {
+      setTogglingId(null);
+    }
+  };
+
+  const handleDelete = async (ch: DistributionChannel) => {
+    if (!confirm(`Delete channel "${ch.name}"? This cannot be undone.`)) return;
+    setDeletingId(ch.channel_id);
+    try {
+      await deleteChannel(ch.channel_id);
+      await loadChannels();
+    } catch (e) {
+      console.warn("Delete failed:", e);
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const handleEdit = (ch: DistributionChannel) => {
+    setEditing(ch);
+    setFormOpen(true);
+  };
+
+  const handleAdd = () => {
+    setEditing(null);
+    setFormOpen(true);
+  };
+
+  const enabledCount = useMemo(() => channels.filter((c) => c.enabled).length, [channels]);
+
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <div className="max-w-5xl mx-auto px-6 py-8">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-6">
+          <div className="flex items-center gap-3">
+            <div className="flex items-center justify-center w-10 h-10 rounded-xl bg-primary-100 dark:bg-primary-500/15">
+              <Send className="w-5 h-5 text-primary-600 dark:text-primary-400" />
+            </div>
+            <div>
+              <h1 className="text-xl font-semibold text-neutral-900 dark:text-white">
+                Distribution
+              </h1>
+              <p className="text-sm text-neutral-500">
+                Publish content to LinkedIn, Twitter, Slack, email, blogs, and more.
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={refreshAll}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm text-neutral-600 dark:text-neutral-400 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+            >
+              <RefreshCw className={cn("w-4 h-4", loading && "animate-spin")} />
+              Refresh
+            </button>
+            <Button
+              onClick={() => setPublishOpen(true)}
+              disabled={enabledCount === 0}
+              size="sm"
+            >
+              <Upload className="w-3.5 h-3.5" />
+              Publish
+            </Button>
+            <Button onClick={handleAdd} variant="secondary" size="sm">
+              <Plus className="w-3.5 h-3.5" />
+              Add channel
+            </Button>
+          </div>
+        </div>
+
+        {/* Tabs */}
+        <div className="mb-6">
+          <Tabs
+            tabs={[
+              { id: "channels", label: `Channels (${channels.length})` },
+              { id: "deliveries", label: `Delivery History (${deliveries.length})` },
+            ]}
+            activeTab={activeTab}
+            onChange={(id) => setActiveTab(id as TabId)}
+            className="w-fit"
+          />
+        </div>
+
+        {/* Channels tab */}
+        {activeTab === "channels" && (
+          <>
+            {loading && channels.length === 0 ? (
+              <div className="flex items-center justify-center py-16">
+                <Loader2 className="w-6 h-6 text-neutral-400 animate-spin" />
+              </div>
+            ) : channels.length === 0 ? (
+              <div className="text-center py-16 rounded-2xl border border-dashed border-neutral-200 dark:border-neutral-800 bg-neutral-50/50 dark:bg-neutral-800/20">
+                <Send className="w-12 h-12 text-neutral-300 dark:text-neutral-600 mx-auto mb-3" />
+                <p className="text-neutral-600 dark:text-neutral-400 font-medium">
+                  No distribution channels yet
+                </p>
+                <p className="text-sm text-neutral-500 mt-1">
+                  Add a channel to start publishing AI-generated content.
+                </p>
+                <div className="mt-4">
+                  <Button onClick={handleAdd} size="sm">
+                    <Plus className="w-3.5 h-3.5" />
+                    Add your first channel
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {channels.map((ch) => {
+                  const meta = CHANNEL_META[ch.channel_type];
+                  const Icon = meta.icon;
+                  return (
+                    <div
+                      key={ch.channel_id}
+                      className={cn(
+                        "rounded-2xl border p-5 bg-white dark:bg-neutral-900 transition-colors",
+                        ch.enabled
+                          ? "border-neutral-200 dark:border-neutral-800"
+                          : "border-neutral-200 dark:border-neutral-800 opacity-70"
+                      )}
+                    >
+                      <div className="flex items-start justify-between gap-4">
+                        <div className="flex items-start gap-4 min-w-0 flex-1">
+                          <div className={cn("p-2.5 rounded-xl flex-shrink-0", meta.bg)}>
+                            <Icon className={cn("w-5 h-5", meta.color)} />
+                          </div>
+                          <div className="min-w-0 flex-1">
+                            <div className="flex items-center gap-2 flex-wrap">
+                              <h3 className="text-sm font-semibold text-neutral-900 dark:text-white truncate">
+                                {ch.name}
+                              </h3>
+                              <Badge variant="info">{meta.label}</Badge>
+                              {ch.enabled ? (
+                                <Badge variant="success" dot>
+                                  enabled
+                                </Badge>
+                              ) : (
+                                <Badge variant="default" dot>
+                                  disabled
+                                </Badge>
+                              )}
+                            </div>
+                            <div className="flex items-center gap-4 mt-1.5 text-xs text-neutral-500 dark:text-neutral-400">
+                              <span>
+                                <span className="font-medium text-neutral-700 dark:text-neutral-300">
+                                  {ch.publish_count}
+                                </span>{" "}
+                                {ch.publish_count === 1 ? "post" : "posts"}
+                              </span>
+                              <span className="flex items-center gap-1">
+                                <Clock className="w-3 h-3" />
+                                Last published {timeAgo(ch.last_published_at)}
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+
+                        <div className="flex items-center gap-1 flex-shrink-0">
+                          <button
+                            onClick={() => handleToggle(ch)}
+                            disabled={togglingId === ch.channel_id}
+                            className={cn(
+                              "relative inline-flex h-5 w-9 items-center rounded-full transition-colors mx-2",
+                              ch.enabled
+                                ? "bg-green-500"
+                                : "bg-neutral-300 dark:bg-neutral-600"
+                            )}
+                            title={ch.enabled ? "Disable" : "Enable"}
+                          >
+                            <span
+                              className={cn(
+                                "inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform",
+                                ch.enabled ? "translate-x-[18px]" : "translate-x-[3px]"
+                              )}
+                            />
+                          </button>
+                          <button
+                            onClick={() => handleEdit(ch)}
+                            className="p-2 rounded-lg text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+                            title="Edit"
+                          >
+                            <Edit3 className="w-4 h-4" />
+                          </button>
+                          <button
+                            onClick={() => handleDelete(ch)}
+                            disabled={deletingId === ch.channel_id}
+                            className="p-2 rounded-lg text-neutral-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-500/10 transition-colors"
+                            title="Delete"
+                          >
+                            {deletingId === ch.channel_id ? (
+                              <Loader2 className="w-4 h-4 animate-spin" />
+                            ) : (
+                              <Trash2 className="w-4 h-4" />
+                            )}
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </>
+        )}
+
+        {/* Deliveries tab */}
+        {activeTab === "deliveries" && (
+          <>
+            {loading && deliveries.length === 0 ? (
+              <div className="flex items-center justify-center py-16">
+                <Loader2 className="w-6 h-6 text-neutral-400 animate-spin" />
+              </div>
+            ) : deliveries.length === 0 ? (
+              <div className="text-center py-16 rounded-2xl border border-dashed border-neutral-200 dark:border-neutral-800 bg-neutral-50/50 dark:bg-neutral-800/20">
+                <Clock className="w-12 h-12 text-neutral-300 dark:text-neutral-600 mx-auto mb-3" />
+                <p className="text-neutral-600 dark:text-neutral-400 font-medium">
+                  No deliveries yet
+                </p>
+                <p className="text-sm text-neutral-500 mt-1">
+                  Publishing activity will show up here.
+                </p>
+              </div>
+            ) : (
+              <div className="rounded-2xl border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 overflow-hidden">
+                <table className="w-full text-sm">
+                  <thead className="bg-neutral-50 dark:bg-neutral-800/50 text-xs text-neutral-500 dark:text-neutral-400">
+                    <tr>
+                      <th className="text-left font-medium px-4 py-2.5">When</th>
+                      <th className="text-left font-medium px-4 py-2.5">Channel</th>
+                      <th className="text-left font-medium px-4 py-2.5">Title</th>
+                      <th className="text-left font-medium px-4 py-2.5">Length</th>
+                      <th className="text-left font-medium px-4 py-2.5">Status</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {deliveries.map((d) => {
+                      const meta = CHANNEL_META[d.channel_type];
+                      const Icon = meta?.icon ?? Send;
+                      const truncTitle = d.title
+                        ? d.title.length > 60
+                          ? d.title.slice(0, 60) + "…"
+                          : d.title
+                        : "—";
+                      return (
+                        <tr
+                          key={d.delivery_id}
+                          className="border-t border-neutral-100 dark:border-neutral-800"
+                        >
+                          <td className="px-4 py-3 text-xs text-neutral-500 whitespace-nowrap">
+                            {timeAgo(d.timestamp)}
+                          </td>
+                          <td className="px-4 py-3">
+                            <div className="flex items-center gap-2">
+                              <div className={cn("p-1 rounded-md", meta?.bg)}>
+                                <Icon className={cn("w-3.5 h-3.5", meta?.color)} />
+                              </div>
+                              <span className="text-xs font-medium text-neutral-800 dark:text-neutral-200 truncate max-w-[180px]">
+                                {d.channel_name || meta?.label || d.channel_type}
+                              </span>
+                            </div>
+                          </td>
+                          <td className="px-4 py-3 text-xs text-neutral-600 dark:text-neutral-400">
+                            {truncTitle}
+                          </td>
+                          <td className="px-4 py-3 text-xs text-neutral-500">
+                            {d.content_length}
+                          </td>
+                          <td className="px-4 py-3">
+                            {d.status === "published" ? (
+                              <Badge variant="success" dot>
+                                published
+                              </Badge>
+                            ) : d.status === "failed" ? (
+                              <Badge variant="error" dot>
+                                failed
+                              </Badge>
+                            ) : (
+                              <Badge variant="warning" dot>
+                                {d.status}
+                              </Badge>
+                            )}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </>
+        )}
+
+        {/* Info banner */}
+        <div className="flex items-start gap-3 p-4 mt-6 bg-primary-50 dark:bg-primary-500/5 border border-primary-200 dark:border-primary-800/50 rounded-xl">
+          <Send className="w-4 h-4 text-primary-500 flex-shrink-0 mt-0.5" />
+          <p className="text-xs text-neutral-600 dark:text-neutral-400 leading-relaxed">
+            Channels store credentials locally and publish directly to each platform&apos;s API.
+            Credentials are masked in the UI once saved — leave fields blank while editing to preserve
+            existing values. Use the <span className="font-medium">Connections</span> page for inbound
+            conversations; this page is for outbound publishing.
+          </p>
+        </div>
+
+        {/* Dialogs */}
+        <ChannelFormDialog
+          open={formOpen}
+          onClose={() => setFormOpen(false)}
+          onSaved={loadChannels}
+          existing={editing}
+        />
+        <PublishDialog
+          open={publishOpen}
+          onClose={() => setPublishOpen(false)}
+          channels={channels}
+          onPublished={refreshAll}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/routes/schedule.tsx
+++ b/frontend/src/routes/schedule.tsx
@@ -1,0 +1,772 @@
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { cn } from "@/lib/utils";
+import {
+  Clock,
+  Plus,
+  Play,
+  Edit3,
+  Trash2,
+  Loader2,
+  RefreshCw,
+  ChevronDown,
+  Send,
+  Users,
+  AlertCircle,
+  CheckCircle2,
+} from "lucide-react";
+import { Dialog, Button, Input, Textarea } from "@/components/ui";
+import {
+  listScheduledJobs,
+  createScheduledJob,
+  updateScheduledJob,
+  deleteScheduledJob,
+  runScheduledJobNow,
+  toggleScheduledJob,
+  validateCron,
+  prettifyCron,
+  type ScheduledJob,
+  type ScheduledJobType,
+} from "@/lib/api/scheduled-jobs-client";
+import { listChannels, type DistributionChannel } from "@/lib/api/distribution-client";
+import { crewsApi, type Crew } from "@/lib/api/crews-client";
+
+// ─── Cron presets ────────────────────────────────────────────────
+
+const CRON_PRESETS: { label: string; expr: string }[] = [
+  { label: "Every day at 9am", expr: "0 9 * * *" },
+  { label: "Every weekday at 9am", expr: "0 9 * * 1-5" },
+  { label: "Every hour", expr: "0 * * * *" },
+  { label: "Every Monday at 9am", expr: "0 9 * * 1" },
+  { label: "Every day at 8am", expr: "0 8 * * *" },
+  { label: "Every 15 minutes", expr: "*/15 * * * *" },
+];
+
+function guessLocalTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  } catch {
+    return "UTC";
+  }
+}
+
+function formatDateTime(iso?: string | null): string {
+  if (!iso) return "—";
+  try {
+    const d = new Date(iso);
+    return d.toLocaleString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+// ─── Job card ────────────────────────────────────────────────────
+
+function JobCard({
+  job,
+  onRun,
+  onToggle,
+  onEdit,
+  onDelete,
+  busy,
+}: {
+  job: ScheduledJob;
+  onRun: (j: ScheduledJob) => void;
+  onToggle: (j: ScheduledJob) => void;
+  onEdit: (j: ScheduledJob) => void;
+  onDelete: (j: ScheduledJob) => void;
+  busy: boolean;
+}) {
+  const typeBadge =
+    job.job_type === "post"
+      ? "bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-400"
+      : "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400";
+
+  const TypeIcon = job.job_type === "post" ? Send : Users;
+
+  const statusChip = job.last_run_status === "success"
+    ? { icon: CheckCircle2, cls: "text-green-600 dark:text-green-400", label: "Last run: success" }
+    : job.last_run_status === "failed"
+    ? { icon: AlertCircle, cls: "text-red-600 dark:text-red-400", label: "Last run: failed" }
+    : null;
+
+  return (
+    <div className="rounded-xl border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800/50 p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-sm font-semibold text-neutral-900 dark:text-white truncate">
+              {job.name}
+            </span>
+            <span
+              className={cn(
+                "inline-flex items-center gap-1 text-[11px] px-2 py-0.5 rounded-full font-medium",
+                typeBadge
+              )}
+            >
+              <TypeIcon className="w-3 h-3" />
+              {job.job_type}
+            </span>
+            {!job.enabled && (
+              <span className="text-[11px] px-2 py-0.5 rounded-full bg-neutral-200 text-neutral-600 dark:bg-neutral-700 dark:text-neutral-300">
+                paused
+              </span>
+            )}
+          </div>
+
+          <div className="mt-1.5 text-xs text-neutral-500 dark:text-neutral-400 flex items-center gap-3 flex-wrap">
+            <span className="flex items-center gap-1">
+              <Clock className="w-3 h-3" />
+              {prettifyCron(job.cron)}
+            </span>
+            <span className="text-neutral-400">·</span>
+            <span>{job.timezone}</span>
+            <span className="text-neutral-400">·</span>
+            <span>Next: {formatDateTime(job.next_run_at)}</span>
+            <span className="text-neutral-400">·</span>
+            <span>Runs: {job.run_count}</span>
+          </div>
+
+          {statusChip && (
+            <div className={cn("mt-1.5 text-xs flex items-center gap-1", statusChip.cls)}>
+              <statusChip.icon className="w-3 h-3" />
+              {statusChip.label}
+              {job.last_run_error && (
+                <span className="text-neutral-500 dark:text-neutral-400 truncate max-w-[320px]">
+                  — {job.last_run_error}
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center gap-1">
+          <button
+            onClick={() => onRun(job)}
+            disabled={busy}
+            title="Run now"
+            className="p-2 rounded-lg text-neutral-500 hover:text-primary-600 hover:bg-primary-50 dark:hover:bg-primary-900/20 disabled:opacity-40"
+          >
+            <Play className="w-4 h-4" />
+          </button>
+          <button
+            onClick={() => onToggle(job)}
+            disabled={busy}
+            title={job.enabled ? "Pause" : "Resume"}
+            className={cn(
+              "px-2 py-1 rounded-lg text-xs font-medium transition-colors",
+              job.enabled
+                ? "text-neutral-600 hover:bg-neutral-100 dark:hover:bg-neutral-700 dark:text-neutral-300"
+                : "text-green-600 hover:bg-green-50 dark:hover:bg-green-900/20 dark:text-green-400"
+            )}
+          >
+            {job.enabled ? "Pause" : "Resume"}
+          </button>
+          <button
+            onClick={() => onEdit(job)}
+            title="Edit"
+            className="p-2 rounded-lg text-neutral-500 hover:text-neutral-800 hover:bg-neutral-100 dark:hover:bg-neutral-700 dark:hover:text-white"
+          >
+            <Edit3 className="w-4 h-4" />
+          </button>
+          <button
+            onClick={() => onDelete(job)}
+            title="Delete"
+            className="p-2 rounded-lg text-neutral-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20"
+          >
+            <Trash2 className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Dialog ──────────────────────────────────────────────────────
+
+interface JobFormState {
+  name: string;
+  job_type: ScheduledJobType;
+  cron: string;
+  timezone: string;
+  channel_id: string;
+  content: string;
+  title: string;
+  metadata_json: string;
+  crew_id: string;
+  crew_input_json: string;
+  enabled: boolean;
+}
+
+function emptyForm(): JobFormState {
+  return {
+    name: "",
+    job_type: "post",
+    cron: "0 9 * * *",
+    timezone: guessLocalTimezone(),
+    channel_id: "",
+    content: "",
+    title: "",
+    metadata_json: "",
+    crew_id: "",
+    crew_input_json: "",
+    enabled: true,
+  };
+}
+
+function jobToForm(j: ScheduledJob): JobFormState {
+  return {
+    name: j.name,
+    job_type: j.job_type,
+    cron: j.cron,
+    timezone: j.timezone,
+    channel_id: j.channel_id ?? "",
+    content: j.content ?? "",
+    title: j.title ?? "",
+    metadata_json: j.metadata ? JSON.stringify(j.metadata, null, 2) : "",
+    crew_id: j.crew_id ?? "",
+    crew_input_json: j.crew_input ? JSON.stringify(j.crew_input, null, 2) : "",
+    enabled: j.enabled,
+  };
+}
+
+function JobDialog({
+  open,
+  editing,
+  channels,
+  crews,
+  onClose,
+  onSaved,
+}: {
+  open: boolean;
+  editing: ScheduledJob | null;
+  channels: DistributionChannel[];
+  crews: Crew[];
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [form, setForm] = useState<JobFormState>(emptyForm());
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showMetadata, setShowMetadata] = useState(false);
+  const [previewRuns, setPreviewRuns] = useState<string[]>([]);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setForm(editing ? jobToForm(editing) : emptyForm());
+    setError(null);
+    setShowMetadata(false);
+    setPreviewRuns([]);
+    setPreviewError(null);
+  }, [open, editing]);
+
+  // Cron preview — debounced
+  useEffect(() => {
+    if (!open) return;
+    const handle = setTimeout(async () => {
+      try {
+        const result = await validateCron(form.cron, form.timezone, 5);
+        setPreviewRuns(result.next_runs);
+        setPreviewError(null);
+      } catch (err) {
+        setPreviewRuns([]);
+        setPreviewError((err as Error).message ?? "Invalid cron");
+      }
+    }, 400);
+    return () => clearTimeout(handle);
+  }, [form.cron, form.timezone, open]);
+
+  const update = <K extends keyof JobFormState>(key: K, value: JobFormState[K]) =>
+    setForm((f) => ({ ...f, [key]: value }));
+
+  const handleSave = async () => {
+    setError(null);
+
+    if (!form.name.trim()) {
+      setError("Name is required");
+      return;
+    }
+    if (form.job_type === "post") {
+      if (!form.channel_id) return setError("Select a channel");
+      if (!form.content.trim()) return setError("Content is required");
+    } else {
+      if (!form.crew_id) return setError("Select a crew");
+    }
+
+    let metadata: Record<string, unknown> | undefined;
+    if (form.metadata_json.trim()) {
+      try {
+        metadata = JSON.parse(form.metadata_json);
+      } catch {
+        return setError("Metadata is not valid JSON");
+      }
+    }
+
+    let crewInput: Record<string, unknown> | undefined;
+    if (form.crew_input_json.trim()) {
+      try {
+        crewInput = JSON.parse(form.crew_input_json);
+      } catch {
+        return setError("Crew input is not valid JSON");
+      }
+    }
+
+    const payload = {
+      name: form.name.trim(),
+      job_type: form.job_type,
+      cron: form.cron.trim(),
+      timezone: form.timezone || "UTC",
+      enabled: form.enabled,
+      ...(form.job_type === "post"
+        ? {
+            channel_id: form.channel_id,
+            content: form.content,
+            title: form.title || undefined,
+            metadata,
+          }
+        : {
+            crew_id: form.crew_id,
+            crew_input: crewInput,
+          }),
+    };
+
+    setSaving(true);
+    try {
+      if (editing) {
+        await updateScheduledJob(editing.id, payload);
+      } else {
+        await createScheduledJob(payload);
+      }
+      onSaved();
+      onClose();
+    } catch (err) {
+      setError((err as Error).message ?? "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const actions = (
+    <>
+      <Button variant="secondary" onClick={onClose} disabled={saving}>
+        Cancel
+      </Button>
+      <Button onClick={handleSave} disabled={saving}>
+        {saving ? <Loader2 className="w-4 h-4 animate-spin" /> : editing ? "Save changes" : "Create"}
+      </Button>
+    </>
+  );
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title={editing ? "Edit scheduled job" : "New scheduled job"}
+      actions={actions}
+      className="max-w-2xl"
+    >
+      <div className="space-y-4 max-h-[70vh] overflow-y-auto pr-1">
+        {error && (
+          <div className="rounded-lg border border-red-200 dark:border-red-800/40 bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-700 dark:text-red-300">
+            {error}
+          </div>
+        )}
+
+        {/* Name */}
+        <div>
+          <label className="text-xs font-medium text-neutral-600 dark:text-neutral-400 mb-1 block">
+            Name
+          </label>
+          <Input
+            value={form.name}
+            onChange={(e) => update("name", e.target.value)}
+            placeholder="Daily LinkedIn post"
+          />
+        </div>
+
+        {/* Type selector */}
+        <div>
+          <label className="text-xs font-medium text-neutral-600 dark:text-neutral-400 mb-1 block">
+            Type
+          </label>
+          <div className="grid grid-cols-2 gap-2">
+            {(["post", "crew"] as const).map((t) => (
+              <button
+                key={t}
+                type="button"
+                onClick={() => update("job_type", t)}
+                className={cn(
+                  "flex items-center gap-2 px-3 py-2 rounded-lg border text-sm font-medium transition-colors",
+                  form.job_type === t
+                    ? "border-primary-500 bg-primary-50 dark:bg-primary-500/10 text-primary-700 dark:text-primary-400"
+                    : "border-neutral-200 dark:border-neutral-700 text-neutral-600 dark:text-neutral-300 hover:bg-neutral-50 dark:hover:bg-neutral-800"
+                )}
+              >
+                {t === "post" ? <Send className="w-4 h-4" /> : <Users className="w-4 h-4" />}
+                {t === "post" ? "Publish post" : "Run crew"}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Post fields */}
+        {form.job_type === "post" && (
+          <>
+            <div>
+              <label className="text-xs font-medium text-neutral-600 dark:text-neutral-400 mb-1 block">
+                Channel
+              </label>
+              <select
+                value={form.channel_id}
+                onChange={(e) => update("channel_id", e.target.value)}
+                className="w-full px-4 py-2.5 rounded-xl text-sm bg-neutral-50 dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 text-neutral-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500/40 focus:border-primary-500"
+              >
+                <option value="">Select a channel…</option>
+                {channels.map((c) => (
+                  <option key={c.channel_id} value={c.channel_id}>
+                    {c.name} ({c.channel_type})
+                  </option>
+                ))}
+              </select>
+              {channels.length === 0 && (
+                <p className="text-xs text-neutral-500 mt-1">
+                  No distribution channels yet — add one in Connections.
+                </p>
+              )}
+            </div>
+
+            <div>
+              <label className="text-xs font-medium text-neutral-600 dark:text-neutral-400 mb-1 block">
+                Title (optional)
+              </label>
+              <Input
+                value={form.title}
+                onChange={(e) => update("title", e.target.value)}
+                placeholder="Optional post title"
+              />
+            </div>
+
+            <div>
+              <label className="text-xs font-medium text-neutral-600 dark:text-neutral-400 mb-1 block">
+                Content
+              </label>
+              <Textarea
+                value={form.content}
+                onChange={(e) => update("content", e.target.value)}
+                rows={5}
+                placeholder="The post body that will be published each time the job fires."
+              />
+            </div>
+
+            <div>
+              <button
+                type="button"
+                onClick={() => setShowMetadata((v) => !v)}
+                className="text-xs text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300 flex items-center gap-1"
+              >
+                <ChevronDown
+                  className={cn(
+                    "w-3 h-3 transition-transform",
+                    showMetadata && "rotate-180"
+                  )}
+                />
+                Advanced: metadata JSON
+              </button>
+              {showMetadata && (
+                <Textarea
+                  value={form.metadata_json}
+                  onChange={(e) => update("metadata_json", e.target.value)}
+                  rows={3}
+                  placeholder='{"image_url": "https://..."}'
+                  className="mt-2 font-mono text-xs"
+                />
+              )}
+            </div>
+          </>
+        )}
+
+        {/* Crew fields */}
+        {form.job_type === "crew" && (
+          <>
+            <div>
+              <label className="text-xs font-medium text-neutral-600 dark:text-neutral-400 mb-1 block">
+                Crew
+              </label>
+              <select
+                value={form.crew_id}
+                onChange={(e) => update("crew_id", e.target.value)}
+                className="w-full px-4 py-2.5 rounded-xl text-sm bg-neutral-50 dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 text-neutral-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary-500/40 focus:border-primary-500"
+              >
+                <option value="">Select a crew…</option>
+                {crews.map((c) => (
+                  <option key={c.crew_id} value={c.crew_id}>
+                    {c.name}
+                  </option>
+                ))}
+              </select>
+              {crews.length === 0 && (
+                <p className="text-xs text-neutral-500 mt-1">
+                  No crews yet — create one in Crews.
+                </p>
+              )}
+            </div>
+
+            <div>
+              <label className="text-xs font-medium text-neutral-600 dark:text-neutral-400 mb-1 block">
+                Crew input JSON (optional)
+              </label>
+              <Textarea
+                value={form.crew_input_json}
+                onChange={(e) => update("crew_input_json", e.target.value)}
+                rows={4}
+                placeholder='{"topic": "weekly news digest"}'
+                className="font-mono text-xs"
+              />
+            </div>
+          </>
+        )}
+
+        {/* Cron presets */}
+        <div>
+          <label className="text-xs font-medium text-neutral-600 dark:text-neutral-400 mb-1 block">
+            Schedule
+          </label>
+          <div className="flex flex-wrap gap-1.5 mb-2">
+            {CRON_PRESETS.map((p) => (
+              <button
+                key={p.expr}
+                type="button"
+                onClick={() => update("cron", p.expr)}
+                className={cn(
+                  "px-2.5 py-1 rounded-md text-xs border transition-colors",
+                  form.cron === p.expr
+                    ? "border-primary-500 bg-primary-50 dark:bg-primary-500/10 text-primary-700 dark:text-primary-400"
+                    : "border-neutral-200 dark:border-neutral-700 text-neutral-600 dark:text-neutral-400 hover:bg-neutral-50 dark:hover:bg-neutral-800"
+                )}
+              >
+                {p.label}
+              </button>
+            ))}
+          </div>
+          <Input
+            value={form.cron}
+            onChange={(e) => update("cron", e.target.value)}
+            placeholder="0 9 * * *"
+            className="font-mono text-sm"
+          />
+          <p className="text-[11px] text-neutral-500 mt-1">
+            Standard 5-field cron: minute hour day-of-month month day-of-week
+          </p>
+        </div>
+
+        {/* Timezone */}
+        <div>
+          <label className="text-xs font-medium text-neutral-600 dark:text-neutral-400 mb-1 block">
+            Timezone
+          </label>
+          <Input
+            value={form.timezone}
+            onChange={(e) => update("timezone", e.target.value)}
+            placeholder="UTC"
+          />
+        </div>
+
+        {/* Preview */}
+        <div className="rounded-lg border border-neutral-200 dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-900/50 px-3 py-2">
+          <p className="text-xs font-medium text-neutral-600 dark:text-neutral-400 mb-1">
+            Next 5 runs
+          </p>
+          {previewError ? (
+            <p className="text-xs text-red-600 dark:text-red-400">{previewError}</p>
+          ) : previewRuns.length === 0 ? (
+            <p className="text-xs text-neutral-400">—</p>
+          ) : (
+            <ul className="text-xs text-neutral-700 dark:text-neutral-300 space-y-0.5">
+              {previewRuns.map((r) => (
+                <li key={r} className="font-mono">
+                  {formatDateTime(r)}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </Dialog>
+  );
+}
+
+// ─── Page ────────────────────────────────────────────────────────
+
+export default function SchedulePage() {
+  const [jobs, setJobs] = useState<ScheduledJob[]>([]);
+  const [channels, setChannels] = useState<DistributionChannel[]>([]);
+  const [crews, setCrews] = useState<Crew[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editing, setEditing] = useState<ScheduledJob | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const loadJobs = useCallback(async () => {
+    try {
+      const result = await listScheduledJobs(0, 200);
+      setJobs(result.jobs);
+    } catch (err) {
+      console.warn("Failed to load scheduled jobs:", err);
+    }
+  }, []);
+
+  const loadChannelsAndCrews = useCallback(async () => {
+    try {
+      const [ch, cr] = await Promise.all([listChannels(), crewsApi.list()]);
+      setChannels(ch);
+      setCrews(cr);
+    } catch (err) {
+      console.warn("Failed to load channels/crews:", err);
+    }
+  }, []);
+
+  useEffect(() => {
+    (async () => {
+      setLoading(true);
+      await Promise.all([loadJobs(), loadChannelsAndCrews()]);
+      setLoading(false);
+    })();
+  }, [loadJobs, loadChannelsAndCrews]);
+
+  const openCreate = () => {
+    setEditing(null);
+    setDialogOpen(true);
+  };
+
+  const openEdit = (j: ScheduledJob) => {
+    setEditing(j);
+    setDialogOpen(true);
+  };
+
+  const handleRun = async (j: ScheduledJob) => {
+    setBusyId(j.id);
+    try {
+      await runScheduledJobNow(j.id);
+      await loadJobs();
+    } catch (err) {
+      console.warn("Run-now failed:", err);
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const handleToggle = async (j: ScheduledJob) => {
+    setBusyId(j.id);
+    try {
+      await toggleScheduledJob(j.id);
+      await loadJobs();
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const handleDelete = async (j: ScheduledJob) => {
+    if (!window.confirm(`Delete scheduled job "${j.name}"?`)) return;
+    setBusyId(j.id);
+    try {
+      await deleteScheduledJob(j.id);
+      await loadJobs();
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const sortedJobs = useMemo(
+    () =>
+      [...jobs].sort((a, b) =>
+        (a.next_run_at ?? "").localeCompare(b.next_run_at ?? "")
+      ),
+    [jobs]
+  );
+
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <div className="max-w-4xl mx-auto px-6 py-8">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-6">
+          <div className="flex items-center gap-3">
+            <div className="flex items-center justify-center w-10 h-10 rounded-xl bg-primary-100 dark:bg-primary-500/20">
+              <Clock className="w-5 h-5 text-primary-600 dark:text-primary-400" />
+            </div>
+            <div>
+              <h1 className="text-xl font-semibold text-neutral-900 dark:text-white">
+                Scheduled Jobs
+              </h1>
+              <p className="text-sm text-neutral-500">
+                Cron-based posts and crew runs
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={loadJobs}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm text-neutral-600 dark:text-neutral-400 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+            >
+              <RefreshCw className={cn("w-4 h-4", loading && "animate-spin")} />
+              Refresh
+            </button>
+            <Button onClick={openCreate}>
+              <Plus className="w-4 h-4 mr-1" />
+              New scheduled job
+            </Button>
+          </div>
+        </div>
+
+        {/* List */}
+        {loading && jobs.length === 0 ? (
+          <div className="flex items-center justify-center py-16">
+            <Loader2 className="w-6 h-6 text-neutral-400 animate-spin" />
+          </div>
+        ) : jobs.length === 0 ? (
+          <div className="text-center py-16">
+            <Clock className="w-12 h-12 text-neutral-300 dark:text-neutral-600 mx-auto mb-3" />
+            <p className="text-neutral-500 dark:text-neutral-400">
+              No scheduled jobs yet
+            </p>
+            <p className="text-sm text-neutral-400 dark:text-neutral-500 mt-1">
+              Schedule a daily post or a recurring crew run to get started
+            </p>
+            <Button onClick={openCreate} className="mt-4">
+              <Plus className="w-4 h-4 mr-1" />
+              Create your first scheduled job
+            </Button>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {sortedJobs.map((j) => (
+              <JobCard
+                key={j.id}
+                job={j}
+                busy={busyId === j.id}
+                onRun={handleRun}
+                onToggle={handleToggle}
+                onEdit={openEdit}
+                onDelete={handleDelete}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <JobDialog
+        open={dialogOpen}
+        editing={editing}
+        channels={channels}
+        crews={crews}
+        onClose={() => setDialogOpen(false)}
+        onSaved={loadJobs}
+      />
+    </div>
+  );
+}

--- a/frontend/tests/e2e/connections/connections.spec.ts
+++ b/frontend/tests/e2e/connections/connections.spec.ts
@@ -23,19 +23,20 @@ test.beforeEach(async ({ page }) => {
 // ==========================================================================
 
 test.describe("CRUD via UI", () => {
-  // DC-CONN-01: View all 6 connection cards
-  test("DC-CONN-01: view all 6 connection cards", async ({ page }) => {
+  // DC-CONN-01: View all 7 connection cards
+  test("DC-CONN-01: view all 7 connection cards", async ({ page }) => {
     await expect(page.locator("h1", { hasText: "Connections" })).toBeVisible();
 
     await expect(page.locator("h3", { hasText: "Telegram Bot" })).toBeVisible();
     await expect(page.locator("h3", { hasText: "Discord Bot" })).toBeVisible();
+    await expect(page.locator("h3", { hasText: "Reddit" })).toBeVisible();
     await expect(page.locator("h3", { hasText: "LinkedIn" })).toBeVisible();
     await expect(page.locator("h3", { hasText: "Twitter / X" })).toBeVisible();
     await expect(page.locator("h3", { hasText: "Instagram" })).toBeVisible();
     await expect(page.locator("h3", { hasText: "Facebook" })).toBeVisible();
 
     const count = await connections.connectionCards.count();
-    expect(count).toBe(6);
+    expect(count).toBe(7);
   });
 
   // DC-CONN-02: Expand Telegram connection form
@@ -168,7 +169,7 @@ test.describe("Positive Workflows", () => {
   test("DC-CONN-09: external docs links are present", async ({ page }) => {
     const docsLinks = page.locator("a[title='Setup guide']");
     const count = await docsLinks.count();
-    expect(count).toBe(6);
+    expect(count).toBe(7);
 
     const links = await docsLinks.all();
     for (const link of links) {

--- a/frontend/tests/e2e/fixtures/page-objects/connections.page.ts
+++ b/frontend/tests/e2e/fixtures/page-objects/connections.page.ts
@@ -3,9 +3,10 @@ import { type Page, type Locator, expect } from "@playwright/test";
 /**
  * Page object for the Desktop Connections route ("/connections").
  *
- * The page contains 6 connection cards:
+ * The page contains 7 connection cards:
  * - Telegram Bot (token-paste flow)
  * - Discord Bot (token-paste flow)
+ * - Reddit (token-paste flow — 6 fields)
  * - Twitter / X (token-paste flow — 4 fields)
  * - LinkedIn (OAuth flow)
  * - Instagram (OAuth flow)

--- a/frontend/tests/e2e/navigation/navigation.spec.ts
+++ b/frontend/tests/e2e/navigation/navigation.spec.ts
@@ -14,18 +14,18 @@ test.beforeEach(async ({ page }) => {
   await nav.goto();
 });
 
-// DC-NAV-01: Sidebar shows all 8 navigation items
+// DC-NAV-01: Sidebar shows all navigation items
 test("DC-NAV-01: sidebar shows all navigation items", async () => {
   await expect(nav.sidebar).toBeVisible();
 
   const labels = await nav.getNavLabels();
-  const expectedItems = ["Chat", "Model Hub", "Personas", "Agents", "Crews", "Blueprints", "Workspace", "Connections", "Approvals", "Settings"];
+  const expectedItems = ["Chat", "Model Hub", "Personas", "Agents", "Crews", "Blueprints", "Workspace", "Connections", "Approvals", "Schedule", "Distribution", "Settings"];
 
   for (const item of expectedItems) {
     expect(labels).toContain(item);
   }
 
-  expect(labels.length).toBe(10);
+  expect(labels.length).toBe(12);
 });
 
 // DC-NAV-02: Navigate to each page and verify heading
@@ -40,6 +40,8 @@ test("DC-NAV-02: navigate to each page and verify heading", async ({ page }) => 
     { label: "Workspace", heading: "Workspace" },
     { label: "Connections", heading: "Connections" },
     { label: "Approvals", heading: "Approval Queue" },
+    { label: "Schedule", heading: "Scheduled Jobs" },
+    { label: "Distribution", heading: "Distribution" },
     { label: "Settings", heading: "Settings" },
   ];
 
@@ -101,12 +103,12 @@ test("DC-NAV-04: sidebar collapse/expand toggle works", async ({ page }) => {
   expect(expandedBox!.width).toBeGreaterThan(100);
 
   const expandedLabels = await nav.getNavLabels();
-  expect(expandedLabels.length).toBe(10);
+  expect(expandedLabels.length).toBe(12);
 });
 
 // DC-NAV-05: Page transitions are smooth (no flash)
 test("DC-NAV-05: page transitions are smooth", async ({ page }) => {
-  const routes = ["Personas", "Agents", "Crews", "Blueprints", "Workspace", "Connections", "Approvals", "Settings", "Chat"];
+  const routes = ["Personas", "Agents", "Crews", "Blueprints", "Workspace", "Connections", "Approvals", "Schedule", "Distribution", "Settings", "Chat"];
 
   for (const route of routes) {
     await nav.navigateTo(route);


### PR DESCRIPTION
## Summary

Bundles two features that landed on this branch since the last release:

**Reddit connection** (commit `73ce764`):
- praw-based inbound poller for subreddit comments + inbox DMs, trigger + approval pipeline integration
- REST CRUD + test + reply endpoints
- Connections UI card

**Phase 2 completion** (commit `ce0cf0f`):
- **P2-1 Twitter/X inbound polling** — 90s poll for mentions + DMs via API v2, OAuth 1.0a HMAC-SHA1 signing, dispatches through trigger/approval pipeline (new `ChannelType.TWITTER`)
- **P2-2 / P2-3 IG + FB OAuth fixes** — callback auto-populates `page_id`, `page_access_token`, and `instagram_user_id` via `/me/accounts` + `instagram_business_account` lookup; no more manual config in the distribution channel
- **P2-4 Distribution UI** at `/distribution` — channels tab with per-type config dialogs (LinkedIn, Twitter, IG, FB, Blog, Email, Slack), multi-channel publish dialog, delivery history
- **P2-5** — `thread-composer`, `dm-closer`, `community-manager` agents (social-engagement now 15/15)
- **P2-6** — 4 crew templates (`auto-reply`, `sales-dm`, `content-distribution`, `crisis-response`) seeded into a separate `crew_templates` collection

**New — cron scheduler** (was backlog BL-3):
- APScheduler-backed, SQLite jobstore survives app restarts
- `job_type=post` → `DistributionService.publish` (LinkedIn / Twitter / IG / FB / Slack / Blog / Email)
- `job_type=crew` → `CrewService.start_run` (same entry point as manual `POST /crews/{id}/run`)
- `/schedule` route with cron presets (daily 9am, weekdays, hourly, Monday), timezone select, live next-runs preview
- Endpoints: CRUD + `/run-now` + `/toggle` + `/validate-cron`

**Impact:** 45 files changed, +5,327 / -81. 9 new scheduler tests pass; full backend suite green (723 tests). `npm run build` clean.

## Test plan

- [ ] Install the local installer and smoke-test on this branch
- [ ] Connections → Twitter card: paste credentials → `/test` succeeds → mention in a test account fires the trigger/approval flow
- [ ] Connections → Instagram OAuth: reconnect → verify `instagram_user_id` populated in the distribution channel row
- [ ] Connections → Facebook OAuth: reconnect → verify `page_id` + `page_access_token` populated
- [ ] `/distribution` → create a LinkedIn channel manually → publish test content → row appears in Delivery History
- [ ] `/schedule` → new job, type `post`, cron `*/5 * * * *`, pick LinkedIn channel → wait 5 min → publish lands + `last_run_status=success`
- [ ] `/schedule` → new job, type `crew`, pick an auto-reply crew → Run Now → crew runs collection shows execution
- [ ] Crew builder lists the 4 seeded templates (or confirm `crew_templates` collection count via `POST /api/v1/desktop/reseed`)
- [ ] `/schedule` survives app restart — existing jobs rehydrate from `~/.contextuai-solo/data/scheduler.db`
- [ ] 3 new social-engagement agents show up in Agents library

## Out of scope / follow-ups

- Playwright `connections.spec.ts` update from 6→7 cards left uncommitted — belongs with a follow-up test cleanup
- IG/FB OAuth picks the first page automatically; multi-page picker is future work
- Scheduled posts to Telegram/Discord/Reddit not yet covered (would need a `channel_send` job_type or channel_service wrapper)
- P2.5-2 Knowledge Base (RAG) is the remaining major pre-launch item

🤖 Generated with [Claude Code](https://claude.com/claude-code)