### PR TITLE
docs: sync counts and model list with code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-ContextuAI Solo is a single-user desktop AI assistant with 93 pre-built business agents (105 in repo, engineering category excluded from desktop). It's a Tauri v2 desktop app with a React 19 frontend and a FastAPI Python backend running as a sidecar process. Data is stored locally in SQLite. Supports both cloud AI providers (Anthropic, AWS Bedrock) and local GGUF models via llama-cpp-python.
+ContextuAI Solo is a single-user desktop AI assistant with 96 pre-built business agents (108 in repo, engineering category excluded from desktop). It's a Tauri v2 desktop app with a React 19 frontend and a FastAPI Python backend running as a sidecar process. Data is stored locally in SQLite. Supports both cloud AI providers (Anthropic, AWS Bedrock) and local GGUF models via llama-cpp-python.
 
 ## Commands
 
@@ -71,19 +71,19 @@ The backend was ported from MongoDB. A compatibility layer preserves the Motor A
 
 ### Local AI Models (`backend/routers/local_models.py`)
 GGUF models downloaded from HuggingFace, stored in `~/.contextuai-solo/models/`. Inference via llama-cpp-python on CPU.
-- Available models: Gemma 3 1B, Qwen 2.5 1.5B, Phi-3 Mini
+- 41 curated GGUF models (Gemma 4, Qwen 3/3.5, DeepSeek R1, Llama 3, Mistral, Phi-4, etc.) from 0.5B to 70B
 - Download: `POST /api/v1/local-models/{model_id}/download` (SSE progress)
 - Sync to DB: `POST /api/v1/local-models/sync` (registers downloaded models in the `models` collection)
 - Models appear in chat dropdown after sync
 
 ### Agent Library (`agent-library/`)
-105 business agents as markdown files across 13 categories (c-suite, marketing-sales, finance-operations, etc.). Engineering category (12 agents) is excluded from desktop mode, so users see 93 across 12 categories. Each markdown file contains a system prompt, recommended model, and tool configs. Auto-seeded into `workspace_agents` collection on first startup. Re-seed via `POST /api/v1/desktop/reseed`.
+108 business agents as markdown files across 13 categories (c-suite, marketing-sales, finance-operations, etc.). Engineering category (12 agents) is excluded from desktop mode, so users see 96 across 12 categories. Each markdown file contains a system prompt, recommended model, and tool configs. Auto-seeded into `workspace_agents` collection on first startup. Re-seed via `POST /api/v1/desktop/reseed`.
 
 ### Crew System
 Multi-agent teams with persistent memory. Crew builder (`components/crews/crew-builder.tsx`) is a 5-step wizard:
 1. **Details** — name, description, blueprint, AI model selection
 2. **Execution Mode** — sequential, parallel, pipeline, autonomous
-3. **Agent Team** — add agents from 81-agent library or manually (skipped for autonomous)
+3. **Agent Team** — add agents from the 96-agent library or manually (skipped for autonomous)
 4. **Connections** — bind crew to social channels (Telegram, Discord, LinkedIn, Twitter/X, Instagram, Facebook)
 5. **Review** — configuration summary before create
 

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ contextuai-solo/
 │   ├── routers/        # API route handlers
 │   ├── services/       # Business logic and AI orchestration
 │   └── requirements.txt
-├── agent-library/      # Built-in agent templates (105 agents across 13 categories; engineering excluded from desktop → 93 visible)
+├── agent-library/      # Built-in agent templates (108 agents across 13 categories; engineering excluded from desktop → 96 visible)
 ├── docs/user-guide/    # Per-module user guides
 ├── run.sh              # One-command backend launcher (Linux/macOS)
 ├── run-tests.ps1       # One-click test runner (backend + frontend)
@@ -286,7 +286,7 @@ contextuai-solo/
 | **Backend** | [FastAPI](https://fastapi.tiangolo.com/) (Python 3.11+) |
 | **Database** | [SQLite](https://sqlite.org/) via async adapter |
 | **AI Providers** | Anthropic Claude, OpenAI GPT, Google Gemini, AWS Bedrock |
-| **Local AI** | 37 GGUF models via llama-cpp-python (Qwen 3.5, Qwen 3, DeepSeek R1, Gemma 3, Llama 3, Mistral, Phi-4) — 0.5B to 70B |
+| **Local AI** | 41 GGUF models via llama-cpp-python (Gemma 4, Qwen 3.5, Qwen 3, DeepSeek R1, Llama 3, Mistral, Phi-4) — 0.5B to 70B |
 | **Agent Framework** | [Strands Agents SDK](https://github.com/strands-agents/sdk-python) |
 
 </details>

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 # TODO — ContextuAI Solo Moonshot
 
 > Master task list. Prioritized by phases. Check off as completed.
-> **Created:** 2026-03-19 | **Last synced with code:** 2026-04-15
+> **Created:** 2026-03-19 | **Last synced with code:** 2026-04-20
 
 ---
 

--- a/docs/user-guide/04-agents.md
+++ b/docs/user-guide/04-agents.md
@@ -1,6 +1,6 @@
 # Agents
 
-The Agent Library contains 93 pre-built business agents organized by department. Each agent is a specialized AI role with a detailed system prompt, recommended tools, and domain expertise. You can also create your own custom agents.
+The Agent Library contains 96 pre-built business agents organized by department. Each agent is a specialized AI role with a detailed system prompt, recommended tools, and domain expertise. You can also create your own custom agents.
 
 ![Agent Library](../screenshots/006-AgentLibrary.png)
 
@@ -95,7 +95,7 @@ When you select a role, a suggested system prompt template appears. Click **"Use
 
 ## Tips
 
-- **Don't create agents from scratch** unless you need something unique — the 93 pre-built agents cover most business functions.
+- **Don't create agents from scratch** unless you need something unique — the 96 pre-built agents cover most business functions.
 - **Combine agents in Crews** for multi-step tasks. For example, pair a "Market Researcher" with a "Content Strategist" and a "Copywriter" for end-to-end content creation.
 - **Customize system prompts** in the detail panel to fine-tune an existing agent's behavior for your specific business context.
 - **Use the search** when you know roughly what you need — typing "pricing" will find the Pricing Strategist even if you don't know the exact name.

--- a/docs/user-guide/05-crews.md
+++ b/docs/user-guide/05-crews.md
@@ -59,7 +59,7 @@ Choose how your agents collaborate:
 Build your agent team:
 
 - Click **Add Agent** to add a blank agent with name, role, and instructions.
-- Click **Browse Library** to pick from the 93 pre-built agents.
+- Click **Browse Library** to pick from the 96 pre-built agents.
 - Reorder agents to control the execution sequence (for Sequential mode).
 - Each agent needs a **name** and **instructions** at minimum.
 

--- a/docs/user-guide/07-workspace.md
+++ b/docs/user-guide/07-workspace.md
@@ -33,7 +33,7 @@ Click any project card to view its results.
 
 ### Step 2: Agent Selection
 
-- Browse the list of available agents from the 81-agent library
+- Browse the list of available agents from the 96-agent library
 - **Search** to filter agents by name
 - **Check** agents to add them to your project
 - A **count badge** shows how many agents you've selected

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -1,6 +1,6 @@
 # ContextuAI Solo — User Guide
 
-Welcome to ContextuAI Solo, your private desktop AI assistant with 93 pre-built business agents. This guide covers every module in the app to help you get started quickly.
+Welcome to ContextuAI Solo, your private desktop AI assistant with 96 pre-built business agents. This guide covers every module in the app to help you get started quickly.
 
 ## Modules
 
@@ -9,11 +9,11 @@ Welcome to ContextuAI Solo, your private desktop AI assistant with 93 pre-built 
 | 1 | [Chat](01-chat.md) | Have conversations with AI models, manage sessions, pick personas |
 | 2 | [Model Hub](02-model-hub.md) | Configure cloud AI providers and download local models |
 | 3 | [Personas](03-personas.md) | Create specialized AI personalities with custom instructions |
-| 4 | [Agents](04-agents.md) | Browse 93 business agents and create your own |
+| 4 | [Agents](04-agents.md) | Browse 96 business agents and create your own |
 | 5 | [Crews](05-crews.md) | Build multi-agent teams that work together on tasks |
 | 6 | [Blueprints](06-blueprints.md) | Use workflow templates to jumpstart projects |
 | 7 | [Workspace](07-workspace.md) | Run multi-agent projects and review results |
-| 8 | [Connections](08-connections.md) | Connect to Telegram, Discord, LinkedIn, Twitter/X, Instagram, Facebook |
+| 8 | [Connections](08-connections.md) | Connect to Telegram, Discord, Reddit, LinkedIn, Twitter/X, Instagram, Facebook |
 | 9 | [Settings](09-settings.md) | API keys, brand voice, appearance, data export |
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- Agent counts were stuck at 93/105 — now 96/108 (engineering category excluded from desktop).
- Local-model catalog list was 37 with outdated families — now 41, Gemma 4 added.
- User-guide Connections row was missing Reddit; added.
- `TODO.md` last-synced footer bumped to 2026-04-20.

## Test plan
- [ ] Skim rendered README.md and user-guide/*.md for any lingering stale numbers.
- [ ] Confirm CLAUDE.md model line matches `backend/services/model_catalog.py` (41 entries, Gemma 4 family).

🤖 Generated with [Claude Code](https://claude.com/claude-code)