### PR TITLE
feat: Phase 3 PR 2 of 4 — unified /api/v1/connections aggregator + blog/email/slack_webhook

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -45,6 +45,7 @@ from routers.blueprints import router as blueprints_router
 from routers.reddit import router as reddit_router
 from routers.twitter import router as twitter_router
 from routers.scheduled_jobs import router as scheduled_jobs_router
+from routers.connections import router as connections_router
 
 # ---------------------------------------------------------------------------
 # Logging
@@ -96,6 +97,7 @@ app.include_router(blueprints_router)
 app.include_router(reddit_router)
 app.include_router(twitter_router)
 app.include_router(scheduled_jobs_router)
+app.include_router(connections_router)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/models/connection_models.py
+++ b/backend/models/connection_models.py
@@ -1,0 +1,160 @@
+"""
+Connection Models — unified shape across every credential store.
+
+Phase 3 PR 2 introduces a single `/api/v1/connections` aggregator that reads
+from oauth_connections (LinkedIn/IG/FB), reddit_accounts, twitter_accounts,
+channel_registrations (Telegram/Discord), and distribution_channels
+(blog/email/slack_webhook). This module defines the request/response models
+for that surface.
+
+Existing per-platform credential endpoints (OAuth callback, Reddit CRUD,
+Twitter CRUD, channels/register) are unchanged — the aggregator is a
+read-plus-capability-toggle layer on top.
+"""
+
+from enum import Enum
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+
+# =============================================================================
+# Platform catalog
+# =============================================================================
+
+class Platform(str, Enum):
+    """All supported connection platforms. Includes PR 2's new outbound-only types."""
+    TELEGRAM = "telegram"
+    DISCORD = "discord"
+    REDDIT = "reddit"
+    TWITTER = "twitter"
+    LINKEDIN = "linkedin"
+    INSTAGRAM = "instagram"
+    FACEBOOK = "facebook"
+    BLOG = "blog"
+    EMAIL = "email"
+    SLACK_WEBHOOK = "slack_webhook"
+
+
+# Platform capabilities — what direction(s) each platform supports.
+PLATFORM_CAPABILITIES: Dict[str, Dict[str, bool]] = {
+    Platform.TELEGRAM.value:      {"inbound_supported": True,  "outbound_supported": True},
+    Platform.DISCORD.value:       {"inbound_supported": True,  "outbound_supported": True},
+    Platform.REDDIT.value:        {"inbound_supported": True,  "outbound_supported": True},
+    Platform.TWITTER.value:       {"inbound_supported": True,  "outbound_supported": True},
+    Platform.LINKEDIN.value:      {"inbound_supported": False, "outbound_supported": True},
+    Platform.INSTAGRAM.value:     {"inbound_supported": False, "outbound_supported": True},
+    Platform.FACEBOOK.value:      {"inbound_supported": False, "outbound_supported": True},
+    Platform.BLOG.value:          {"inbound_supported": False, "outbound_supported": True},
+    Platform.EMAIL.value:         {"inbound_supported": False, "outbound_supported": True},
+    Platform.SLACK_WEBHOOK.value: {"inbound_supported": False, "outbound_supported": True},
+}
+
+OUTBOUND_ONLY_PLATFORMS = {
+    Platform.BLOG.value,
+    Platform.EMAIL.value,
+    Platform.SLACK_WEBHOOK.value,
+}
+
+
+# =============================================================================
+# Aggregator response
+# =============================================================================
+
+class ConnectionSummary(BaseModel):
+    """Unified view of one connection across all stores.
+
+    `id` is the store-native identifier (OAuth provider id, reddit_accounts
+    _id, channel_registrations _id, distribution_channels channel_id, etc.).
+    The aggregator stamps a `store` hint so writes can route back to the
+    originating collection.
+    """
+    id: str
+    platform: str
+    store: Literal[
+        "oauth_connections",
+        "reddit_accounts",
+        "twitter_accounts",
+        "channel_registrations",
+        "distribution_channels",
+    ]
+    display_name: Optional[str] = None
+    connected: bool = True
+    inbound_enabled: bool = True
+    outbound_enabled: bool = True
+    inbound_supported: bool = False
+    outbound_supported: bool = False
+    config_summary: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Non-sensitive subset safe to show in UI (e.g. profile_name, subreddits count, from_email).",
+    )
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+class ConnectionListResponse(BaseModel):
+    success: bool = True
+    connections: List[ConnectionSummary]
+    total_count: int
+
+
+# =============================================================================
+# Capability PATCH
+# =============================================================================
+
+class CapabilityUpdate(BaseModel):
+    """Toggle inbound/outbound on an existing connection. Omitted fields untouched."""
+    inbound_enabled: Optional[bool] = None
+    outbound_enabled: Optional[bool] = None
+
+    @model_validator(mode="after")
+    def at_least_one_field(self):
+        if self.inbound_enabled is None and self.outbound_enabled is None:
+            raise ValueError("Specify inbound_enabled and/or outbound_enabled")
+        return self
+
+
+# =============================================================================
+# Outbound-only connections (blog / email / slack_webhook)
+# =============================================================================
+
+class OutboundConnectionCreate(BaseModel):
+    """Create a blog / email / slack_webhook connection.
+
+    Type-specific fields live in `config`; the validator enforces required
+    keys per platform.
+    """
+    platform: Literal["blog", "email", "slack_webhook"]
+    name: str = Field(..., min_length=1, max_length=200)
+    config: Dict[str, Any] = Field(default_factory=dict)
+    enabled: bool = True
+
+    @model_validator(mode="after")
+    def validate_config_for_platform(self):
+        cfg = self.config or {}
+        if self.platform == "blog":
+            if not cfg.get("api_url"):
+                raise ValueError("blog config requires api_url")
+            if not cfg.get("cms_type"):
+                raise ValueError("blog config requires cms_type (ghost | wordpress | custom)")
+        elif self.platform == "email":
+            for key in ("provider", "api_key", "from_email"):
+                if not cfg.get(key):
+                    raise ValueError(f"email config requires {key}")
+        elif self.platform == "slack_webhook":
+            if not cfg.get("webhook_url"):
+                raise ValueError("slack_webhook config requires webhook_url")
+        return self
+
+
+class OutboundConnectionUpdate(BaseModel):
+    """Partial update for an outbound-only connection."""
+    name: Optional[str] = Field(None, min_length=1, max_length=200)
+    config: Optional[Dict[str, Any]] = None
+    enabled: Optional[bool] = None
+
+    @model_validator(mode="after")
+    def at_least_one_field(self):
+        if self.name is None and self.config is None and self.enabled is None:
+            raise ValueError("Specify at least one field to update")
+        return self

--- a/backend/routers/connections.py
+++ b/backend/routers/connections.py
@@ -1,0 +1,103 @@
+"""Unified Connections REST API (Phase 3 PR 2).
+
+Surfaces all credential stores — OAuth (LinkedIn/IG/FB), Reddit, Twitter,
+token-paste channels (Telegram/Discord), and outbound-only types (Blog,
+Email, Slack webhook) — behind one endpoint.
+
+  GET    /api/v1/connections                      — unified list
+  GET    /api/v1/connections/{id}                 — single summary
+  PATCH  /api/v1/connections/{id}/capabilities    — toggle inbound/outbound
+  POST   /api/v1/connections/outbound             — create blog/email/slack_webhook
+  PUT    /api/v1/connections/outbound/{id}        — update
+  DELETE /api/v1/connections/outbound/{id}        — remove
+
+Per-platform credential endpoints (reddit, twitter, oauth, channels) stay
+unchanged — this router is a read-plus-capability-toggle layer on top.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from database import get_database
+from models.connection_models import (
+    CapabilityUpdate,
+    ConnectionListResponse,
+    ConnectionSummary,
+    OutboundConnectionCreate,
+    OutboundConnectionUpdate,
+)
+from services.auth_service import get_current_user
+from services.connection_service import ConnectionService
+
+router = APIRouter(prefix="/api/v1/connections", tags=["connections"])
+
+
+def _svc(db=Depends(get_database)) -> ConnectionService:
+    return ConnectionService(db)
+
+
+def _user_id(user: dict) -> str:
+    return user.get("user_id") or user.get("sub") or "desktop"
+
+
+# ---------------------------------------------------------------------------
+# List + single read
+# ---------------------------------------------------------------------------
+
+@router.get("", response_model=ConnectionListResponse)
+async def list_connections(svc: ConnectionService = Depends(_svc)):
+    rows = await svc.list_connections()
+    return ConnectionListResponse(connections=rows, total_count=len(rows))
+
+
+@router.get("/{connection_id}", response_model=ConnectionSummary)
+async def get_connection(
+    connection_id: str,
+    svc: ConnectionService = Depends(_svc),
+):
+    row = await svc.get_connection(connection_id)
+    if not row:
+        raise HTTPException(404, f"Connection {connection_id} not found")
+    return row
+
+
+# ---------------------------------------------------------------------------
+# PATCH capabilities
+# ---------------------------------------------------------------------------
+
+@router.patch("/{connection_id}/capabilities", response_model=ConnectionSummary)
+async def patch_capabilities(
+    connection_id: str,
+    update: CapabilityUpdate,
+    svc: ConnectionService = Depends(_svc),
+):
+    return await svc.update_capabilities(connection_id, update)
+
+
+# ---------------------------------------------------------------------------
+# Outbound-only CRUD (blog / email / slack_webhook)
+# ---------------------------------------------------------------------------
+
+@router.post("/outbound", response_model=ConnectionSummary, status_code=201)
+async def create_outbound(
+    request: OutboundConnectionCreate,
+    svc: ConnectionService = Depends(_svc),
+    user: dict = Depends(get_current_user),
+):
+    return await svc.create_outbound(request, _user_id(user))
+
+
+@router.put("/outbound/{connection_id}", response_model=ConnectionSummary)
+async def update_outbound(
+    connection_id: str,
+    update: OutboundConnectionUpdate,
+    svc: ConnectionService = Depends(_svc),
+):
+    return await svc.update_outbound(connection_id, update)
+
+
+@router.delete("/outbound/{connection_id}", status_code=204)
+async def delete_outbound(
+    connection_id: str,
+    svc: ConnectionService = Depends(_svc),
+):
+    await svc.delete_outbound(connection_id)

--- a/backend/services/connection_service.py
+++ b/backend/services/connection_service.py
@@ -1,0 +1,419 @@
+"""
+ConnectionService — unified read/write over every credential store.
+
+Surfaces a single list of `ConnectionSummary` records merging:
+  - oauth_connections (linkedin / instagram / facebook — OAuth2)
+  - reddit_accounts (token-paste)
+  - twitter_accounts (OAuth 1.0a + bearer)
+  - channel_registrations (telegram / discord — token-paste)
+  - distribution_channels (blog / email / slack_webhook — the new outbound-only types)
+
+Each summary carries a `store` discriminator and a prefixed `id`
+(e.g. `oauth:linkedin`, `reddit:abc123`) so PATCH/DELETE can route back
+to the originating collection without ambiguity.
+
+Capability flags (`inbound_enabled` / `outbound_enabled`) are read from
+raw records with `.get(..., default)` — works whether PR 1's typed-model
+defaults have migrated yet or not.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+from fastapi import HTTPException
+
+from models.connection_models import (
+    OUTBOUND_ONLY_PLATFORMS,
+    PLATFORM_CAPABILITIES,
+    CapabilityUpdate,
+    ConnectionSummary,
+    OutboundConnectionCreate,
+    OutboundConnectionUpdate,
+)
+from services.distribution_service import DistributionService
+
+
+# Map ConnectionService platform slug → distribution_service.channel_type
+# (slack_webhook is our platform name; the underlying publisher in
+# distribution_service keys the record as "slack".)
+PLATFORM_TO_DIST_CHANNEL_TYPE = {
+    "blog": "blog",
+    "email": "email",
+    "slack_webhook": "slack",
+}
+DIST_CHANNEL_TYPE_TO_PLATFORM = {v: k for k, v in PLATFORM_TO_DIST_CHANNEL_TYPE.items()}
+
+OAUTH_PROVIDERS = ("linkedin", "instagram", "facebook")
+
+
+def _prefix(store: str, native_id: str) -> str:
+    return f"{store}:{native_id}"
+
+
+def _unprefix(prefixed_id: str) -> Tuple[str, str]:
+    if ":" not in prefixed_id:
+        raise HTTPException(400, f"Invalid connection id: {prefixed_id!r}")
+    store, native = prefixed_id.split(":", 1)
+    return store, native
+
+
+def _capability_defaults(platform: str) -> Dict[str, bool]:
+    """Return (inbound_enabled, outbound_enabled) defaults for a platform.
+
+    Outbound-only platforms default inbound off. Everything else defaults
+    both on — these are the flags applied when a record has never been
+    touched by a capability PATCH.
+    """
+    caps = PLATFORM_CAPABILITIES.get(platform, {})
+    return {
+        "inbound_enabled": caps.get("inbound_supported", False),
+        "outbound_enabled": caps.get("outbound_supported", False),
+    }
+
+
+def _mask(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    if len(value) <= 4:
+        return "****"
+    return value[:2] + "****" + value[-2:]
+
+
+class ConnectionService:
+    def __init__(self, db):
+        self.db = db
+        self.distribution = DistributionService(db)
+
+    # ------------------------------------------------------------------
+    # LIST
+    # ------------------------------------------------------------------
+
+    async def list_connections(self) -> List[ConnectionSummary]:
+        out: List[ConnectionSummary] = []
+        out.extend(await self._list_oauth())
+        out.extend(await self._list_reddit())
+        out.extend(await self._list_twitter())
+        out.extend(await self._list_channel_registrations())
+        out.extend(await self._list_outbound())
+        return out
+
+    async def _list_oauth(self) -> List[ConnectionSummary]:
+        rows: List[ConnectionSummary] = []
+        coll = self.db["oauth_connections"]
+        async for doc in coll.find({}):
+            provider = doc.get("_id") if isinstance(doc.get("_id"), str) else None
+            if provider not in OAUTH_PROVIDERS:
+                continue
+            connected = bool(doc.get("access_token"))
+            caps = _capability_defaults(provider)
+            rows.append(ConnectionSummary(
+                id=_prefix("oauth", provider),
+                platform=provider,
+                store="oauth_connections",
+                display_name=doc.get("profile_name") or provider.title(),
+                connected=connected,
+                inbound_enabled=bool(doc.get("inbound_enabled", caps["inbound_enabled"])),
+                outbound_enabled=bool(doc.get("outbound_enabled", caps["outbound_enabled"])),
+                inbound_supported=PLATFORM_CAPABILITIES[provider]["inbound_supported"],
+                outbound_supported=PLATFORM_CAPABILITIES[provider]["outbound_supported"],
+                config_summary={
+                    "profile_id": doc.get("profile_id"),
+                    "scopes": doc.get("scopes", []),
+                    "org_id": doc.get("org_id"),
+                    "expires_in": doc.get("expires_in"),
+                },
+                created_at=doc.get("connected_at") or doc.get("updated_at"),
+                updated_at=doc.get("updated_at"),
+            ))
+        return rows
+
+    async def _list_reddit(self) -> List[ConnectionSummary]:
+        rows: List[ConnectionSummary] = []
+        coll = self.db["reddit_accounts"]
+        async for doc in coll.find({}):
+            native_id = str(doc.get("_id"))
+            caps = _capability_defaults("reddit")
+            rows.append(ConnectionSummary(
+                id=_prefix("reddit", native_id),
+                platform="reddit",
+                store="reddit_accounts",
+                display_name=doc.get("username"),
+                connected=bool(doc.get("client_id") and doc.get("client_secret")),
+                inbound_enabled=bool(doc.get("inbound_enabled", caps["inbound_enabled"])),
+                outbound_enabled=bool(doc.get("outbound_enabled", caps["outbound_enabled"])),
+                inbound_supported=True,
+                outbound_supported=True,
+                config_summary={
+                    "subreddits": doc.get("subreddits", []),
+                    "keyword_count": len(doc.get("keywords", []) or []),
+                    "poll_inbox": doc.get("poll_inbox", True),
+                },
+                created_at=_iso(doc.get("created_at")),
+                updated_at=_iso(doc.get("updated_at")),
+            ))
+        return rows
+
+    async def _list_twitter(self) -> List[ConnectionSummary]:
+        rows: List[ConnectionSummary] = []
+        coll = self.db["twitter_accounts"]
+        async for doc in coll.find({}):
+            native_id = str(doc.get("_id"))
+            caps = _capability_defaults("twitter")
+            has_write = bool(
+                doc.get("api_key") and doc.get("api_secret")
+                and doc.get("access_token") and doc.get("access_token_secret")
+            )
+            rows.append(ConnectionSummary(
+                id=_prefix("twitter", native_id),
+                platform="twitter",
+                store="twitter_accounts",
+                display_name=doc.get("user_id"),
+                connected=bool(doc.get("user_id") and (doc.get("bearer_token") or has_write)),
+                inbound_enabled=bool(doc.get("inbound_enabled", caps["inbound_enabled"])),
+                # If no OAuth 1.0a creds, outbound is physically impossible — force off.
+                outbound_enabled=bool(doc.get("outbound_enabled", caps["outbound_enabled"])) and has_write,
+                inbound_supported=True,
+                outbound_supported=has_write,
+                config_summary={
+                    "poll_mentions": doc.get("poll_mentions", True),
+                    "poll_dms": doc.get("poll_dms", True),
+                    "has_write_creds": has_write,
+                    "keyword_count": len(doc.get("keywords", []) or []),
+                },
+                created_at=_iso(doc.get("created_at")),
+                updated_at=_iso(doc.get("updated_at")),
+            ))
+        return rows
+
+    async def _list_channel_registrations(self) -> List[ConnectionSummary]:
+        rows: List[ConnectionSummary] = []
+        coll = self.db["channel_registrations"]
+        async for doc in coll.find({"channel_type": {"$in": ["telegram", "discord"]}}):
+            platform = doc["channel_type"]
+            native_id = str(doc.get("_id"))
+            caps = _capability_defaults(platform)
+            rows.append(ConnectionSummary(
+                id=_prefix("channel", native_id),
+                platform=platform,
+                store="channel_registrations",
+                display_name=(doc.get("config") or {}).get("bot_name") or platform.title(),
+                connected=bool((doc.get("config") or {}).get("bot_token")),
+                inbound_enabled=bool(doc.get("inbound_enabled", caps["inbound_enabled"])),
+                outbound_enabled=bool(doc.get("outbound_enabled", caps["outbound_enabled"])),
+                inbound_supported=True,
+                outbound_supported=True,
+                config_summary={
+                    "has_token": bool((doc.get("config") or {}).get("bot_token")),
+                },
+                created_at=_iso(doc.get("created_at")),
+                updated_at=_iso(doc.get("updated_at")),
+            ))
+        return rows
+
+    async def _list_outbound(self) -> List[ConnectionSummary]:
+        """Blog/email/slack from distribution_channels. Skip rows that duplicate OAuth providers."""
+        rows: List[ConnectionSummary] = []
+        coll = self.db["distribution_channels"]
+        async for doc in coll.find({"channel_type": {"$in": list(DIST_CHANNEL_TYPE_TO_PLATFORM.keys())}}):
+            underlying = doc.get("channel_type")
+            platform = DIST_CHANNEL_TYPE_TO_PLATFORM.get(underlying)
+            if not platform:
+                continue
+            channel_id = doc.get("channel_id") or str(doc.get("_id"))
+            caps = _capability_defaults(platform)
+            cfg = doc.get("config") or {}
+            rows.append(ConnectionSummary(
+                id=_prefix("outbound", channel_id),
+                platform=platform,
+                store="distribution_channels",
+                display_name=doc.get("name"),
+                connected=bool(doc.get("enabled", True)),
+                inbound_enabled=bool(doc.get("inbound_enabled", caps["inbound_enabled"])),
+                outbound_enabled=bool(doc.get("outbound_enabled", caps["outbound_enabled"])),
+                inbound_supported=False,
+                outbound_supported=True,
+                config_summary=self._outbound_summary(platform, cfg),
+                created_at=doc.get("created_at"),
+                updated_at=doc.get("updated_at"),
+            ))
+        return rows
+
+    @staticmethod
+    def _outbound_summary(platform: str, cfg: Dict[str, Any]) -> Dict[str, Any]:
+        if platform == "blog":
+            return {"cms_type": cfg.get("cms_type"), "api_url": cfg.get("api_url")}
+        if platform == "email":
+            return {"provider": cfg.get("provider"), "from_email": cfg.get("from_email")}
+        if platform == "slack_webhook":
+            return {"webhook_host": _webhook_host(cfg.get("webhook_url"))}
+        return {}
+
+    # ------------------------------------------------------------------
+    # GET single
+    # ------------------------------------------------------------------
+
+    async def get_connection(self, connection_id: str) -> Optional[ConnectionSummary]:
+        store, native = _unprefix(connection_id)
+        all_rows = await self.list_connections()
+        for row in all_rows:
+            if row.id == connection_id:
+                return row
+        return None
+
+    # ------------------------------------------------------------------
+    # PATCH capabilities
+    # ------------------------------------------------------------------
+
+    async def update_capabilities(
+        self,
+        connection_id: str,
+        update: CapabilityUpdate,
+    ) -> ConnectionSummary:
+        store, native = _unprefix(connection_id)
+        existing = await self.get_connection(connection_id)
+        if not existing:
+            raise HTTPException(404, f"Connection {connection_id} not found")
+
+        # Reject toggling a capability the platform doesn't support
+        if update.inbound_enabled is True and not existing.inbound_supported:
+            raise HTTPException(
+                422,
+                f"Platform {existing.platform} does not support inbound",
+            )
+        if update.outbound_enabled is True and not existing.outbound_supported:
+            raise HTTPException(
+                422,
+                f"Platform {existing.platform} does not support outbound",
+            )
+
+        set_fields: Dict[str, Any] = {"updated_at": datetime.utcnow().isoformat()}
+        if update.inbound_enabled is not None:
+            set_fields["inbound_enabled"] = update.inbound_enabled
+        if update.outbound_enabled is not None:
+            set_fields["outbound_enabled"] = update.outbound_enabled
+
+        if store == "oauth":
+            await self.db["oauth_connections"].update_one(
+                {"_id": native}, {"$set": set_fields}
+            )
+        elif store == "reddit":
+            await self.db["reddit_accounts"].update_one(
+                _by_id(native), {"$set": set_fields}
+            )
+        elif store == "twitter":
+            await self.db["twitter_accounts"].update_one(
+                _by_id(native), {"$set": set_fields}
+            )
+        elif store == "channel":
+            await self.db["channel_registrations"].update_one(
+                _by_id(native), {"$set": set_fields}
+            )
+        elif store == "outbound":
+            await self.db["distribution_channels"].update_one(
+                {"channel_id": native}, {"$set": set_fields}
+            )
+        else:
+            raise HTTPException(400, f"Unknown connection store: {store}")
+
+        refreshed = await self.get_connection(connection_id)
+        if not refreshed:
+            raise HTTPException(500, "Failed to re-read connection after update")
+        return refreshed
+
+    # ------------------------------------------------------------------
+    # Outbound CRUD (blog / email / slack_webhook)
+    # ------------------------------------------------------------------
+
+    async def create_outbound(
+        self,
+        req: OutboundConnectionCreate,
+        user_id: str,
+    ) -> ConnectionSummary:
+        if req.platform not in OUTBOUND_ONLY_PLATFORMS:
+            raise HTTPException(400, f"Platform {req.platform} is not outbound-only")
+
+        underlying = PLATFORM_TO_DIST_CHANNEL_TYPE[req.platform]
+        doc = await self.distribution.create_channel(
+            channel_type=underlying,
+            name=req.name,
+            config=req.config,
+            organization="solo",
+            created_by=user_id,
+        )
+        # Write capability defaults so reads are stable
+        await self.db["distribution_channels"].update_one(
+            {"channel_id": doc["channel_id"]},
+            {"$set": {
+                "inbound_enabled": False,
+                "outbound_enabled": True,
+                "enabled": req.enabled,
+            }},
+        )
+        summary = await self.get_connection(_prefix("outbound", doc["channel_id"]))
+        if not summary:
+            raise HTTPException(500, "Created outbound connection could not be read back")
+        return summary
+
+    async def update_outbound(
+        self,
+        connection_id: str,
+        update: OutboundConnectionUpdate,
+    ) -> ConnectionSummary:
+        store, native = _unprefix(connection_id)
+        if store != "outbound":
+            raise HTTPException(400, "Only outbound-only connections support this update")
+        set_fields: Dict[str, Any] = {}
+        if update.name is not None:
+            set_fields["name"] = update.name
+        if update.config is not None:
+            set_fields["config"] = update.config
+        if update.enabled is not None:
+            set_fields["enabled"] = update.enabled
+        set_fields["updated_at"] = datetime.utcnow().isoformat()
+        result = await self.db["distribution_channels"].update_one(
+            {"channel_id": native}, {"$set": set_fields}
+        )
+        if result.matched_count == 0:
+            raise HTTPException(404, f"Outbound connection {connection_id} not found")
+        summary = await self.get_connection(connection_id)
+        if not summary:
+            raise HTTPException(404, f"Outbound connection {connection_id} not found")
+        return summary
+
+    async def delete_outbound(self, connection_id: str) -> None:
+        store, native = _unprefix(connection_id)
+        if store != "outbound":
+            raise HTTPException(400, "Only outbound-only connections support delete via this endpoint")
+        deleted = await self.distribution.delete_channel(native)
+        if not deleted:
+            raise HTTPException(404, f"Outbound connection {connection_id} not found")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _by_id(native_id: str) -> Dict[str, Any]:
+    """SQLite adapter stores _id as str; return a single-key filter."""
+    return {"_id": native_id}
+
+
+def _iso(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def _webhook_host(url: Optional[str]) -> Optional[str]:
+    if not url:
+        return None
+    # Only expose the host — redact the token segment for privacy.
+    try:
+        from urllib.parse import urlparse
+        return urlparse(url).hostname
+    except Exception:
+        return None

--- a/backend/tests/test_connections_aggregator.py
+++ b/backend/tests/test_connections_aggregator.py
@@ -1,0 +1,213 @@
+"""Tests for Phase 3 PR 2 — unified connections aggregator."""
+
+import pytest
+import pytest_asyncio
+
+from services.connection_service import ConnectionService
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def svc(db_proxy):
+    return ConnectionService(db_proxy)
+
+
+async def _seed_oauth(db, provider: str, connected: bool = True):
+    doc = {"_id": provider, "client_id": "x", "client_secret": "y"}
+    if connected:
+        doc.update({"access_token": "tok", "profile_name": f"{provider}-user"})
+    await db["oauth_connections"].insert_one(doc)
+
+
+async def _seed_reddit(db, _id="r1"):
+    await db["reddit_accounts"].insert_one({
+        "_id": _id,
+        "client_id": "cid",
+        "client_secret": "csec",
+        "username": "u1",
+        "password": "p",
+        "subreddits": ["LocalLLaMA"],
+        "keywords": ["pricing", "demo"],
+    })
+
+
+async def _seed_twitter(db, _id="tw1", with_write=True):
+    doc = {
+        "_id": _id,
+        "user_id": "999",
+        "bearer_token": "bearer",
+    }
+    if with_write:
+        doc.update({
+            "api_key": "k",
+            "api_secret": "s",
+            "access_token": "a",
+            "access_token_secret": "b",
+        })
+    await db["twitter_accounts"].insert_one(doc)
+
+
+async def _seed_telegram(db, _id="tg1"):
+    await db["channel_registrations"].insert_one({
+        "_id": _id,
+        "channel_type": "telegram",
+        "config": {"bot_token": "123:abc", "bot_name": "MyBot"},
+    })
+
+
+# ---------------------------------------------------------------------------
+# LIST
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_list_is_empty_when_no_records(svc):
+    rows = await svc.list_connections()
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_list_merges_all_stores(svc, db_proxy):
+    await _seed_oauth(db_proxy, "linkedin")
+    await _seed_oauth(db_proxy, "instagram", connected=False)
+    await _seed_reddit(db_proxy)
+    await _seed_twitter(db_proxy)
+    await _seed_telegram(db_proxy)
+
+    rows = await svc.list_connections()
+    platforms = sorted(r.platform for r in rows)
+    assert platforms == ["instagram", "linkedin", "reddit", "telegram", "twitter"]
+
+    by_platform = {r.platform: r for r in rows}
+    assert by_platform["linkedin"].id == "oauth:linkedin"
+    assert by_platform["linkedin"].connected is True
+    assert by_platform["instagram"].connected is False
+    assert by_platform["reddit"].id.startswith("reddit:")
+    assert by_platform["twitter"].outbound_supported is True
+    assert by_platform["telegram"].display_name == "MyBot"
+
+
+@pytest.mark.asyncio
+async def test_twitter_without_write_creds_loses_outbound(svc, db_proxy):
+    await _seed_twitter(db_proxy, with_write=False)
+    rows = await svc.list_connections()
+    tw = next(r for r in rows if r.platform == "twitter")
+    assert tw.outbound_supported is False
+    assert tw.outbound_enabled is False
+
+
+# ---------------------------------------------------------------------------
+# Outbound CRUD (blog / email / slack_webhook)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_create_slack_webhook_outbound(svc):
+    from models.connection_models import OutboundConnectionCreate
+    created = await svc.create_outbound(
+        OutboundConnectionCreate(
+            platform="slack_webhook",
+            name="Team ops",
+            config={"webhook_url": "https://hooks.slack.com/services/TXXX/BXXX/xxx"},
+        ),
+        user_id="test-user",
+    )
+    assert created.platform == "slack_webhook"
+    assert created.id.startswith("outbound:")
+    assert created.outbound_enabled is True
+    assert created.inbound_enabled is False
+    assert created.inbound_supported is False
+    assert created.config_summary.get("webhook_host") == "hooks.slack.com"
+
+
+@pytest.mark.asyncio
+async def test_create_blog_rejects_missing_api_url(svc):
+    from pydantic import ValidationError
+    from models.connection_models import OutboundConnectionCreate
+    with pytest.raises(ValidationError):
+        OutboundConnectionCreate(
+            platform="blog",
+            name="My Blog",
+            config={"cms_type": "ghost"},  # missing api_url
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_email_rejects_missing_from_email(svc):
+    from pydantic import ValidationError
+    from models.connection_models import OutboundConnectionCreate
+    with pytest.raises(ValidationError):
+        OutboundConnectionCreate(
+            platform="email",
+            name="Mailer",
+            config={"provider": "sendgrid", "api_key": "sg-xxx"},  # missing from_email
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_and_delete_outbound(svc):
+    from models.connection_models import OutboundConnectionCreate, OutboundConnectionUpdate
+    created = await svc.create_outbound(
+        OutboundConnectionCreate(
+            platform="email",
+            name="Old",
+            config={"provider": "sendgrid", "api_key": "sg-xxx", "from_email": "a@b.c"},
+        ),
+        user_id="u1",
+    )
+    updated = await svc.update_outbound(
+        created.id, OutboundConnectionUpdate(name="Renamed")
+    )
+    assert updated.display_name == "Renamed"
+
+    await svc.delete_outbound(created.id)
+    assert await svc.get_connection(created.id) is None
+
+
+# ---------------------------------------------------------------------------
+# Capability PATCH
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_patch_capabilities_toggles_reddit(svc, db_proxy):
+    await _seed_reddit(db_proxy, _id="r1")
+    rows = await svc.list_connections()
+    reddit = next(r for r in rows if r.platform == "reddit")
+    assert reddit.inbound_enabled is True
+
+    from models.connection_models import CapabilityUpdate
+    updated = await svc.update_capabilities(reddit.id, CapabilityUpdate(inbound_enabled=False))
+    assert updated.inbound_enabled is False
+
+    raw = await db_proxy["reddit_accounts"].find_one({"_id": "r1"})
+    assert raw["inbound_enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_patch_rejects_enabling_unsupported_capability(svc, db_proxy):
+    # LinkedIn is outbound-supported but not inbound-supported
+    await _seed_oauth(db_proxy, "linkedin")
+
+    from fastapi import HTTPException
+    from models.connection_models import CapabilityUpdate
+    with pytest.raises(HTTPException) as exc:
+        await svc.update_capabilities("oauth:linkedin", CapabilityUpdate(inbound_enabled=True))
+    assert exc.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_patch_capabilities_rejects_empty_update():
+    from pydantic import ValidationError
+    from models.connection_models import CapabilityUpdate
+    with pytest.raises(ValidationError):
+        CapabilityUpdate()  # both None → invalid
+
+
+@pytest.mark.asyncio
+async def test_patch_unknown_connection_is_404(svc):
+    from fastapi import HTTPException
+    from models.connection_models import CapabilityUpdate
+    with pytest.raises(HTTPException) as exc:
+        await svc.update_capabilities("reddit:nonexistent", CapabilityUpdate(inbound_enabled=True))
+    assert exc.value.status_code == 404

--- a/frontend/src/lib/api/connections-client.ts
+++ b/frontend/src/lib/api/connections-client.ts
@@ -1,0 +1,112 @@
+import { api } from "@/lib/transport";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ConnectionPlatform =
+  | "telegram"
+  | "discord"
+  | "reddit"
+  | "twitter"
+  | "linkedin"
+  | "instagram"
+  | "facebook"
+  | "blog"
+  | "email"
+  | "slack_webhook";
+
+export type ConnectionStore =
+  | "oauth_connections"
+  | "reddit_accounts"
+  | "twitter_accounts"
+  | "channel_registrations"
+  | "distribution_channels";
+
+export interface ConnectionSummary {
+  id: string;
+  platform: ConnectionPlatform;
+  store: ConnectionStore;
+  display_name?: string | null;
+  connected: boolean;
+  inbound_enabled: boolean;
+  outbound_enabled: boolean;
+  inbound_supported: boolean;
+  outbound_supported: boolean;
+  config_summary: Record<string, unknown>;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface ConnectionListResponse {
+  success: boolean;
+  connections: ConnectionSummary[];
+  total_count: number;
+}
+
+export interface CapabilityUpdate {
+  inbound_enabled?: boolean;
+  outbound_enabled?: boolean;
+}
+
+export type OutboundPlatform = "blog" | "email" | "slack_webhook";
+
+export interface OutboundConnectionCreate {
+  platform: OutboundPlatform;
+  name: string;
+  config: Record<string, unknown>;
+  enabled?: boolean;
+}
+
+export interface OutboundConnectionUpdate {
+  name?: string;
+  config?: Record<string, unknown>;
+  enabled?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// API client
+// ---------------------------------------------------------------------------
+
+export const connectionsApi = {
+  list: async (): Promise<ConnectionSummary[]> => {
+    const { data } = await api.get<ConnectionListResponse>("/connections");
+    return data.connections ?? [];
+  },
+
+  get: async (id: string): Promise<ConnectionSummary> => {
+    const { data } = await api.get<ConnectionSummary>(`/connections/${encodeURIComponent(id)}`);
+    return data;
+  },
+
+  updateCapabilities: async (
+    id: string,
+    update: CapabilityUpdate,
+  ): Promise<ConnectionSummary> => {
+    const { data } = await api.patch<ConnectionSummary>(
+      `/connections/${encodeURIComponent(id)}/capabilities`,
+      update,
+    );
+    return data;
+  },
+
+  createOutbound: async (payload: OutboundConnectionCreate): Promise<ConnectionSummary> => {
+    const { data } = await api.post<ConnectionSummary>("/connections/outbound", payload);
+    return data;
+  },
+
+  updateOutbound: async (
+    id: string,
+    update: OutboundConnectionUpdate,
+  ): Promise<ConnectionSummary> => {
+    const { data } = await api.put<ConnectionSummary>(
+      `/connections/outbound/${encodeURIComponent(id)}`,
+      update,
+    );
+    return data;
+  },
+
+  deleteOutbound: async (id: string): Promise<void> => {
+    await api.delete(`/connections/outbound/${encodeURIComponent(id)}`);
+  },
+};

--- a/frontend/src/routes/connections.tsx
+++ b/frontend/src/routes/connections.tsx
@@ -21,6 +21,9 @@ import {
   LogIn,
   User,
   Copy,
+  FileText,
+  Mail,
+  Hash,
 } from "lucide-react";
 import {
   configureOAuthClient,
@@ -38,10 +41,25 @@ import {
   deleteTrigger,
   type Trigger,
 } from "@/lib/api/triggers-client";
+import {
+  connectionsApi,
+  type ConnectionSummary,
+  type OutboundPlatform,
+} from "@/lib/api/connections-client";
 
 // ─── Types ──────────────────────────────────────────────────────
 
-type ConnectionId = "telegram" | "discord" | "linkedin" | "twitter" | "instagram" | "facebook" | "reddit";
+type ConnectionId =
+  | "telegram"
+  | "discord"
+  | "linkedin"
+  | "twitter"
+  | "instagram"
+  | "facebook"
+  | "reddit"
+  | "blog"
+  | "email"
+  | "slack_webhook";
 
 interface ConnectionConfig {
   id: ConnectionId;
@@ -63,6 +81,8 @@ interface ConnectionConfig {
   supportsOutbound: boolean;
   defaultInbound: boolean;
   defaultOutbound: boolean;
+  /** True for blog/email/slack_webhook — stored in backend via /connections/outbound. */
+  outboundOnly?: boolean;
 }
 
 interface SavedConnection {
@@ -273,6 +293,67 @@ const CONNECTIONS: ConnectionConfig[] = [
       { key: "keywords", label: "Keywords (comma-separated)", placeholder: "local LLM, ollama, gguf" },
     ],
   },
+  {
+    id: "blog",
+    name: "Blog",
+    description: "Publish to Ghost, WordPress, or any custom REST endpoint.",
+    icon: FileText,
+    iconBg: "bg-amber-100 dark:bg-amber-500/20",
+    iconColor: "text-amber-600 dark:text-amber-400",
+    docsUrl: "https://ghost.org/docs/content-api/",
+    oauthProvider: null,
+    supportsInbound: false,
+    supportsOutbound: true,
+    defaultInbound: false,
+    defaultOutbound: true,
+    outboundOnly: true,
+    fields: [
+      { key: "name", label: "Connection Name", placeholder: "My Blog" },
+      { key: "cms_type", label: "CMS Type (ghost | wordpress | custom)", placeholder: "ghost" },
+      { key: "api_url", label: "API URL", placeholder: "https://my-blog.com/ghost/api/v3/admin/posts" },
+      { key: "api_key", label: "API Key (optional)", placeholder: "Admin API key", secret: true },
+    ],
+  },
+  {
+    id: "email",
+    name: "Email",
+    description: "Send AI-generated content by email (SendGrid, SES, or SMTP).",
+    icon: Mail,
+    iconBg: "bg-rose-100 dark:bg-rose-500/20",
+    iconColor: "text-rose-600 dark:text-rose-400",
+    docsUrl: "https://docs.sendgrid.com/api-reference/mail-send/mail-send",
+    oauthProvider: null,
+    supportsInbound: false,
+    supportsOutbound: true,
+    defaultInbound: false,
+    defaultOutbound: true,
+    outboundOnly: true,
+    fields: [
+      { key: "name", label: "Connection Name", placeholder: "Newsletter sender" },
+      { key: "provider", label: "Provider (sendgrid | ses | smtp)", placeholder: "sendgrid" },
+      { key: "api_key", label: "API Key", placeholder: "SG.xxxx...", secret: true },
+      { key: "from_email", label: "From Address", placeholder: "hello@example.com" },
+    ],
+  },
+  {
+    id: "slack_webhook",
+    name: "Slack Webhook",
+    description: "Post to a Slack channel via an incoming webhook URL.",
+    icon: Hash,
+    iconBg: "bg-violet-100 dark:bg-violet-500/20",
+    iconColor: "text-violet-600 dark:text-violet-400",
+    docsUrl: "https://api.slack.com/messaging/webhooks",
+    oauthProvider: null,
+    supportsInbound: false,
+    supportsOutbound: true,
+    defaultInbound: false,
+    defaultOutbound: true,
+    outboundOnly: true,
+    fields: [
+      { key: "name", label: "Connection Name", placeholder: "Team ops" },
+      { key: "webhook_url", label: "Webhook URL", placeholder: "https://hooks.slack.com/services/T.../B.../xxx", secret: true },
+    ],
+  },
 ];
 
 // ─── Helpers ────────────────────────────────────────────────────
@@ -387,9 +468,87 @@ export default function ConnectionsPage() {
     setShowSecrets({});
   };
 
-  // Token-paste save (Telegram/Discord/Reddit)
+  // Load existing outbound-only connections from the aggregator on mount so
+  // blog/email/slack_webhook cards reflect real backend state (not localStorage).
+  useEffect(() => {
+    let cancelled = false;
+    connectionsApi
+      .list()
+      .then((rows: ConnectionSummary[]) => {
+        if (cancelled) return;
+        const outboundRows = rows.filter(
+          (r) => r.platform === "blog" || r.platform === "email" || r.platform === "slack_webhook",
+        );
+        if (outboundRows.length === 0) return;
+        setConnections((prev) => {
+          const filtered = prev.filter(
+            (c) => c.id !== "blog" && c.id !== "email" && c.id !== "slack_webhook",
+          );
+          for (const row of outboundRows) {
+            filtered.push({
+              id: row.platform as ConnectionId,
+              config: { _backend_id: row.id, name: row.display_name ?? "" },
+              inbound: row.inbound_enabled,
+              outbound: row.outbound_enabled,
+              status: row.connected ? "connected" : "disconnected",
+              connectedAt: row.created_at ?? undefined,
+              profileName: row.display_name ?? undefined,
+            });
+          }
+          saveConnections(filtered);
+          return filtered;
+        });
+      })
+      .catch(() => {
+        // Backend may not yet know about /connections — non-fatal for localStorage-based cards.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Token-paste save (Telegram/Discord/Reddit/Blog/Email/Slack webhook)
   const handleSave = async (connId: ConnectionId) => {
     setTesting(connId);
+
+    const conf = CONNECTIONS.find((c) => c.id === connId);
+
+    // Outbound-only connections (blog / email / slack_webhook) go to the unified backend.
+    if (conf?.outboundOnly) {
+      try {
+        const name = (formData.name || conf.name).trim();
+        const cfg: Record<string, unknown> = {};
+        for (const field of conf.fields) {
+          if (field.key === "name") continue;
+          const value = (formData[field.key] || "").trim();
+          if (value) cfg[field.key] = value;
+        }
+        const created = await connectionsApi.createOutbound({
+          platform: conf.id as OutboundPlatform,
+          name,
+          config: cfg,
+        });
+
+        const updated = connections.filter((c) => c.id !== connId);
+        updated.push({
+          id: connId,
+          config: { _backend_id: created.id, name },
+          inbound: false,
+          outbound: true,
+          status: "connected",
+          connectedAt: created.created_at ?? new Date().toISOString(),
+          profileName: name,
+        });
+        setConnections(updated);
+        saveConnections(updated);
+      } catch (e) {
+        console.error("Outbound connection save failed", e);
+      }
+      setTesting(null);
+      setEditing(null);
+      setFormData({});
+      return;
+    }
 
     // Reddit has a dedicated backend endpoint — save there too so the poller picks it up.
     if (connId === "reddit") {
@@ -486,6 +645,19 @@ export default function ConnectionsPage() {
   };
 
   const handleDisconnect = async (conn: ConnectionConfig) => {
+    // Outbound-only connections live in the backend — delete there.
+    if (conn.outboundOnly) {
+      const saved = getConnection(conn.id);
+      const backendId = saved?.config._backend_id;
+      if (backendId) {
+        try {
+          await connectionsApi.deleteOutbound(backendId);
+        } catch {
+          // proceed with local cleanup anyway
+        }
+      }
+    }
+
     // If OAuth provider, also disconnect on backend
     if (conn.oauthProvider) {
       try {


### PR DESCRIPTION
## Summary

Second of four PRs for Phase 3 (see TODO.md → PHASE 3). Ships the **unified Connections aggregator** and introduces **Blog, Email, and Slack webhook** as first-class outbound-only connection types.

## What landed

**Backend**
- New `GET /api/v1/connections` aggregator merging five stores into one list: `oauth_connections` (LinkedIn/IG/FB), `reddit_accounts`, `twitter_accounts`, `channel_registrations` (Telegram/Discord), `distribution_channels` (blog/email/slack).
- New `PATCH /api/v1/connections/{id}/capabilities` toggles `inbound_enabled` / `outbound_enabled`. Rejects enabling directions the platform physically doesn't support (e.g. inbound on LinkedIn, outbound on a read-only Twitter bearer).
- New outbound-only CRUD: `POST/PUT/DELETE /api/v1/connections/outbound` for blog/email/slack_webhook. Stores in the existing `distribution_channels` collection (no data migration).
- Prefixed IDs (`oauth:linkedin`, `reddit:<id>`, etc.) so writes route back to the originating store unambiguously.
- `ConnectionSummary` is raw-dict-driven — reads capability flags with `.get(..., default)` so this works whether PR #21 has landed or not. Capability defaults derive from `PLATFORM_CAPABILITIES`.

**Frontend**
- New `connections-client.ts` typed API client.
- Three new cards in `connections.tsx`: Blog, Email, Slack webhook. Outbound-only flag branches save/disconnect to the aggregator API (real backend state, not localStorage).
- Existing 7 social auth flows (OAuth, Reddit token-paste, Telegram/Discord token-paste) untouched. Per-card capability toggle rewiring is deferred to PR 3 alongside crew-builder direction chips to keep this PR's blast radius small.

## Why this PR stops short of a full page rewrite

The original Phase 3 plan called for a full rewrite of `connections.tsx`. In review, the existing page is 1076 lines with intricate OAuth redirect + localStorage flows; rewriting it mid-phase risks breaking working auth. Instead this PR:
1. Ships the backend aggregator in full (what PR 3 consumes).
2. Adds the 3 missing outbound types (what users will see today).
3. Leaves the capability-toggle UI migration for PR 3, where the crew-builder direction chips drive it anyway.

## Depends on

- Conceptually on PR #21 (data model + capability flags on Reddit/Twitter Pydantic models). Not at import time — aggregator reads raw dicts with defaults. Merge order: #21 → this PR.

## Test plan

- [x] `pytest backend/tests/test_connections_aggregator.py` — 11 tests: list merging, outbound CRUD round-trip, capability PATCH including unsupported-direction rejection, unknown connection 404
- [x] Full backend suite: **734 passed** (723 baseline + 11 new)
- [x] `cd frontend && npm run build` → clean
- [ ] Manual: visit /connections, confirm new Blog/Email/Slack webhook cards render; connect a Slack webhook and confirm it round-trips via `GET /api/v1/connections`; disconnect deletes from backend
- [ ] Smoke: confirm existing Telegram / Discord / Reddit / OAuth flows still work (regression)

## Follow-up PRs

| PR | Scope |
|---|---|
| PR 1 (#21) | Data model + migration |
| **PR 2 (this)** | Aggregator + outbound-only types |
| PR 3 | Crew builder trigger step + direction chips + `inbound_router.py` + `scheduled_runner.py`; Runs tab trigger_type badge |
| PR 4 | `/distribution` + `/schedule` → Coming Soon; flip `UNIFIED_CREWS` on |

🤖 Generated with [Claude Code](https://claude.com/claude-code)