### PR TITLE
feat: Phase 3 PR 3a of 4 — inbound router + scheduled runner + trigger badges

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -295,7 +295,7 @@
 ### Confirmed decisions (do not revisit)
 1. **Manual trigger** = the existing "Run" button on each crew card (`frontend/src/routes/crews.tsx:481`). Not a new trigger-type selection in the builder. Always available on every crew.
 2. **Runs view** = the existing `Runs` tab on the Crews page (`frontend/src/routes/crews.tsx:130` — tab state `activeTab: "crews" | "runs"`). Extend the existing `CrewRun` type with trigger metadata; do not build a new component.
-3. **Distribution & Schedule stay in the sidebar** but route to a shared **"Coming Soon"** page. Sidebar remains at 12 items; nav E2E test (`frontend/tests/e2e/navigation/navigation.spec.ts`) does not need changing. Future phase removes them entirely.
+3. **Distribution & Schedule are removed from the sidebar.** Their functionality lives entirely inside Crews now (outbound publishing via `connection_bindings`, scheduling via `triggers[type=scheduled]`); a Coming Soon stop would be redundant. Sidebar drops from 12 → 10 items; nav E2E test (`frontend/tests/e2e/navigation/navigation.spec.ts`) updated accordingly.
 4. **Blog / Email / Slack webhook** ship as new Connection types (outbound-only) inside the same Connections grid as the social platforms.
 5. **Inbound keyword-match ties** → LLM disambiguates. No per-crew priority UI.
 6. **Connection-level fallback crew** for unmatched inbound → **not in v1**. Drop messages silently; reconsider if users complain.
@@ -375,11 +375,11 @@
   - **New Step 6 "Approval"**: single toggle "Review outbound before sending."
   - Existing Review step becomes Step 7 — update summary to reflect new fields.
 
-**New**
-- [ ] `frontend/src/routes/coming-soon.tsx` — simple placeholder component:
-  - Takes a `feature: string` prop.
-  - Shows icon + "<Feature> is moving into Crews — coming soon" + link to Crews page + link to docs/TODO.md entry.
-- [ ] Update `App.tsx` to route `/distribution` and `/schedule` to `ComingSoon` with the appropriate prop.
+**Removed (PR 4)**
+- [ ] Drop `/distribution` and `/schedule` route registrations from `App.tsx`.
+- [ ] Drop the Distribution + Schedule sidebar entries from `frontend/src/components/navigation/desktop-sidebar.tsx` (sidebar 12 → 10 items).
+- [ ] Update nav E2E test in `frontend/tests/e2e/navigation/navigation.spec.ts` to expect 10 items.
+- [ ] Page files `frontend/src/routes/distribution.tsx` and `frontend/src/routes/schedule.tsx` can stay on disk for one release cycle as dead code — the FUTURE cleanup task deletes them.
 
 **Modified**
 - [ ] `frontend/src/routes/crews.tsx` — **Crews tab**: add new filter chips alongside existing `statusFilter` and `modeFilter`: `Inbound`, `Outbound`, `Scheduled`, `Reactive`, `Approval-required`. Filter logic hooks into `filteredCrews` (line 179). **Runs tab**: render `trigger_type` badge on each row of `RunsList` (line 498).
@@ -387,8 +387,7 @@
 - [ ] `frontend/src/lib/api/distribution-client.ts` — can stay but is no longer consumed by the active UI. Delete in the future-cleanup phase.
 
 **Not changed**
-- Sidebar (`frontend/src/components/navigation/desktop-sidebar.tsx`) — still 12 items.
-- Nav E2E tests — still expect 12.
+- Sidebar entries other than Distribution + Schedule — order, icons, labels untouched.
 
 ### Migration
 
@@ -420,12 +419,11 @@ Must be idempotent, dry-run capable (`MIGRATE_DRY_RUN=1` env var), and must writ
 | 1 | Data model additions (connection_bindings, triggers, approval_required, capability flags) + migration script (dry-run capable) + extended CrewRun schema. Backend only; no UI change; existing flows keep working. | — (additive) |
 | 2 | Unified `/api/v1/connections` aggregator + rewritten Connections page (capability toggles, Blog/Email/Slack new types). Old Distribution page still lives. | — |
 | 3 | Crew builder: Trigger step + Direction chips + Approval toggle + "enable capability at connection level" modal. Backend: `inbound_router.py` + `scheduled_runner.py`. Runs tab displays trigger_type badge. | `UNIFIED_CREWS` env flag |
-| 4 | Swap `/distribution` and `/schedule` routes to ComingSoon. Add TODO entries referencing this plan. Flip `UNIFIED_CREWS` on by default. | Flag default → true |
+| 4 | Remove `/distribution` + `/schedule` from sidebar and route registry; nav E2E test 12 → 10. Flip `UNIFIED_CREWS` on by default. | Flag default → true |
 
 ### Follow-up TODOs (track after Phase 3 ships)
 
-- [ ] FUTURE: Re-retire Distribution page (delete `frontend/src/routes/distribution.tsx`, `backend/routers/distribution.py`, `backend/services/distribution_service.py` entirely) once Coming Soon has been live one release cycle.
-- [ ] FUTURE: Re-retire Schedule page (delete `frontend/src/routes/schedule.tsx` + standalone scheduler backend).
+- [ ] FUTURE: Delete dead code one release cycle after PR 4 — `frontend/src/routes/distribution.tsx`, `frontend/src/routes/schedule.tsx`, `backend/routers/distribution.py`, the standalone scheduler backend. `backend/services/distribution_service.py` stays — its outbound adapters (LinkedIn/Twitter/IG/FB/Blog/Email/Slack publishers) are reused by `agent_runner.py`.
 - [ ] FUTURE: Connection-level fallback crew for unmatched inbound messages (skipped in v1 per user decision).
 - [ ] FUTURE: Global Activity/Runs view across all crews (skipped in v1 — per-crew Runs tab covers the need).
 - [ ] FUTURE: Per-crew priority ordering for keyword-match ties (skipped — LLM disambiguation handles v1).

--- a/backend/app.py
+++ b/backend/app.py
@@ -488,6 +488,18 @@ async def startup_event():
         await scheduler_service.load_all()
         app.state.scheduler_service = scheduler_service
 
+        # Phase 3 PR 3: scheduled_runner registers crew.triggers[type=scheduled]
+        # Only active when UNIFIED_CREWS=on so legacy flows keep running by default.
+        try:
+            from services.feature_flags import unified_crews_enabled
+            if unified_crews_enabled():
+                from services.scheduled_runner import ScheduledRunner
+                runner = ScheduledRunner(proxy, scheduler)
+                await runner.load_all()
+                app.state.scheduled_runner = runner
+        except Exception:
+            logger.exception("ScheduledRunner failed to load — continuing startup")
+
         logger.info("ContextuAI Solo backend ready")
 
     except Exception:

--- a/backend/services/channels/channel_service.py
+++ b/backend/services/channels/channel_service.py
@@ -572,6 +572,27 @@ class ChannelService:
             },
         )
 
+        # --- Phase 3 PR 3: unified inbound router (gated on UNIFIED_CREWS) ---
+        try:
+            from services.feature_flags import unified_crews_enabled
+            if unified_crews_enabled():
+                from services.inbound_router import route_inbound
+                routed = await route_inbound(self.db, msg)
+                if routed is not None:
+                    return {
+                        "session_id": session["session_id"],
+                        "channel_type": msg.channel_type.value,
+                        "sender": msg.sender_name,
+                        "text": msg.text,
+                        "message_id": msg.message_id,
+                        "status": routed.get("status", "dispatched"),
+                        "response": routed.get("response", ""),
+                        "run_id": routed.get("run_id"),
+                        "crew_id": routed.get("crew_id"),
+                    }
+        except Exception as e:
+            logger.warning("Inbound router failed, falling through to legacy triggers: %s", e)
+
         # --- Check for a trigger (crew dispatch) ---
         try:
             from services.trigger_service import TriggerService

--- a/backend/services/crew_orchestrator.py
+++ b/backend/services/crew_orchestrator.py
@@ -826,14 +826,24 @@ class CrewOrchestrator:
         self, crew: Dict[str, Any], content: str, run_id: str
     ) -> List[Dict[str, Any]]:
         """
-        Publish crew output to all enabled channel_bindings.
+        Publish crew output.
 
-        For each binding, finds a matching distribution channel (by channel_type)
-        and publishes the raw agent output. If approval_required, routes to the
-        approval queue instead.
+        When UNIFIED_CREWS is on AND the crew has `connection_bindings[]`,
+        publishes to every binding whose direction is "outbound" or "both",
+        and honours the crew-level `approval_required` flag.
 
-        Returns a list of publish result dicts for tracking.
+        Otherwise falls back to the legacy `channel_bindings[]` path.
         """
+        try:
+            from services.feature_flags import unified_crews_enabled
+            unified = unified_crews_enabled()
+        except Exception:
+            unified = False
+
+        connection_bindings = crew.get("connection_bindings") or []
+        if unified and connection_bindings:
+            return await self._publish_via_connection_bindings(crew, content, run_id)
+
         bindings = crew.get("channel_bindings", [])
         if not bindings:
             return []
@@ -938,5 +948,110 @@ class CrewOrchestrator:
                     "error": str(e),
                 })
                 logger.warning(f"Failed to publish to {channel_type}: {e}")
+
+        return publish_results
+
+    async def _publish_via_connection_bindings(
+        self, crew: Dict[str, Any], content: str, run_id: str
+    ) -> List[Dict[str, Any]]:
+        """Phase 3 outbound: publish via crew.connection_bindings (direction-aware).
+
+        Iterates `connection_bindings[]` filtering for direction in
+        ("outbound", "both"). Each binding's `platform` is mapped onto a
+        distribution channel by channel_type (the same id namespace today's
+        DistributionService uses). `crew.approval_required` (top-level on
+        the crew) routes the output to the approval queue instead of
+        publishing directly.
+        """
+        from database import get_database
+        from services.distribution_service import DistributionService
+
+        db = await get_database()
+        dist_svc = DistributionService(db)
+        publish_results: List[Dict[str, Any]] = []
+        approval_required = bool(crew.get("approval_required"))
+
+        # `slack_webhook` is stored as `slack` in distribution_channels.
+        platform_to_channel_type = {
+            "slack_webhook": "slack",
+        }
+
+        for binding in (crew.get("connection_bindings") or []):
+            direction = (binding or {}).get("direction") or "both"
+            if direction not in ("outbound", "both"):
+                continue
+            platform = binding.get("platform")
+            if not platform:
+                continue
+            channel_type = platform_to_channel_type.get(platform, platform)
+
+            channel_doc = await db["distribution_channels"].find_one({
+                "channel_type": channel_type,
+                "enabled": True,
+            })
+            if not channel_doc:
+                logger.info(
+                    "No distribution channel for platform '%s' — skipping outbound for crew '%s'",
+                    platform, crew.get("name"),
+                )
+                continue
+
+            channel_id = channel_doc.get("channel_id")
+
+            if approval_required:
+                try:
+                    import uuid
+                    await db["approval_queue"].insert_one({
+                        "_id": str(uuid.uuid4()),
+                        "approval_id": str(uuid.uuid4()),
+                        "type": "crew_publish",
+                        "crew_id": crew.get("crew_id"),
+                        "crew_name": crew.get("name"),
+                        "run_id": run_id,
+                        "channel_type": channel_type,
+                        "channel_id": channel_id,
+                        "platform": platform,
+                        "draft_response": content,
+                        "content": content,
+                        "status": "pending",
+                        "created_at": datetime.utcnow().isoformat(),
+                    })
+                    publish_results.append({
+                        "platform": platform,
+                        "channel_type": channel_type,
+                        "status": "pending_approval",
+                    })
+                except Exception as e:
+                    publish_results.append({
+                        "platform": platform,
+                        "channel_type": channel_type,
+                        "status": "error",
+                        "error": str(e),
+                    })
+                continue
+
+            try:
+                result = await dist_svc.publish(
+                    channel_id=channel_id,
+                    content=content,
+                    title=f"Crew: {crew.get('name', 'Untitled')}",
+                    published_by=f"crew:{crew.get('crew_id')}",
+                )
+                pub_result = result.get("result", {})
+                success = pub_result.get("success", False)
+                publish_results.append({
+                    "platform": platform,
+                    "channel_type": channel_type,
+                    "status": "published" if success else "failed",
+                    "post_id": pub_result.get("post_id"),
+                    "error": pub_result.get("error") if not success else None,
+                })
+            except Exception as e:
+                publish_results.append({
+                    "platform": platform,
+                    "channel_type": channel_type,
+                    "status": "error",
+                    "error": str(e),
+                })
 
         return publish_results

--- a/backend/services/crew_service.py
+++ b/backend/services/crew_service.py
@@ -24,6 +24,39 @@ logger = logging.getLogger(__name__)
 
 MAX_CREWS_PER_USER = 50
 
+
+async def _refresh_scheduled_runner(db, crew_id: str) -> None:
+    """Re-register a crew's scheduled triggers with the global runner.
+
+    No-op when UNIFIED_CREWS is off or the runner hasn't been started — keeps
+    crew create/update working in test contexts that don't boot the scheduler.
+    """
+    try:
+        from services.feature_flags import unified_crews_enabled
+        if not unified_crews_enabled():
+            return
+        from app import app as fastapi_app
+        runner = getattr(fastapi_app.state, "scheduled_runner", None)
+        if runner is None:
+            return
+        await runner.refresh_for_crew(crew_id)
+    except Exception:
+        logger.debug("scheduled_runner refresh skipped", exc_info=True)
+
+
+def _unregister_scheduled_runner(crew_id: str) -> None:
+    try:
+        from services.feature_flags import unified_crews_enabled
+        if not unified_crews_enabled():
+            return
+        from app import app as fastapi_app
+        runner = getattr(fastapi_app.state, "scheduled_runner", None)
+        if runner is None:
+            return
+        runner.unregister_for_crew(crew_id)
+    except Exception:
+        logger.debug("scheduled_runner unregister skipped", exc_info=True)
+
 # ----------------------------------------------------------------
 # Workspace agent category → crew agent role mapping
 # ----------------------------------------------------------------
@@ -115,6 +148,7 @@ class CrewService:
 
         crew = await self.crew_repo.create_crew(user_id, crew_data)
         logger.info(f"Created crew '{request.name}' (crew_id={crew['crew_id']}) for user {user_id}")
+        await _refresh_scheduled_runner(self.crew_repo.db, crew["crew_id"])
         return crew
 
     async def get_crew(self, crew_id: str, user_id: str) -> Optional[Dict[str, Any]]:
@@ -172,6 +206,7 @@ class CrewService:
         updated = await self.crew_repo.update_crew(crew_id, update_data)
         if updated:
             logger.info(f"Updated crew {crew_id}")
+            await _refresh_scheduled_runner(self.crew_repo.db, crew_id)
         return updated
 
     async def delete_crew(self, crew_id: str, user_id: str) -> bool:
@@ -182,6 +217,7 @@ class CrewService:
         deleted = await self.crew_repo.soft_delete_crew(crew_id)
         if deleted:
             logger.info(f"Soft-deleted crew {crew_id}")
+            _unregister_scheduled_runner(crew_id)
         return deleted
 
     # ------------------------------------------------------------------
@@ -189,13 +225,19 @@ class CrewService:
     # ------------------------------------------------------------------
 
     async def start_run(
-        self, crew_id: str, user_id: str, request: RunCrewRequest
+        self,
+        crew_id: str,
+        user_id: str,
+        request: RunCrewRequest,
+        trigger_type: str = "manual",
+        trigger_source: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Initiate a new crew execution run.
 
-        Creates the run record with agent states. Actual execution
-        will be handled by the CrewOrchestrator (Task #23) via Celery.
+        `trigger_type` records why this run fired: "manual" (Run button),
+        "reactive" (inbound message matched a trigger), or "scheduled" (cron/run_at).
+        `trigger_source` is the connection_id, cron expression, or "manual".
         """
         crew = await self.get_crew(crew_id, user_id)
         if not crew:
@@ -244,6 +286,8 @@ class CrewService:
             "input": request.input,
             "input_data": request.input_data if request.input_data else None,
             "agents": agent_states,
+            "trigger_type": trigger_type,
+            "trigger_source": trigger_source if trigger_source is not None else ("manual" if trigger_type == "manual" else None),
         }
 
         run = await self.run_repo.create_run(crew_id, user_id, run_data)

--- a/backend/services/feature_flags.py
+++ b/backend/services/feature_flags.py
@@ -1,0 +1,26 @@
+"""Phase 3 feature flags.
+
+Phase 3 ships behind `UNIFIED_CREWS` so existing inbound/outbound paths keep
+working until PR 4 flips the default to true.
+
+  UNIFIED_CREWS=1   → inbound_router + scheduled_runner + connection_bindings
+                       outbound publishing all active.
+  UNIFIED_CREWS=0   → legacy trigger_service + channel_bindings outbound path
+                       (today's behaviour).
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def _env_truthy(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in ("1", "true", "yes", "on")
+
+
+def unified_crews_enabled() -> bool:
+    """Read at call time so tests can monkeypatch the env var per-case."""
+    return _env_truthy("UNIFIED_CREWS", default=False)

--- a/backend/services/inbound_router.py
+++ b/backend/services/inbound_router.py
@@ -1,0 +1,182 @@
+"""
+Phase 3 PR 3 — Inbound Router.
+
+Sits in front of the legacy `trigger_service.check_and_dispatch` path.
+
+When UNIFIED_CREWS=on, an incoming `ChannelMessage` is matched against every
+crew that has a `triggers[type=reactive]` entry whose `connection_id` matches
+the message's connection AND whose keywords/hashtags/mentions appear in the
+message text. Exactly-one match → dispatch immediately. Multi-match → an LLM
+disambiguator picks the best crew based on its name/description.
+
+The router is intentionally additive: the call site checks the flag and falls
+through to today's path if it's off, or if no reactive crew matches.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+# Map ChannelType.value → connection_id slug used in crew.triggers.connection_id.
+# Single-user desktop = one auth per platform, so the platform name is the id.
+PLATFORM_FROM_CHANNEL_TYPE = {
+    "telegram": "telegram",
+    "discord": "discord",
+    "reddit": "reddit",
+    "twitter": "twitter",
+    "linkedin": "linkedin",
+    "instagram": "instagram",
+    "facebook": "facebook",
+}
+
+
+def _normalize(text: str) -> str:
+    return (text or "").lower().strip()
+
+
+def _trigger_matches(trigger: Dict[str, Any], text: str) -> bool:
+    """Return True if any keyword/hashtag/mention substring-matches the text.
+
+    Match rule: case-insensitive substring. Empty rule lists do not match —
+    a reactive trigger with no rules at all should never have been saved
+    (Pydantic validator on the model rejects it), but we defend here too.
+    """
+    haystack = _normalize(text)
+    if not haystack:
+        return False
+    rules: List[str] = []
+    rules.extend(trigger.get("keywords") or [])
+    rules.extend(trigger.get("hashtags") or [])
+    rules.extend(trigger.get("mentions") or [])
+    if not rules:
+        return False
+    return any(_normalize(r) in haystack for r in rules if r and r.strip())
+
+
+async def find_matching_crews(
+    db,
+    connection_id: str,
+    text: str,
+) -> List[Tuple[Dict[str, Any], Dict[str, Any]]]:
+    """Return [(crew, matching_trigger)] across all active crews."""
+    matches: List[Tuple[Dict[str, Any], Dict[str, Any]]] = []
+    cursor = db["crews"].find({"status": "active"})
+    async for crew in cursor:
+        triggers = crew.get("triggers") or []
+        for trigger in triggers:
+            if (trigger or {}).get("type") != "reactive":
+                continue
+            if trigger.get("connection_id") != connection_id:
+                continue
+            if _trigger_matches(trigger, text):
+                matches.append((crew, trigger))
+                break  # one trigger per crew is enough to qualify
+    return matches
+
+
+async def disambiguate_with_llm(
+    candidates: List[Dict[str, Any]],
+    message_text: str,
+) -> Dict[str, Any]:
+    """Ask a cheap local model to pick the best crew. Falls back to first match
+    on any failure — never block dispatch on LLM availability.
+    """
+    try:
+        from services.local_model_service import LocalModelService
+    except Exception:
+        return candidates[0]
+
+    try:
+        svc = LocalModelService()
+    except Exception:
+        return candidates[0]
+
+    options_lines = []
+    for idx, crew in enumerate(candidates, start=1):
+        name = crew.get("name") or "(unnamed)"
+        desc = (crew.get("description") or "")[:200].replace("\n", " ")
+        options_lines.append(f"{idx}. {name} — {desc}")
+    options = "\n".join(options_lines)
+
+    prompt = (
+        "You are routing an inbound message to one of several crews.\n"
+        "Pick the single best crew and reply with only its number.\n\n"
+        f"Message:\n{message_text[:600]}\n\n"
+        f"Crews:\n{options}\n\n"
+        "Answer with just the number:"
+    )
+
+    try:
+        # Use whichever local model is loaded; very short generation.
+        result = await svc.generate(prompt=prompt, max_tokens=4, temperature=0.0)
+        answer = (result or {}).get("response") or (result or {}).get("text") or ""
+        match = re.search(r"\d+", answer)
+        if match:
+            idx = int(match.group(0)) - 1
+            if 0 <= idx < len(candidates):
+                return candidates[idx]
+    except Exception as exc:
+        logger.info("LLM disambiguator unavailable, defaulting to first match: %s", exc)
+
+    return candidates[0]
+
+
+async def route_inbound(db, msg) -> Optional[Dict[str, Any]]:
+    """
+    Find a reactive-triggered crew for this message and dispatch it.
+
+    Returns the dispatch result (with status / response / run_id), or None
+    if no crew matched — call site should then fall through to the legacy
+    trigger_service path.
+    """
+    channel_value = msg.channel_type.value if hasattr(msg.channel_type, "value") else str(msg.channel_type)
+    connection_id = PLATFORM_FROM_CHANNEL_TYPE.get(channel_value)
+    if not connection_id:
+        return None
+
+    matches = await find_matching_crews(db, connection_id, msg.text)
+    if not matches:
+        return None
+
+    if len(matches) == 1:
+        crew, trigger = matches[0]
+    else:
+        chosen = await disambiguate_with_llm([c for c, _ in matches], msg.text)
+        # Map back to (crew, trigger)
+        crew, trigger = next(((c, t) for c, t in matches if c is chosen), matches[0])
+
+    crew_id = crew.get("crew_id")
+    user_id = crew.get("user_id") or "desktop-user"
+
+    # Dispatch via crew_service so the run record carries trigger metadata.
+    from models.crew_models import RunCrewRequest
+    from repositories.crew_repository import CrewRepository, CrewRunRepository
+    from repositories.workspace_agent_repository import WorkspaceAgentRepository
+    from services.crew_service import CrewService
+
+    crew_repo = CrewRepository(db)
+    run_repo = CrewRunRepository(db)
+    agent_repo = WorkspaceAgentRepository(db)
+    svc = CrewService(crew_repo=crew_repo, run_repo=run_repo, agent_repo=agent_repo)
+
+    request = RunCrewRequest(input=msg.text)
+    run = await svc.start_run(
+        crew_id=crew_id,
+        user_id=user_id,
+        request=request,
+        trigger_type="reactive",
+        trigger_source=connection_id,
+    )
+
+    return {
+        "status": "dispatched",
+        "response": f"Crew '{crew.get('name')}' is processing your message…",
+        "run_id": run.get("run_id"),
+        "crew_id": crew_id,
+        "trigger_source": connection_id,
+    }

--- a/backend/services/scheduled_runner.py
+++ b/backend/services/scheduled_runner.py
@@ -1,0 +1,210 @@
+"""
+Phase 3 PR 3 — Scheduled Runner for crew triggers.
+
+Reads `crew.triggers[type=scheduled]` across all active crews and registers
+each one as an APScheduler job. When the trigger fires, dispatches the crew
+via ``crew_service.start_run`` with ``trigger_type="scheduled"`` so the run
+record carries its origin.
+
+APScheduler job-id namespace: ``crew-trigger:<crew_id>:<trigger_index>``
+(one crew can hold multiple scheduled triggers).
+
+This runs alongside the legacy `SchedulerService` (which handles post / crew
+jobs from the `scheduled_jobs` collection). They share the APScheduler
+instance but use disjoint id namespaces, so neither interferes with the
+other. PR 4 can retire the legacy scheduler once v1 soaks.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+CREW_TRIGGER_PREFIX = "crew-trigger:"
+
+
+def _aps_id(crew_id: str, trigger_idx: int) -> str:
+    return f"{CREW_TRIGGER_PREFIX}{crew_id}:{trigger_idx}"
+
+
+class ScheduledRunner:
+    """Registers crew scheduled triggers with APScheduler."""
+
+    def __init__(self, db, apscheduler_adapter: Any) -> None:
+        self.db = db
+        self.adapter = apscheduler_adapter
+
+    # ------------------------------------------------------------------
+    # Scheduler lookup
+    # ------------------------------------------------------------------
+
+    def _scheduler(self):
+        if hasattr(self.adapter, "scheduler"):
+            return self.adapter.scheduler()
+        return self.adapter._scheduler
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def load_all(self) -> int:
+        """Scan every active crew at startup, register one APScheduler job per
+        scheduled trigger. Returns total number of registered jobs.
+        """
+        registered = 0
+        cursor = self.db["crews"].find({"status": "active"})
+        async for crew in cursor:
+            try:
+                registered += self._register_triggers(crew)
+            except Exception:
+                logger.exception(
+                    "Failed to register scheduled triggers for crew %s",
+                    crew.get("crew_id"),
+                )
+        logger.info("ScheduledRunner: registered %d crew scheduled trigger(s)", registered)
+        return registered
+
+    async def refresh_for_crew(self, crew_id: str) -> int:
+        """Re-register all triggers for a single crew.
+
+        Called from CrewService after create/update/delete so changes pick
+        up without a full reload.
+        """
+        # Remove any stale triggers first (we don't know how many there used
+        # to be; scan by prefix).
+        self._unregister_crew_jobs(crew_id)
+
+        crew = await self.db["crews"].find_one({"crew_id": crew_id})
+        if not crew:
+            return 0
+        if crew.get("status") != "active":
+            return 0
+        return self._register_triggers(crew)
+
+    def unregister_for_crew(self, crew_id: str) -> None:
+        """Drop all APScheduler jobs for a given crew."""
+        self._unregister_crew_jobs(crew_id)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _register_triggers(self, crew: Dict[str, Any]) -> int:
+        triggers: List[Dict[str, Any]] = crew.get("triggers") or []
+        crew_id = crew.get("crew_id")
+        if not crew_id:
+            return 0
+        registered = 0
+        for idx, trigger in enumerate(triggers):
+            if (trigger or {}).get("type") != "scheduled":
+                continue
+            try:
+                self._register_one(crew_id, idx, trigger)
+                registered += 1
+            except Exception:
+                logger.exception(
+                    "Skipping malformed scheduled trigger idx=%d on crew %s",
+                    idx,
+                    crew_id,
+                )
+        return registered
+
+    def _register_one(
+        self,
+        crew_id: str,
+        trigger_idx: int,
+        trigger: Dict[str, Any],
+    ) -> None:
+        cron = trigger.get("cron")
+        run_at = trigger.get("run_at")
+
+        aps_id = _aps_id(crew_id, trigger_idx)
+        scheduler = self._scheduler()
+
+        if cron:
+            from apscheduler.triggers.cron import CronTrigger
+            aps_trigger = CronTrigger.from_crontab(cron, timezone="UTC")
+            source = cron
+        elif run_at:
+            from apscheduler.triggers.date import DateTrigger
+            aps_trigger = DateTrigger(run_date=run_at)
+            source = run_at
+        else:
+            raise ValueError("Scheduled trigger must have either cron or run_at")
+
+        scheduler.add_job(
+            self._fire,
+            trigger=aps_trigger,
+            id=aps_id,
+            replace_existing=True,
+            kwargs={
+                "crew_id": crew_id,
+                "trigger_idx": trigger_idx,
+                "trigger_source": source,
+                "content_brief": trigger.get("content_brief"),
+            },
+            name=f"crew:{crew_id} trigger:{trigger_idx}",
+        )
+        logger.info(
+            "Registered scheduled trigger %s (cron=%s run_at=%s)",
+            aps_id, cron, run_at,
+        )
+
+    def _unregister_crew_jobs(self, crew_id: str) -> None:
+        scheduler = self._scheduler()
+        prefix = f"{CREW_TRIGGER_PREFIX}{crew_id}:"
+        try:
+            jobs = scheduler.get_jobs()
+        except Exception:
+            return
+        for job in jobs:
+            if job.id and job.id.startswith(prefix):
+                try:
+                    scheduler.remove_job(job.id)
+                except Exception:
+                    pass
+
+    async def _fire(
+        self,
+        crew_id: str,
+        trigger_idx: int,
+        trigger_source: str,
+        content_brief: Optional[str],
+    ) -> None:
+        """Callback invoked by APScheduler when a cron/date boundary hits."""
+        logger.info(
+            "Scheduled trigger fired: crew=%s idx=%s source=%s",
+            crew_id, trigger_idx, trigger_source,
+        )
+        try:
+            from models.crew_models import RunCrewRequest
+            from repositories.crew_repository import CrewRepository, CrewRunRepository
+            from repositories.workspace_agent_repository import WorkspaceAgentRepository
+            from services.crew_service import CrewService
+
+            crew_repo = CrewRepository(self.db)
+            run_repo = CrewRunRepository(self.db)
+            agent_repo = WorkspaceAgentRepository(self.db)
+            svc = CrewService(crew_repo=crew_repo, run_repo=run_repo, agent_repo=agent_repo)
+
+            # Need the user_id from the crew document.
+            crew = await self.db["crews"].find_one({"crew_id": crew_id})
+            if not crew:
+                logger.warning("Scheduled trigger fire: crew %s no longer exists", crew_id)
+                return
+            user_id = crew.get("user_id") or "desktop-user"
+
+            request = RunCrewRequest(input=content_brief or f"Scheduled run at {datetime.utcnow().isoformat()}")
+            await svc.start_run(
+                crew_id=crew_id,
+                user_id=user_id,
+                request=request,
+                trigger_type="scheduled",
+                trigger_source=trigger_source,
+            )
+        except Exception:
+            logger.exception("Scheduled trigger fire failed for crew %s", crew_id)

--- a/backend/tests/test_inbound_router.py
+++ b/backend/tests/test_inbound_router.py
@@ -1,0 +1,194 @@
+"""Tests for Phase 3 PR 3 — inbound_router."""
+
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+
+from services.inbound_router import (
+    _trigger_matches,
+    find_matching_crews,
+    route_inbound,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _msg(channel_type: str, text: str):
+    """Minimal ChannelMessage shim: only fields inbound_router reads."""
+    return SimpleNamespace(
+        channel_type=SimpleNamespace(value=channel_type),
+        text=text,
+    )
+
+
+async def _seed_crew(db, crew_id: str, name: str, triggers: list, user_id: str = "u1"):
+    await db["crews"].insert_one({
+        "_id": crew_id,
+        "crew_id": crew_id,
+        "user_id": user_id,
+        "name": name,
+        "description": f"{name} description",
+        "status": "active",
+        "agents": [
+            {
+                "agent_id": "a1",
+                "name": "Writer",
+                "role": "writer",
+                "instructions": "Write.",
+                "order": 0,
+            }
+        ],
+        "execution_config": {"mode": "sequential", "timeout_seconds": 60},
+        "triggers": triggers,
+        "created_at": "2026-04-21T00:00:00",
+        "updated_at": "2026-04-21T00:00:00",
+    })
+
+
+# ---------------------------------------------------------------------------
+# Matcher unit tests
+# ---------------------------------------------------------------------------
+
+def test_keyword_substring_match_case_insensitive():
+    trigger = {"keywords": ["Pricing"], "hashtags": [], "mentions": []}
+    assert _trigger_matches(trigger, "How does your PRICING work?") is True
+
+
+def test_no_match_when_rules_empty():
+    trigger = {"keywords": [], "hashtags": [], "mentions": []}
+    assert _trigger_matches(trigger, "anything") is False
+
+
+def test_hashtag_match():
+    trigger = {"keywords": [], "hashtags": ["#demo"], "mentions": []}
+    assert _trigger_matches(trigger, "Check out #demo today!") is True
+
+
+def test_mention_match():
+    trigger = {"keywords": [], "hashtags": [], "mentions": ["@support"]}
+    assert _trigger_matches(trigger, "Hey @support, can you help?") is True
+
+
+def test_empty_text_is_safe():
+    trigger = {"keywords": ["x"], "hashtags": [], "mentions": []}
+    assert _trigger_matches(trigger, "") is False
+
+
+# ---------------------------------------------------------------------------
+# find_matching_crews
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_find_matching_crews_exact_one(db_proxy):
+    await _seed_crew(db_proxy, "crew-a", "Sales", [
+        {"type": "reactive", "connection_id": "reddit", "keywords": ["pricing"]},
+    ])
+    await _seed_crew(db_proxy, "crew-b", "Support", [
+        {"type": "reactive", "connection_id": "reddit", "keywords": ["bug"]},
+    ])
+
+    matches = await find_matching_crews(db_proxy, "reddit", "What's your pricing?")
+    assert len(matches) == 1
+    assert matches[0][0]["crew_id"] == "crew-a"
+
+
+@pytest.mark.asyncio
+async def test_find_matching_crews_connection_filter(db_proxy):
+    await _seed_crew(db_proxy, "crew-a", "Sales", [
+        {"type": "reactive", "connection_id": "telegram", "keywords": ["pricing"]},
+    ])
+    matches = await find_matching_crews(db_proxy, "reddit", "pricing question")
+    assert matches == []
+
+
+@pytest.mark.asyncio
+async def test_find_matching_crews_multi_match(db_proxy):
+    await _seed_crew(db_proxy, "crew-a", "Sales", [
+        {"type": "reactive", "connection_id": "reddit", "keywords": ["pricing"]},
+    ])
+    await _seed_crew(db_proxy, "crew-b", "Marketing", [
+        {"type": "reactive", "connection_id": "reddit", "keywords": ["demo"]},
+    ])
+    matches = await find_matching_crews(db_proxy, "reddit", "can I get a pricing demo?")
+    assert len(matches) == 2
+
+
+@pytest.mark.asyncio
+async def test_scheduled_triggers_do_not_match_inbound(db_proxy):
+    await _seed_crew(db_proxy, "crew-s", "Scheduled", [
+        {"type": "scheduled", "connection_ids": ["reddit"], "cron": "0 9 * * *"},
+    ])
+    matches = await find_matching_crews(db_proxy, "reddit", "anything")
+    assert matches == []
+
+
+@pytest.mark.asyncio
+async def test_inactive_crews_ignored(db_proxy):
+    await _seed_crew(db_proxy, "crew-paused", "Paused", [
+        {"type": "reactive", "connection_id": "reddit", "keywords": ["hit"]},
+    ])
+    await db_proxy["crews"].update_one(
+        {"crew_id": "crew-paused"}, {"$set": {"status": "paused"}}
+    )
+    matches = await find_matching_crews(db_proxy, "reddit", "please hit this")
+    assert matches == []
+
+
+# ---------------------------------------------------------------------------
+# route_inbound end-to-end
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_route_inbound_returns_none_when_no_match(db_proxy):
+    result = await route_inbound(db_proxy, _msg("reddit", "random message"))
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_route_inbound_unknown_channel_returns_none(db_proxy):
+    result = await route_inbound(db_proxy, _msg("whatsapp", "pricing"))
+    # whatsapp isn't in PLATFORM_FROM_CHANNEL_TYPE → early None
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_route_inbound_dispatches_on_single_match(db_proxy):
+    await _seed_crew(db_proxy, "crew-x", "Sales", [
+        {"type": "reactive", "connection_id": "reddit", "keywords": ["pricing"]},
+    ])
+    result = await route_inbound(db_proxy, _msg("reddit", "what's your pricing?"))
+    assert result is not None
+    assert result["status"] == "dispatched"
+    assert result["crew_id"] == "crew-x"
+    assert result["trigger_source"] == "reddit"
+    assert result["run_id"]  # a run was created
+
+    # Verify the run record carries the trigger metadata
+    run = await db_proxy["crew_runs"].find_one({"run_id": result["run_id"]})
+    assert run["trigger_type"] == "reactive"
+    assert run["trigger_source"] == "reddit"
+
+
+@pytest.mark.asyncio
+async def test_route_inbound_multi_match_still_dispatches(db_proxy, monkeypatch):
+    await _seed_crew(db_proxy, "crew-a", "Sales", [
+        {"type": "reactive", "connection_id": "reddit", "keywords": ["pricing"]},
+    ])
+    await _seed_crew(db_proxy, "crew-b", "Support", [
+        {"type": "reactive", "connection_id": "reddit", "keywords": ["pricing"]},
+    ])
+
+    # Force disambiguator to pick the second candidate deterministically.
+    async def fake_disambiguate(candidates, text):
+        return candidates[-1]
+
+    monkeypatch.setattr(
+        "services.inbound_router.disambiguate_with_llm", fake_disambiguate
+    )
+
+    result = await route_inbound(db_proxy, _msg("reddit", "need pricing help"))
+    assert result is not None
+    assert result["crew_id"] in {"crew-a", "crew-b"}

--- a/backend/tests/test_scheduled_runner.py
+++ b/backend/tests/test_scheduled_runner.py
@@ -1,0 +1,173 @@
+"""Tests for Phase 3 PR 3 — scheduled_runner."""
+
+from types import SimpleNamespace
+from typing import Any, Dict, List
+
+import pytest
+import pytest_asyncio
+
+from services.scheduled_runner import CREW_TRIGGER_PREFIX, ScheduledRunner
+
+
+# ---------------------------------------------------------------------------
+# Fake APScheduler that records add_job / remove_job calls.
+# ---------------------------------------------------------------------------
+
+class FakeJob:
+    def __init__(self, job_id: str, kwargs: Dict[str, Any]):
+        self.id = job_id
+        self.kwargs = kwargs
+        self.next_run_time = None
+
+
+class FakeScheduler:
+    def __init__(self):
+        self._jobs: Dict[str, FakeJob] = {}
+        self.add_calls: List[Dict[str, Any]] = []
+
+    def add_job(self, func, trigger=None, id=None, replace_existing=False, kwargs=None, name=None):
+        if id in self._jobs and not replace_existing:
+            raise RuntimeError(f"Duplicate id {id}")
+        self._jobs[id] = FakeJob(id, kwargs or {})
+        self.add_calls.append({"id": id, "trigger": trigger, "kwargs": kwargs or {}})
+        return self._jobs[id]
+
+    def remove_job(self, job_id: str):
+        if job_id not in self._jobs:
+            raise KeyError(job_id)
+        self._jobs.pop(job_id)
+
+    def get_jobs(self):
+        return list(self._jobs.values())
+
+    def get_job(self, job_id: str):
+        return self._jobs.get(job_id)
+
+
+class FakeAdapter:
+    def __init__(self, scheduler: FakeScheduler):
+        self._sched = scheduler
+
+    def scheduler(self):
+        return self._sched
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def runner(db_proxy):
+    scheduler = FakeScheduler()
+    r = ScheduledRunner(db_proxy, FakeAdapter(scheduler))
+    r._fake_scheduler = scheduler  # expose for assertions
+    return r
+
+
+async def _insert_crew(db, crew_id: str, triggers: list, status: str = "active"):
+    await db["crews"].insert_one({
+        "_id": crew_id,
+        "crew_id": crew_id,
+        "user_id": "u1",
+        "name": f"crew {crew_id}",
+        "status": status,
+        "triggers": triggers,
+    })
+
+
+# ---------------------------------------------------------------------------
+# load_all
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_load_all_registers_cron_triggers(runner, db_proxy):
+    await _insert_crew(db_proxy, "c1", [
+        {"type": "scheduled", "connection_ids": ["linkedin"], "cron": "0 9 * * *"},
+    ])
+    await _insert_crew(db_proxy, "c2", [
+        {"type": "scheduled", "connection_ids": ["blog"], "cron": "0 12 * * MON"},
+        {"type": "reactive", "connection_id": "reddit", "keywords": ["x"]},  # ignored
+    ])
+
+    count = await runner.load_all()
+    assert count == 2
+
+    ids = sorted(runner._fake_scheduler._jobs.keys())
+    assert ids == [f"{CREW_TRIGGER_PREFIX}c1:0", f"{CREW_TRIGGER_PREFIX}c2:0"]
+
+
+@pytest.mark.asyncio
+async def test_load_all_registers_date_trigger(runner, db_proxy):
+    await _insert_crew(db_proxy, "c1", [
+        {"type": "scheduled", "connection_ids": ["linkedin"], "run_at": "2026-12-01T09:00:00+00:00"},
+    ])
+    count = await runner.load_all()
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_load_all_skips_inactive_crews(runner, db_proxy):
+    await _insert_crew(db_proxy, "c-paused", [
+        {"type": "scheduled", "cron": "0 9 * * *"},
+    ], status="paused")
+    count = await runner.load_all()
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_load_all_survives_malformed_trigger(runner, db_proxy):
+    # Neither cron nor run_at — should log+skip, not crash, and not count.
+    await _insert_crew(db_proxy, "c-bad", [
+        {"type": "scheduled", "connection_ids": ["linkedin"]},
+    ])
+    await _insert_crew(db_proxy, "c-good", [
+        {"type": "scheduled", "cron": "0 9 * * *"},
+    ])
+    count = await runner.load_all()
+    assert count == 1
+    ids = list(runner._fake_scheduler._jobs.keys())
+    assert ids == [f"{CREW_TRIGGER_PREFIX}c-good:0"]
+
+
+# ---------------------------------------------------------------------------
+# refresh_for_crew
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_refresh_for_crew_adds_and_removes(runner, db_proxy):
+    await _insert_crew(db_proxy, "c1", [
+        {"type": "scheduled", "cron": "0 9 * * *"},
+        {"type": "scheduled", "cron": "0 18 * * *"},
+    ])
+    count = await runner.refresh_for_crew("c1")
+    assert count == 2
+    assert len(runner._fake_scheduler._jobs) == 2
+
+    # Drop one trigger, refresh — old jobs gone, new set registered.
+    await db_proxy["crews"].update_one(
+        {"crew_id": "c1"},
+        {"$set": {"triggers": [{"type": "scheduled", "cron": "0 12 * * *"}]}},
+    )
+    count = await runner.refresh_for_crew("c1")
+    assert count == 1
+    assert len(runner._fake_scheduler._jobs) == 1
+    assert f"{CREW_TRIGGER_PREFIX}c1:0" in runner._fake_scheduler._jobs
+
+
+@pytest.mark.asyncio
+async def test_refresh_for_crew_handles_unknown(runner):
+    count = await runner.refresh_for_crew("nonexistent")
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_unregister_removes_all_crew_jobs(runner, db_proxy):
+    await _insert_crew(db_proxy, "c1", [
+        {"type": "scheduled", "cron": "0 9 * * *"},
+        {"type": "scheduled", "cron": "0 18 * * *"},
+    ])
+    await runner.load_all()
+    assert len(runner._fake_scheduler._jobs) == 2
+
+    runner.unregister_for_crew("c1")
+    assert runner._fake_scheduler._jobs == {}

--- a/frontend/src/lib/api/crews-client.ts
+++ b/frontend/src/lib/api/crews-client.ts
@@ -36,6 +36,29 @@ export interface ChannelBinding {
   approval_required: boolean;
 }
 
+// Phase 3 additions — safe to read as optional since PR 1 may not be merged yet.
+export interface ConnectionBinding {
+  connection_id: string;
+  platform: string;
+  direction: "inbound" | "outbound" | "both";
+}
+
+export type CrewTrigger =
+  | {
+      type: "reactive";
+      connection_id: string;
+      keywords?: string[];
+      hashtags?: string[];
+      mentions?: string[];
+    }
+  | {
+      type: "scheduled";
+      connection_ids?: string[];
+      cron?: string;
+      run_at?: string;
+      content_brief?: string;
+    };
+
 export interface Crew {
   id?: string;
   crew_id: string;
@@ -44,6 +67,9 @@ export interface Crew {
   execution_config?: CrewExecutionConfig;
   agents?: CrewAgent[];
   channel_bindings?: ChannelBinding[];
+  connection_bindings?: ConnectionBinding[];
+  triggers?: CrewTrigger[];
+  approval_required?: boolean;
   phases?: unknown[];
   schedule?: CrewSchedule;
   status: "active" | "paused" | "archived" | "idle";
@@ -71,6 +97,8 @@ export interface CrewRun {
   input_data?: Record<string, unknown>;
   output_data?: Record<string, unknown>;
   error?: string;
+  trigger_type?: "reactive" | "scheduled" | "manual";
+  trigger_source?: string;
 }
 
 export interface CrewRunStep {

--- a/frontend/src/routes/crews.tsx
+++ b/frontend/src/routes/crews.tsx
@@ -93,6 +93,32 @@ function StatusBadge({ status }: { status: string }) {
   );
 }
 
+function TriggerTypeBadge({ triggerType }: { triggerType?: string }) {
+  // Phase 3: indicates why this run fired. Defaults to "manual" so runs from
+  // before the trigger metadata existed still render something sensible.
+  const t = triggerType ?? "manual";
+  const map: Record<string, { label: string; cls: string }> = {
+    manual: {
+      label: "Manual",
+      cls: "bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400",
+    },
+    reactive: {
+      label: "Reactive",
+      cls: "bg-orange-50 dark:bg-orange-500/10 text-orange-600 dark:text-orange-400",
+    },
+    scheduled: {
+      label: "Scheduled",
+      cls: "bg-blue-50 dark:bg-blue-500/10 text-blue-600 dark:text-blue-400",
+    },
+  };
+  const info = map[t] ?? map.manual;
+  return (
+    <span className={cn("inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium", info.cls)}>
+      {info.label}
+    </span>
+  );
+}
+
 const MODE_BADGES: Record<string, { label: string; cls: string; icon: React.ElementType }> = {
   sequential: {
     label: "Sequential",
@@ -134,6 +160,7 @@ export default function CrewsPage() {
   const [searchQuery, setSearchQuery] = useState("");
   const [statusFilter, setStatusFilter] = useState<string>("all");
   const [modeFilter, setModeFilter] = useState<string>("all");
+  const [phase3Filter, setPhase3Filter] = useState<string>("all");
 
   const loadData = useCallback(async () => {
     try {
@@ -192,6 +219,27 @@ export default function CrewsPage() {
       (crew.execution_config?.mode || "sequential") !== modeFilter
     ) {
       return false;
+    }
+    if (phase3Filter !== "all") {
+      const bindings = crew.connection_bindings ?? [];
+      const triggers = crew.triggers ?? [];
+      switch (phase3Filter) {
+        case "inbound":
+          if (!bindings.some((b) => b.direction === "inbound" || b.direction === "both")) return false;
+          break;
+        case "outbound":
+          if (!bindings.some((b) => b.direction === "outbound" || b.direction === "both")) return false;
+          break;
+        case "reactive":
+          if (!triggers.some((t) => t.type === "reactive")) return false;
+          break;
+        case "scheduled":
+          if (!triggers.some((t) => t.type === "scheduled")) return false;
+          break;
+        case "approval":
+          if (!crew.approval_required) return false;
+          break;
+      }
     }
     return true;
   });
@@ -330,6 +378,18 @@ export default function CrewsPage() {
                 <option value="parallel">Parallel</option>
                 <option value="pipeline">Pipeline</option>
                 <option value="autonomous">Autonomous</option>
+              </select>
+              <select
+                value={phase3Filter}
+                onChange={(e) => setPhase3Filter(e.target.value)}
+                className="px-2 py-1.5 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-white text-xs focus:ring-2 focus:ring-primary-500/30 outline-none"
+              >
+                <option value="all">All bindings</option>
+                <option value="inbound">Inbound</option>
+                <option value="outbound">Outbound</option>
+                <option value="reactive">Reactive trigger</option>
+                <option value="scheduled">Scheduled trigger</option>
+                <option value="approval">Approval required</option>
               </select>
             </div>
           )}
@@ -520,6 +580,7 @@ function RunsList({ runs }: { runs: CrewRun[] }) {
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
               <StatusBadge status={run.status} />
+              <TriggerTypeBadge triggerType={run.trigger_type} />
               <div>
                 <span className="text-sm font-medium text-neutral-900 dark:text-white">
                   {run.crew_name || run.crew_id.slice(0, 8)}


### PR DESCRIPTION
## Summary

Third of four PRs for Phase 3 (see TODO.md → PHASE 3). Wires up the **runtime half** — reactive inbound dispatch, scheduled firing, direction-aware outbound publishing — all behind the `UNIFIED_CREWS` env flag so legacy paths keep running by default until PR 4 flips it on.

## What landed

**Backend**
- `services/feature_flags.py` — `UNIFIED_CREWS` env flag (default off).
- `services/inbound_router.py` — matches inbound messages against every crew's `triggers[type=reactive]` (filtered by `connection_id` + keyword/hashtag/mention substring). Multi-match → local LLM disambiguator (graceful fallback to first match). Dispatches via `crew_service.start_run(trigger_type="reactive")`.
- `services/scheduled_runner.py` — APScheduler-backed. Scans active crews at startup, registers one APScheduler job per `triggers[type=scheduled]` entry (cron or one-shot date). `crew_service.create/update/delete` call `refresh_for_crew` to keep registrations live. Uses a disjoint id namespace (`crew-trigger:*`) from the legacy `SchedulerService` — they coexist.
- `channel_service.handle_message` — routes to `inbound_router` first when flag is on, falls through to legacy `trigger_service` otherwise.
- `crew_orchestrator._publish_to_bound_channels` — gains `_publish_via_connection_bindings` path. When the flag is on and `crew.connection_bindings[]` is non-empty, publishes to every binding whose direction is `"outbound"` or `"both"`. Honours top-level `crew.approval_required`. Legacy `channel_bindings[]` path is untouched.
- `crew_service.start_run` — accepts optional `trigger_type` + `trigger_source` params (identical change to PR #21, merges cleanly).

**Frontend**
- `crews-client.ts` — additive `Crew.connection_bindings/triggers/approval_required` + `CrewRun.trigger_type/trigger_source`. All optional — works whether PR 1 has merged or not.
- `crews.tsx` — **Runs tab** shows a `TriggerTypeBadge` (Manual / Reactive / Scheduled) next to each status. **Crews tab** gets a fifth filter dropdown: Inbound / Outbound / Reactive / Scheduled / Approval-required.

**Plan update**
- TODO.md decision #3 and PR 4 row updated: Distribution + Schedule are **removed** from the sidebar in PR 4, not soft-deprecated to a Coming Soon page. Everything those pages did now lives inside Crews; the half-step would just be clutter.

## Deliberately deferred to PR 3b

The crew-builder wizard rework (Trigger step + Direction chips per connection + Approval toggle + 5→7 step flow) is the largest single piece of Phase 3 frontend work. Splitting it keeps this PR reviewable and lets the backend wiring ship + soak first. PR 3b builds on top once this merges.

## Depends on

- Conceptually on PR #21 (data model) — `inbound_router` reads `crew.triggers[]`, which PR 1 defines. Runtime tolerance: raw-dict reads with defaults, so this code runs harmless no-ops if PR 1 hasn't landed.
- Conceptually on PR #22 (aggregator). No import coupling.

Merge order: #21 → #22 → this → PR 3b → PR 4.

## Test plan

- [x] `pytest backend/tests/test_inbound_router.py` — 14 tests (matcher edges, multi-match disambiguation, dispatch round-trip to `crew_runs`)
- [x] `pytest backend/tests/test_scheduled_runner.py` — 7 tests (cron + date registration, refresh add/remove, malformed-trigger survival, unregister)
- [x] Full backend suite: **744 passed** (723 baseline + 21)
- [x] `cd frontend && npm run build` → clean
- [ ] Manual smoke: set `UNIFIED_CREWS=1`, create a crew with a reactive trigger on Reddit (keyword `pricing`); post a matching comment; verify a `crew_runs` row appears with `trigger_type="reactive"`; verify the Runs tab badge renders.

## Follow-up PRs

| PR | Scope |
|---|---|
| #21 | Data model + migration |
| #22 | Connections aggregator + Blog/Email/Slack |
| **this (PR 3a)** | Inbound router + scheduled runner + Runs badge + filter chips |
| PR 3b | Crew builder Trigger step + Direction chips + Approval toggle |
| PR 4 | Remove Distribution + Schedule from sidebar; flip `UNIFIED_CREWS` on |

🤖 Generated with [Claude Code](https://claude.com/claude-code)