### PR TITLE
feat: Phase 3 PR 1 of 4 — data model for unified connections + crews

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -470,6 +470,15 @@ async def startup_event():
         # Seed model configs for any already-downloaded local GGUF models
         await _seed_local_models(proxy)
 
+        # Phase 3 PR 1: backfill crew.connection_bindings / triggers / approval_required
+        try:
+            from services.migrations.unify_connections_migration import (
+                run_unify_connections_migration,
+            )
+            await run_unify_connections_migration(proxy)
+        except Exception:
+            logger.exception("unify_connections migration failed; continuing startup")
+
         # Start Reddit poller (runs only when a Reddit account is configured)
         from services.reddit_poller import get_poller
 

--- a/backend/models/crew_models.py
+++ b/backend/models/crew_models.py
@@ -6,8 +6,8 @@ and maintain shared memory across runs.
 """
 
 from enum import Enum
-from typing import Optional, List, Dict, Any
-from pydantic import BaseModel, Field, model_validator
+from typing import Optional, List, Dict, Any, Literal, Union, Annotated
+from pydantic import BaseModel, Field, model_validator, Discriminator
 
 
 # =============================================================================
@@ -116,6 +116,50 @@ class DistributionChannel(BaseModel):
     enabled: bool = True
 
 
+class ConnectionBinding(BaseModel):
+    """Binds a crew to a connection (platform auth) with a direction.
+
+    Direction controls whether the crew listens on inbound messages from this
+    connection, publishes outbound via it, or both.
+    """
+    connection_id: str = Field(..., description="ID of the underlying connection record (oauth_tokens.id, reddit_accounts.id, etc.)")
+    platform: str = Field(..., description="telegram | discord | reddit | linkedin | twitter | instagram | facebook | blog | email | slack_webhook")
+    direction: Literal["inbound", "outbound", "both"] = "both"
+
+
+class ReactiveTrigger(BaseModel):
+    """Fires when an inbound message on `connection_id` matches any keyword/hashtag/mention."""
+    type: Literal["reactive"] = "reactive"
+    connection_id: str
+    keywords: List[str] = Field(default_factory=list)
+    hashtags: List[str] = Field(default_factory=list)
+    mentions: List[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def require_at_least_one_match(self):
+        if not (self.keywords or self.hashtags or self.mentions):
+            raise ValueError("Reactive trigger requires at least one of keywords, hashtags, or mentions")
+        return self
+
+
+class ScheduledTrigger(BaseModel):
+    """Fires on a cron schedule (repeating) or at `run_at` (one-shot)."""
+    type: Literal["scheduled"] = "scheduled"
+    connection_ids: List[str] = Field(default_factory=list)
+    cron: Optional[str] = None
+    run_at: Optional[str] = Field(None, description="ISO-8601 datetime for one-shot scheduling")
+    content_brief: Optional[str] = None
+
+    @model_validator(mode="after")
+    def require_exactly_one_schedule(self):
+        if bool(self.cron) == bool(self.run_at):
+            raise ValueError("Scheduled trigger requires exactly one of `cron` or `run_at`")
+        return self
+
+
+CrewTrigger = Annotated[Union[ReactiveTrigger, ScheduledTrigger], Discriminator("type")]
+
+
 # =============================================================================
 # Request Models
 # =============================================================================
@@ -129,6 +173,9 @@ class CreateCrewRequest(BaseModel):
     schedule: Optional[CrewSchedule] = None
     channel_bindings: List[ChannelBinding] = Field(default_factory=list)
     distribution_channels: List[DistributionChannel] = Field(default_factory=list)
+    connection_bindings: List[ConnectionBinding] = Field(default_factory=list)
+    triggers: List[CrewTrigger] = Field(default_factory=list)
+    approval_required: bool = False
     memory_enabled: bool = True
     tags: List[str] = Field(default_factory=list)
 
@@ -177,6 +224,9 @@ class UpdateCrewRequest(BaseModel):
     schedule: Optional[CrewSchedule] = None
     channel_bindings: Optional[List[ChannelBinding]] = None
     distribution_channels: Optional[List[DistributionChannel]] = None
+    connection_bindings: Optional[List[ConnectionBinding]] = None
+    triggers: Optional[List[CrewTrigger]] = None
+    approval_required: Optional[bool] = None
     memory_enabled: Optional[bool] = None
     tags: Optional[List[str]] = None
     status: Optional[CrewStatus] = None
@@ -206,6 +256,9 @@ class CrewResponse(BaseModel):
     schedule: Optional[CrewSchedule] = None
     channel_bindings: List[ChannelBinding] = Field(default_factory=list)
     distribution_channels: List[DistributionChannel] = Field(default_factory=list)
+    connection_bindings: List[ConnectionBinding] = Field(default_factory=list)
+    triggers: List[CrewTrigger] = Field(default_factory=list)
+    approval_required: bool = False
     memory_enabled: bool = True
     tags: List[str] = Field(default_factory=list)
     total_runs: int = 0
@@ -281,6 +334,11 @@ class CrewRunResponse(BaseModel):
     completed_at: Optional[str] = None
     created_at: Optional[str] = None
     duration_ms: Optional[int] = None
+    trigger_type: Literal["reactive", "scheduled", "manual"] = "manual"
+    trigger_source: Optional[str] = Field(
+        None,
+        description="connection_id (reactive), cron expression or run_at (scheduled), or 'manual' (button)"
+    )
 
     class Config:
         from_attributes = True
@@ -298,6 +356,8 @@ class CrewRunListItem(BaseModel):
     completed_at: Optional[str] = None
     duration_ms: Optional[int] = None
     created_at: Optional[str] = None
+    trigger_type: Literal["reactive", "scheduled", "manual"] = "manual"
+    trigger_source: Optional[str] = None
 
 
 class CrewRunListResponse(BaseModel):

--- a/backend/models/reddit_models.py
+++ b/backend/models/reddit_models.py
@@ -24,6 +24,9 @@ class RedditAccount(BaseModel):
     enabled: bool = Field(default=True)
     last_seen_ids: dict = Field(default_factory=dict)
 
+    inbound_enabled: bool = Field(default=True)
+    outbound_enabled: bool = Field(default=True)
+
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
 
@@ -44,6 +47,8 @@ class RedditAccountUpdate(BaseModel):
     keywords: Optional[List[str]] = None
     poll_inbox: Optional[bool] = None
     enabled: Optional[bool] = None
+    inbound_enabled: Optional[bool] = None
+    outbound_enabled: Optional[bool] = None
 
 
 class RedditPostReply(BaseModel):

--- a/backend/models/twitter_models.py
+++ b/backend/models/twitter_models.py
@@ -37,6 +37,9 @@ class TwitterAccount(BaseModel):
     enabled: bool = Field(default=True)
     last_seen_ids: dict = Field(default_factory=dict)
 
+    inbound_enabled: bool = Field(default=True)
+    outbound_enabled: bool = Field(default=True)
+
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
 
@@ -58,6 +61,8 @@ class TwitterAccountUpdate(BaseModel):
     poll_mentions: Optional[bool] = None
     poll_dms: Optional[bool] = None
     enabled: Optional[bool] = None
+    inbound_enabled: Optional[bool] = None
+    outbound_enabled: Optional[bool] = None
 
 
 class TwitterPostReply(BaseModel):

--- a/backend/services/crew_service.py
+++ b/backend/services/crew_service.py
@@ -189,13 +189,19 @@ class CrewService:
     # ------------------------------------------------------------------
 
     async def start_run(
-        self, crew_id: str, user_id: str, request: RunCrewRequest
+        self,
+        crew_id: str,
+        user_id: str,
+        request: RunCrewRequest,
+        trigger_type: str = "manual",
+        trigger_source: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Initiate a new crew execution run.
 
-        Creates the run record with agent states. Actual execution
-        will be handled by the CrewOrchestrator (Task #23) via Celery.
+        `trigger_type` records why this run fired: "manual" (Run button),
+        "reactive" (inbound message matched a trigger), or "scheduled" (cron/run_at).
+        `trigger_source` is the connection_id, cron expression, or "manual".
         """
         crew = await self.get_crew(crew_id, user_id)
         if not crew:
@@ -244,6 +250,8 @@ class CrewService:
             "input": request.input,
             "input_data": request.input_data if request.input_data else None,
             "agents": agent_states,
+            "trigger_type": trigger_type,
+            "trigger_source": trigger_source if trigger_source is not None else ("manual" if trigger_type == "manual" else None),
         }
 
         run = await self.run_repo.create_run(crew_id, user_id, run_data)

--- a/backend/services/migrations/unify_connections_migration.py
+++ b/backend/services/migrations/unify_connections_migration.py
@@ -1,0 +1,145 @@
+"""
+Phase 3 PR 1 migration: backfill connection_bindings, triggers, approval_required.
+
+Idempotent. Inline at startup. Tracks completion in the `migrations_applied`
+collection. Set MIGRATE_DRY_RUN=1 to log the diff without writing.
+
+What it does
+------------
+1. For every crew with non-empty legacy `channel_bindings` and empty
+   `connection_bindings`, convert each binding to the new schema with
+   `direction="both"` (preserves current behavior — bound channels were
+   implicitly bidirectional).
+2. If any legacy binding had `approval_required=true`, set the new
+   top-level `crew.approval_required=true`.
+3. Defaults `triggers=[]`, `connection_bindings=[]`, `approval_required=false`
+   on any crew missing the fields entirely.
+4. Records orphan `distribution_channels` (no matching crew) for follow-up.
+
+The migration does NOT delete `channel_bindings` — they stay alongside the new
+fields until PR 4 retires the legacy code path.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+MIGRATION_NAME = "unify_connections_v1"
+MARKER_COLLECTION = "migrations_applied"
+
+
+def _is_dry_run() -> bool:
+    return os.environ.get("MIGRATE_DRY_RUN", "").strip() in ("1", "true", "True")
+
+
+def _connection_id_for(channel_type: str) -> str:
+    """For legacy bindings, the channel_type is the de-facto connection identifier
+    (single-user app: one Telegram, one Discord, etc.). PR 2's connection_service
+    normalises this to real record IDs."""
+    return channel_type
+
+
+async def run_unify_connections_migration(db) -> Dict[str, Any]:
+    """Run the migration. Returns a stats dict (always — even on dry run / no-op)."""
+    dry_run = _is_dry_run()
+    stats: Dict[str, Any] = {
+        "name": MIGRATION_NAME,
+        "dry_run": dry_run,
+        "skipped": False,
+        "crews_processed": 0,
+        "bindings_converted": 0,
+        "crews_marked_approval_required": 0,
+        "crews_initialised_empty": 0,
+        "distribution_channels_orphaned": 0,
+    }
+
+    marker_collection = db[MARKER_COLLECTION]
+    existing = await marker_collection.find_one({"name": MIGRATION_NAME})
+    if existing:
+        stats["skipped"] = True
+        logger.info("Migration %s already applied at %s — skipping",
+                    MIGRATION_NAME, existing.get("applied_at"))
+        return stats
+
+    crews_collection = db["crews"]
+    cursor = crews_collection.find({})
+    diff_log = []
+
+    async for crew in cursor:
+        stats["crews_processed"] += 1
+        crew_id = crew.get("crew_id") or str(crew.get("_id"))
+        legacy_bindings = crew.get("channel_bindings") or []
+        new_bindings = crew.get("connection_bindings") or []
+        crew_changes: Dict[str, Any] = {}
+
+        if legacy_bindings and not new_bindings:
+            converted = []
+            any_approval = False
+            for binding in legacy_bindings:
+                channel_type = binding.get("channel_type")
+                if not channel_type:
+                    continue
+                converted.append({
+                    "connection_id": _connection_id_for(channel_type),
+                    "platform": channel_type,
+                    "direction": "both",
+                })
+                if binding.get("approval_required"):
+                    any_approval = True
+
+            if converted:
+                crew_changes["connection_bindings"] = converted
+                stats["bindings_converted"] += len(converted)
+
+            if any_approval and not crew.get("approval_required"):
+                crew_changes["approval_required"] = True
+                stats["crews_marked_approval_required"] += 1
+
+        if "connection_bindings" not in crew:
+            crew_changes.setdefault("connection_bindings", new_bindings)
+            stats["crews_initialised_empty"] += 1
+        if "triggers" not in crew:
+            crew_changes.setdefault("triggers", crew.get("triggers") or [])
+        if "approval_required" not in crew:
+            crew_changes.setdefault("approval_required", bool(crew.get("approval_required")))
+
+        if crew_changes:
+            diff_log.append({"crew_id": crew_id, "changes": crew_changes})
+            if not dry_run:
+                await crews_collection.update_one(
+                    {"_id": crew["_id"]},
+                    {"$set": crew_changes},
+                )
+
+    # Orphan check: distribution_channels with no crew tied to them.
+    # In v1 we just count and log — PR 2 wires real ownership.
+    try:
+        dc_collection = db["distribution_channels"]
+        dc_count = await dc_collection.count_documents({})
+        stats["distribution_channels_orphaned"] = dc_count
+    except Exception:
+        # Collection may not exist yet on a fresh install
+        pass
+
+    if dry_run:
+        logger.info(
+            "[DRY RUN] %s would touch %d crew(s); diff:\n%s",
+            MIGRATION_NAME,
+            len(diff_log),
+            json.dumps(diff_log, indent=2, default=str)[:4000],
+        )
+        return stats
+
+    await marker_collection.insert_one({
+        "name": MIGRATION_NAME,
+        "applied_at": datetime.utcnow().isoformat(),
+        "stats": {k: v for k, v in stats.items() if k != "name"},
+    })
+    logger.info("Migration %s applied: %s", MIGRATION_NAME, stats)
+    return stats

--- a/backend/tests/test_crew_connection_bindings.py
+++ b/backend/tests/test_crew_connection_bindings.py
@@ -1,0 +1,175 @@
+"""Schema tests for Phase 3 PR 1 — ConnectionBinding, triggers, CrewRun trigger fields."""
+
+import pytest
+from pydantic import ValidationError
+
+from models.crew_models import (
+    ConnectionBinding,
+    CreateCrewRequest,
+    CrewAgentConfig,
+    CrewRunListItem,
+    CrewRunResponse,
+    ReactiveTrigger,
+    ScheduledTrigger,
+)
+
+
+# ---------------------------------------------------------------------------
+# ConnectionBinding
+# ---------------------------------------------------------------------------
+def test_connection_binding_defaults_direction_to_both():
+    cb = ConnectionBinding(connection_id="telegram", platform="telegram")
+    assert cb.direction == "both"
+
+
+def test_connection_binding_rejects_invalid_direction():
+    with pytest.raises(ValidationError):
+        ConnectionBinding(
+            connection_id="telegram",
+            platform="telegram",
+            direction="sideways",
+        )
+
+
+# ---------------------------------------------------------------------------
+# ReactiveTrigger
+# ---------------------------------------------------------------------------
+def test_reactive_trigger_requires_at_least_one_match_rule():
+    with pytest.raises(ValidationError):
+        ReactiveTrigger(connection_id="reddit")
+
+
+def test_reactive_trigger_accepts_keywords_only():
+    t = ReactiveTrigger(connection_id="reddit", keywords=["demo"])
+    assert t.type == "reactive"
+    assert t.keywords == ["demo"]
+
+
+def test_reactive_trigger_accepts_hashtags_or_mentions():
+    t = ReactiveTrigger(connection_id="twitter", hashtags=["#launch"])
+    assert t.hashtags == ["#launch"]
+    t2 = ReactiveTrigger(connection_id="twitter", mentions=["@me"])
+    assert t2.mentions == ["@me"]
+
+
+# ---------------------------------------------------------------------------
+# ScheduledTrigger
+# ---------------------------------------------------------------------------
+def test_scheduled_trigger_requires_exactly_one_of_cron_or_run_at():
+    # Neither
+    with pytest.raises(ValidationError):
+        ScheduledTrigger(connection_ids=["linkedin"])
+    # Both
+    with pytest.raises(ValidationError):
+        ScheduledTrigger(
+            connection_ids=["linkedin"],
+            cron="0 9 * * *",
+            run_at="2026-05-01T09:00:00Z",
+        )
+
+
+def test_scheduled_trigger_accepts_cron():
+    t = ScheduledTrigger(connection_ids=["linkedin"], cron="0 9 * * *")
+    assert t.cron == "0 9 * * *"
+    assert t.run_at is None
+
+
+def test_scheduled_trigger_accepts_run_at():
+    t = ScheduledTrigger(connection_ids=["linkedin"], run_at="2026-05-01T09:00:00Z")
+    assert t.run_at == "2026-05-01T09:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# CreateCrewRequest — new additive fields
+# ---------------------------------------------------------------------------
+def _min_agent():
+    return CrewAgentConfig(name="Writer", instructions="Write a post")
+
+
+def test_create_crew_defaults_connection_bindings_and_triggers_to_empty():
+    req = CreateCrewRequest(name="C1", agents=[_min_agent()])
+    assert req.connection_bindings == []
+    assert req.triggers == []
+    assert req.approval_required is False
+
+
+def test_create_crew_accepts_reactive_and_scheduled_triggers():
+    req = CreateCrewRequest(
+        name="Multi",
+        agents=[_min_agent()],
+        connection_bindings=[
+            ConnectionBinding(
+                connection_id="reddit",
+                platform="reddit",
+                direction="both",
+            )
+        ],
+        triggers=[
+            ReactiveTrigger(connection_id="reddit", keywords=["pricing"]),
+            ScheduledTrigger(connection_ids=["linkedin"], cron="0 9 * * MON"),
+        ],
+        approval_required=True,
+    )
+    assert len(req.triggers) == 2
+    assert req.triggers[0].type == "reactive"
+    assert req.triggers[1].type == "scheduled"
+    assert req.approval_required is True
+
+
+def test_create_crew_round_trips_through_dict():
+    req = CreateCrewRequest(
+        name="RT",
+        agents=[_min_agent()],
+        connection_bindings=[
+            ConnectionBinding(connection_id="discord", platform="discord")
+        ],
+    )
+    roundtrip = CreateCrewRequest(**req.model_dump())
+    assert roundtrip.connection_bindings[0].connection_id == "discord"
+
+
+# ---------------------------------------------------------------------------
+# CrewRun trigger metadata
+# ---------------------------------------------------------------------------
+def test_crew_run_response_defaults_to_manual():
+    run = CrewRunResponse(
+        run_id="r1",
+        crew_id="c1",
+        user_id="u1",
+    )
+    assert run.trigger_type == "manual"
+    assert run.trigger_source is None
+
+
+def test_crew_run_response_accepts_reactive_metadata():
+    run = CrewRunResponse(
+        run_id="r2",
+        crew_id="c1",
+        user_id="u1",
+        trigger_type="reactive",
+        trigger_source="reddit",
+    )
+    assert run.trigger_type == "reactive"
+    assert run.trigger_source == "reddit"
+
+
+def test_crew_run_list_item_accepts_scheduled_metadata():
+    item = CrewRunListItem(
+        run_id="r3",
+        crew_id="c1",
+        status="completed",
+        trigger_type="scheduled",
+        trigger_source="0 9 * * *",
+    )
+    assert item.trigger_type == "scheduled"
+    assert item.trigger_source == "0 9 * * *"
+
+
+def test_crew_run_response_rejects_invalid_trigger_type():
+    with pytest.raises(ValidationError):
+        CrewRunResponse(
+            run_id="r4",
+            crew_id="c1",
+            user_id="u1",
+            trigger_type="webhook",  # not in the allowed literal
+        )

--- a/backend/tests/test_unify_migration.py
+++ b/backend/tests/test_unify_migration.py
@@ -1,0 +1,140 @@
+"""Tests for Phase 3 PR 1 unify_connections migration."""
+
+import os
+
+import pytest
+import pytest_asyncio
+
+from services.migrations.unify_connections_migration import (
+    MARKER_COLLECTION,
+    MIGRATION_NAME,
+    run_unify_connections_migration,
+)
+
+
+@pytest_asyncio.fixture
+async def seeded_db(db_proxy):
+    """Seed the test DB with a few legacy crews and a distribution channel."""
+    crews = db_proxy["crews"]
+
+    # Crew 1: legacy channel_bindings, one with approval_required
+    await crews.insert_one({
+        "crew_id": "crew-1",
+        "user_id": "u1",
+        "name": "Legacy Telegram",
+        "status": "active",
+        "channel_bindings": [
+            {"channel_type": "telegram", "enabled": True, "approval_required": True},
+            {"channel_type": "discord", "enabled": True, "approval_required": False},
+        ],
+    })
+
+    # Crew 2: no bindings at all, missing new fields entirely
+    await crews.insert_one({
+        "crew_id": "crew-2",
+        "user_id": "u1",
+        "name": "Bare",
+        "status": "active",
+    })
+
+    # Crew 3: already migrated (has connection_bindings) — must not double-convert
+    await crews.insert_one({
+        "crew_id": "crew-3",
+        "user_id": "u1",
+        "name": "Already Migrated",
+        "status": "active",
+        "channel_bindings": [
+            {"channel_type": "reddit", "enabled": True, "approval_required": False},
+        ],
+        "connection_bindings": [
+            {"connection_id": "reddit-custom", "platform": "reddit", "direction": "inbound"},
+        ],
+    })
+
+    await db_proxy["distribution_channels"].insert_one({
+        "channel_type": "linkedin",
+        "config": {},
+        "enabled": True,
+    })
+
+    return db_proxy
+
+
+@pytest.mark.asyncio
+async def test_migration_converts_legacy_bindings(seeded_db):
+    stats = await run_unify_connections_migration(seeded_db)
+
+    assert stats["skipped"] is False
+    assert stats["crews_processed"] == 3
+    # Crew 1: 2 bindings. Crew 3: already has connection_bindings (skipped).
+    assert stats["bindings_converted"] == 2
+    assert stats["crews_marked_approval_required"] == 1
+    assert stats["distribution_channels_orphaned"] == 1
+
+    crew1 = await seeded_db["crews"].find_one({"crew_id": "crew-1"})
+    assert len(crew1["connection_bindings"]) == 2
+    platforms = {b["platform"] for b in crew1["connection_bindings"]}
+    assert platforms == {"telegram", "discord"}
+    for b in crew1["connection_bindings"]:
+        assert b["direction"] == "both"
+    assert crew1["approval_required"] is True
+
+    crew2 = await seeded_db["crews"].find_one({"crew_id": "crew-2"})
+    assert crew2["connection_bindings"] == []
+    assert crew2["triggers"] == []
+    assert crew2["approval_required"] is False
+
+    # Crew 3 must keep its pre-existing connection_bindings untouched.
+    crew3 = await seeded_db["crews"].find_one({"crew_id": "crew-3"})
+    assert len(crew3["connection_bindings"]) == 1
+    assert crew3["connection_bindings"][0]["connection_id"] == "reddit-custom"
+
+
+@pytest.mark.asyncio
+async def test_migration_is_idempotent(seeded_db):
+    first = await run_unify_connections_migration(seeded_db)
+    assert first["skipped"] is False
+
+    # Tamper with a crew to prove second run doesn't re-touch it.
+    await seeded_db["crews"].update_one(
+        {"crew_id": "crew-1"},
+        {"$set": {"connection_bindings": [{"connection_id": "x", "platform": "telegram", "direction": "outbound"}]}},
+    )
+
+    second = await run_unify_connections_migration(seeded_db)
+    assert second["skipped"] is True
+
+    crew1 = await seeded_db["crews"].find_one({"crew_id": "crew-1"})
+    # Still the tampered value — migration did not run again
+    assert crew1["connection_bindings"][0]["connection_id"] == "x"
+
+
+@pytest.mark.asyncio
+async def test_dry_run_does_not_write(seeded_db, monkeypatch):
+    monkeypatch.setenv("MIGRATE_DRY_RUN", "1")
+    stats = await run_unify_connections_migration(seeded_db)
+
+    assert stats["dry_run"] is True
+    assert stats["bindings_converted"] == 2  # still reports what it *would* do
+
+    # Marker NOT written
+    marker = await seeded_db[MARKER_COLLECTION].find_one({"name": MIGRATION_NAME})
+    assert marker is None
+
+    # Crew 1 NOT mutated
+    crew1 = await seeded_db["crews"].find_one({"crew_id": "crew-1"})
+    assert "connection_bindings" not in crew1 or crew1.get("connection_bindings") == []
+
+
+@pytest.mark.asyncio
+async def test_migration_survives_missing_distribution_collection(db_proxy):
+    # No seeding → no distribution_channels rows
+    await db_proxy["crews"].insert_one({
+        "crew_id": "solo",
+        "user_id": "u1",
+        "name": "Solo",
+        "status": "active",
+    })
+    stats = await run_unify_connections_migration(db_proxy)
+    assert stats["skipped"] is False
+    assert stats["crews_processed"] == 1

--- a/frontend/src/lib/api/crews-client.ts
+++ b/frontend/src/lib/api/crews-client.ts
@@ -71,6 +71,8 @@ export interface CrewRun {
   input_data?: Record<string, unknown>;
   output_data?: Record<string, unknown>;
   error?: string;
+  trigger_type?: "reactive" | "scheduled" | "manual";
+  trigger_source?: string;
 }
 
 export interface CrewRunStep {


### PR DESCRIPTION
## Summary

First of four PRs implementing **Phase 3: Unify Connections + Crews** (see `TODO.md` → PHASE 3). This PR is backend-only and fully additive — existing flows continue to work unchanged.

- **Crew model** gains `connection_bindings[]`, `triggers[]` (reactive/scheduled discriminated union), and `approval_required`. Legacy `channel_bindings[]` stays in place; PR 4 retires it.
- **CrewRunResponse** / **CrewRunListItem** gain `trigger_type` + `trigger_source` so the Runs tab (PR 3) can show *why* each run fired.
- **RedditAccount** and **TwitterAccount** gain `inbound_enabled` / `outbound_enabled` capability flags.
- **`crew_service.start_run()`** accepts `trigger_type` + `trigger_source` (default: `"manual"`).
- **New inline startup migration** (`services/migrations/unify_connections_migration.py`) backfills `connection_bindings` from legacy `channel_bindings` with `direction="both"`, promotes per-binding `approval_required` to the new top-level flag, and records completion in the `migrations_applied` collection. Idempotent; honours `MIGRATE_DRY_RUN=1`.

## Why this PR is intentionally boring

This is the additive data-model layer. No UI changes, no new routes, no auth changes. All existing crews continue to serialize/deserialize unchanged; the migration runs once and is a no-op on subsequent boots. This unblocks PR 2 (Connections aggregator + grid rewrite) without shipping visible behavior.

## Follow-up PRs in this phase

| PR | Scope |
|---|---|
| **PR 1 (this)** | Data model + migration (additive) |
| PR 2 | Unified `/api/v1/connections` aggregator + rewritten Connections page (capability toggles; Blog/Email/Slack new types) |
| PR 3 | Crew builder trigger step + direction chips + approval toggle + `inbound_router.py` + `scheduled_runner.py`; Runs tab shows trigger_type badge (behind `UNIFIED_CREWS` flag) |
| PR 4 | Swap `/distribution` and `/schedule` routes to Coming Soon; flip flag on by default |

## Test plan

- [x] `pytest backend/tests/test_crew_connection_bindings.py` — 15 tests: discriminated-union validation, round-trip serialization, invalid literals rejected
- [x] `pytest backend/tests/test_unify_migration.py` — 4 tests: conversion correctness, idempotency, dry-run no-writes, orphan collection safety
- [x] Full backend suite: `pytest backend/tests/` → **742 passed**
- [x] `cd frontend && npm run build` → clean (tsc + vite OK)
- [ ] Manual: boot desktop app, confirm existing crews load and Run button still works (regression)
- [ ] Spot-check `migrations_applied` row appears in `~/.contextuai-solo/data/contextuai.db` after first boot post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)