### PR TITLE
feat: Phase 3 PR 3b of 4 — crew builder revamp (7-step wizard)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -45,6 +45,7 @@ from routers.blueprints import router as blueprints_router
 from routers.reddit import router as reddit_router
 from routers.twitter import router as twitter_router
 from routers.scheduled_jobs import router as scheduled_jobs_router
+from routers.connections import router as connections_router
 
 # ---------------------------------------------------------------------------
 # Logging
@@ -96,6 +97,7 @@ app.include_router(blueprints_router)
 app.include_router(reddit_router)
 app.include_router(twitter_router)
 app.include_router(scheduled_jobs_router)
+app.include_router(connections_router)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/models/connection_models.py
+++ b/backend/models/connection_models.py
@@ -1,0 +1,160 @@
+"""
+Connection Models — unified shape across every credential store.
+
+Phase 3 PR 2 introduces a single `/api/v1/connections` aggregator that reads
+from oauth_connections (LinkedIn/IG/FB), reddit_accounts, twitter_accounts,
+channel_registrations (Telegram/Discord), and distribution_channels
+(blog/email/slack_webhook). This module defines the request/response models
+for that surface.
+
+Existing per-platform credential endpoints (OAuth callback, Reddit CRUD,
+Twitter CRUD, channels/register) are unchanged — the aggregator is a
+read-plus-capability-toggle layer on top.
+"""
+
+from enum import Enum
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+
+# =============================================================================
+# Platform catalog
+# =============================================================================
+
+class Platform(str, Enum):
+    """All supported connection platforms. Includes PR 2's new outbound-only types."""
+    TELEGRAM = "telegram"
+    DISCORD = "discord"
+    REDDIT = "reddit"
+    TWITTER = "twitter"
+    LINKEDIN = "linkedin"
+    INSTAGRAM = "instagram"
+    FACEBOOK = "facebook"
+    BLOG = "blog"
+    EMAIL = "email"
+    SLACK_WEBHOOK = "slack_webhook"
+
+
+# Platform capabilities — what direction(s) each platform supports.
+PLATFORM_CAPABILITIES: Dict[str, Dict[str, bool]] = {
+    Platform.TELEGRAM.value:      {"inbound_supported": True,  "outbound_supported": True},
+    Platform.DISCORD.value:       {"inbound_supported": True,  "outbound_supported": True},
+    Platform.REDDIT.value:        {"inbound_supported": True,  "outbound_supported": True},
+    Platform.TWITTER.value:       {"inbound_supported": True,  "outbound_supported": True},
+    Platform.LINKEDIN.value:      {"inbound_supported": False, "outbound_supported": True},
+    Platform.INSTAGRAM.value:     {"inbound_supported": False, "outbound_supported": True},
+    Platform.FACEBOOK.value:      {"inbound_supported": False, "outbound_supported": True},
+    Platform.BLOG.value:          {"inbound_supported": False, "outbound_supported": True},
+    Platform.EMAIL.value:         {"inbound_supported": False, "outbound_supported": True},
+    Platform.SLACK_WEBHOOK.value: {"inbound_supported": False, "outbound_supported": True},
+}
+
+OUTBOUND_ONLY_PLATFORMS = {
+    Platform.BLOG.value,
+    Platform.EMAIL.value,
+    Platform.SLACK_WEBHOOK.value,
+}
+
+
+# =============================================================================
+# Aggregator response
+# =============================================================================
+
+class ConnectionSummary(BaseModel):
+    """Unified view of one connection across all stores.
+
+    `id` is the store-native identifier (OAuth provider id, reddit_accounts
+    _id, channel_registrations _id, distribution_channels channel_id, etc.).
+    The aggregator stamps a `store` hint so writes can route back to the
+    originating collection.
+    """
+    id: str
+    platform: str
+    store: Literal[
+        "oauth_connections",
+        "reddit_accounts",
+        "twitter_accounts",
+        "channel_registrations",
+        "distribution_channels",
+    ]
+    display_name: Optional[str] = None
+    connected: bool = True
+    inbound_enabled: bool = True
+    outbound_enabled: bool = True
+    inbound_supported: bool = False
+    outbound_supported: bool = False
+    config_summary: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Non-sensitive subset safe to show in UI (e.g. profile_name, subreddits count, from_email).",
+    )
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+class ConnectionListResponse(BaseModel):
+    success: bool = True
+    connections: List[ConnectionSummary]
+    total_count: int
+
+
+# =============================================================================
+# Capability PATCH
+# =============================================================================
+
+class CapabilityUpdate(BaseModel):
+    """Toggle inbound/outbound on an existing connection. Omitted fields untouched."""
+    inbound_enabled: Optional[bool] = None
+    outbound_enabled: Optional[bool] = None
+
+    @model_validator(mode="after")
+    def at_least_one_field(self):
+        if self.inbound_enabled is None and self.outbound_enabled is None:
+            raise ValueError("Specify inbound_enabled and/or outbound_enabled")
+        return self
+
+
+# =============================================================================
+# Outbound-only connections (blog / email / slack_webhook)
+# =============================================================================
+
+class OutboundConnectionCreate(BaseModel):
+    """Create a blog / email / slack_webhook connection.
+
+    Type-specific fields live in `config`; the validator enforces required
+    keys per platform.
+    """
+    platform: Literal["blog", "email", "slack_webhook"]
+    name: str = Field(..., min_length=1, max_length=200)
+    config: Dict[str, Any] = Field(default_factory=dict)
+    enabled: bool = True
+
+    @model_validator(mode="after")
+    def validate_config_for_platform(self):
+        cfg = self.config or {}
+        if self.platform == "blog":
+            if not cfg.get("api_url"):
+                raise ValueError("blog config requires api_url")
+            if not cfg.get("cms_type"):
+                raise ValueError("blog config requires cms_type (ghost | wordpress | custom)")
+        elif self.platform == "email":
+            for key in ("provider", "api_key", "from_email"):
+                if not cfg.get(key):
+                    raise ValueError(f"email config requires {key}")
+        elif self.platform == "slack_webhook":
+            if not cfg.get("webhook_url"):
+                raise ValueError("slack_webhook config requires webhook_url")
+        return self
+
+
+class OutboundConnectionUpdate(BaseModel):
+    """Partial update for an outbound-only connection."""
+    name: Optional[str] = Field(None, min_length=1, max_length=200)
+    config: Optional[Dict[str, Any]] = None
+    enabled: Optional[bool] = None
+
+    @model_validator(mode="after")
+    def at_least_one_field(self):
+        if self.name is None and self.config is None and self.enabled is None:
+            raise ValueError("Specify at least one field to update")
+        return self

--- a/backend/routers/connections.py
+++ b/backend/routers/connections.py
@@ -1,0 +1,103 @@
+"""Unified Connections REST API (Phase 3 PR 2).
+
+Surfaces all credential stores — OAuth (LinkedIn/IG/FB), Reddit, Twitter,
+token-paste channels (Telegram/Discord), and outbound-only types (Blog,
+Email, Slack webhook) — behind one endpoint.
+
+  GET    /api/v1/connections                      — unified list
+  GET    /api/v1/connections/{id}                 — single summary
+  PATCH  /api/v1/connections/{id}/capabilities    — toggle inbound/outbound
+  POST   /api/v1/connections/outbound             — create blog/email/slack_webhook
+  PUT    /api/v1/connections/outbound/{id}        — update
+  DELETE /api/v1/connections/outbound/{id}        — remove
+
+Per-platform credential endpoints (reddit, twitter, oauth, channels) stay
+unchanged — this router is a read-plus-capability-toggle layer on top.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from database import get_database
+from models.connection_models import (
+    CapabilityUpdate,
+    ConnectionListResponse,
+    ConnectionSummary,
+    OutboundConnectionCreate,
+    OutboundConnectionUpdate,
+)
+from services.auth_service import get_current_user
+from services.connection_service import ConnectionService
+
+router = APIRouter(prefix="/api/v1/connections", tags=["connections"])
+
+
+def _svc(db=Depends(get_database)) -> ConnectionService:
+    return ConnectionService(db)
+
+
+def _user_id(user: dict) -> str:
+    return user.get("user_id") or user.get("sub") or "desktop"
+
+
+# ---------------------------------------------------------------------------
+# List + single read
+# ---------------------------------------------------------------------------
+
+@router.get("", response_model=ConnectionListResponse)
+async def list_connections(svc: ConnectionService = Depends(_svc)):
+    rows = await svc.list_connections()
+    return ConnectionListResponse(connections=rows, total_count=len(rows))
+
+
+@router.get("/{connection_id}", response_model=ConnectionSummary)
+async def get_connection(
+    connection_id: str,
+    svc: ConnectionService = Depends(_svc),
+):
+    row = await svc.get_connection(connection_id)
+    if not row:
+        raise HTTPException(404, f"Connection {connection_id} not found")
+    return row
+
+
+# ---------------------------------------------------------------------------
+# PATCH capabilities
+# ---------------------------------------------------------------------------
+
+@router.patch("/{connection_id}/capabilities", response_model=ConnectionSummary)
+async def patch_capabilities(
+    connection_id: str,
+    update: CapabilityUpdate,
+    svc: ConnectionService = Depends(_svc),
+):
+    return await svc.update_capabilities(connection_id, update)
+
+
+# ---------------------------------------------------------------------------
+# Outbound-only CRUD (blog / email / slack_webhook)
+# ---------------------------------------------------------------------------
+
+@router.post("/outbound", response_model=ConnectionSummary, status_code=201)
+async def create_outbound(
+    request: OutboundConnectionCreate,
+    svc: ConnectionService = Depends(_svc),
+    user: dict = Depends(get_current_user),
+):
+    return await svc.create_outbound(request, _user_id(user))
+
+
+@router.put("/outbound/{connection_id}", response_model=ConnectionSummary)
+async def update_outbound(
+    connection_id: str,
+    update: OutboundConnectionUpdate,
+    svc: ConnectionService = Depends(_svc),
+):
+    return await svc.update_outbound(connection_id, update)
+
+
+@router.delete("/outbound/{connection_id}", status_code=204)
+async def delete_outbound(
+    connection_id: str,
+    svc: ConnectionService = Depends(_svc),
+):
+    await svc.delete_outbound(connection_id)

--- a/backend/services/connection_service.py
+++ b/backend/services/connection_service.py
@@ -1,0 +1,419 @@
+"""
+ConnectionService — unified read/write over every credential store.
+
+Surfaces a single list of `ConnectionSummary` records merging:
+  - oauth_connections (linkedin / instagram / facebook — OAuth2)
+  - reddit_accounts (token-paste)
+  - twitter_accounts (OAuth 1.0a + bearer)
+  - channel_registrations (telegram / discord — token-paste)
+  - distribution_channels (blog / email / slack_webhook — the new outbound-only types)
+
+Each summary carries a `store` discriminator and a prefixed `id`
+(e.g. `oauth:linkedin`, `reddit:abc123`) so PATCH/DELETE can route back
+to the originating collection without ambiguity.
+
+Capability flags (`inbound_enabled` / `outbound_enabled`) are read from
+raw records with `.get(..., default)` — works whether PR 1's typed-model
+defaults have migrated yet or not.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+from fastapi import HTTPException
+
+from models.connection_models import (
+    OUTBOUND_ONLY_PLATFORMS,
+    PLATFORM_CAPABILITIES,
+    CapabilityUpdate,
+    ConnectionSummary,
+    OutboundConnectionCreate,
+    OutboundConnectionUpdate,
+)
+from services.distribution_service import DistributionService
+
+
+# Map ConnectionService platform slug → distribution_service.channel_type
+# (slack_webhook is our platform name; the underlying publisher in
+# distribution_service keys the record as "slack".)
+PLATFORM_TO_DIST_CHANNEL_TYPE = {
+    "blog": "blog",
+    "email": "email",
+    "slack_webhook": "slack",
+}
+DIST_CHANNEL_TYPE_TO_PLATFORM = {v: k for k, v in PLATFORM_TO_DIST_CHANNEL_TYPE.items()}
+
+OAUTH_PROVIDERS = ("linkedin", "instagram", "facebook")
+
+
+def _prefix(store: str, native_id: str) -> str:
+    return f"{store}:{native_id}"
+
+
+def _unprefix(prefixed_id: str) -> Tuple[str, str]:
+    if ":" not in prefixed_id:
+        raise HTTPException(400, f"Invalid connection id: {prefixed_id!r}")
+    store, native = prefixed_id.split(":", 1)
+    return store, native
+
+
+def _capability_defaults(platform: str) -> Dict[str, bool]:
+    """Return (inbound_enabled, outbound_enabled) defaults for a platform.
+
+    Outbound-only platforms default inbound off. Everything else defaults
+    both on — these are the flags applied when a record has never been
+    touched by a capability PATCH.
+    """
+    caps = PLATFORM_CAPABILITIES.get(platform, {})
+    return {
+        "inbound_enabled": caps.get("inbound_supported", False),
+        "outbound_enabled": caps.get("outbound_supported", False),
+    }
+
+
+def _mask(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    if len(value) <= 4:
+        return "****"
+    return value[:2] + "****" + value[-2:]
+
+
+class ConnectionService:
+    def __init__(self, db):
+        self.db = db
+        self.distribution = DistributionService(db)
+
+    # ------------------------------------------------------------------
+    # LIST
+    # ------------------------------------------------------------------
+
+    async def list_connections(self) -> List[ConnectionSummary]:
+        out: List[ConnectionSummary] = []
+        out.extend(await self._list_oauth())
+        out.extend(await self._list_reddit())
+        out.extend(await self._list_twitter())
+        out.extend(await self._list_channel_registrations())
+        out.extend(await self._list_outbound())
+        return out
+
+    async def _list_oauth(self) -> List[ConnectionSummary]:
+        rows: List[ConnectionSummary] = []
+        coll = self.db["oauth_connections"]
+        async for doc in coll.find({}):
+            provider = doc.get("_id") if isinstance(doc.get("_id"), str) else None
+            if provider not in OAUTH_PROVIDERS:
+                continue
+            connected = bool(doc.get("access_token"))
+            caps = _capability_defaults(provider)
+            rows.append(ConnectionSummary(
+                id=_prefix("oauth", provider),
+                platform=provider,
+                store="oauth_connections",
+                display_name=doc.get("profile_name") or provider.title(),
+                connected=connected,
+                inbound_enabled=bool(doc.get("inbound_enabled", caps["inbound_enabled"])),
+                outbound_enabled=bool(doc.get("outbound_enabled", caps["outbound_enabled"])),
+                inbound_supported=PLATFORM_CAPABILITIES[provider]["inbound_supported"],
+                outbound_supported=PLATFORM_CAPABILITIES[provider]["outbound_supported"],
+                config_summary={
+                    "profile_id": doc.get("profile_id"),
+                    "scopes": doc.get("scopes", []),
+                    "org_id": doc.get("org_id"),
+                    "expires_in": doc.get("expires_in"),
+                },
+                created_at=doc.get("connected_at") or doc.get("updated_at"),
+                updated_at=doc.get("updated_at"),
+            ))
+        return rows
+
+    async def _list_reddit(self) -> List[ConnectionSummary]:
+        rows: List[ConnectionSummary] = []
+        coll = self.db["reddit_accounts"]
+        async for doc in coll.find({}):
+            native_id = str(doc.get("_id"))
+            caps = _capability_defaults("reddit")
+            rows.append(ConnectionSummary(
+                id=_prefix("reddit", native_id),
+                platform="reddit",
+                store="reddit_accounts",
+                display_name=doc.get("username"),
+                connected=bool(doc.get("client_id") and doc.get("client_secret")),
+                inbound_enabled=bool(doc.get("inbound_enabled", caps["inbound_enabled"])),
+                outbound_enabled=bool(doc.get("outbound_enabled", caps["outbound_enabled"])),
+                inbound_supported=True,
+                outbound_supported=True,
+                config_summary={
+                    "subreddits": doc.get("subreddits", []),
+                    "keyword_count": len(doc.get("keywords", []) or []),
+                    "poll_inbox": doc.get("poll_inbox", True),
+                },
+                created_at=_iso(doc.get("created_at")),
+                updated_at=_iso(doc.get("updated_at")),
+            ))
+        return rows
+
+    async def _list_twitter(self) -> List[ConnectionSummary]:
+        rows: List[ConnectionSummary] = []
+        coll = self.db["twitter_accounts"]
+        async for doc in coll.find({}):
+            native_id = str(doc.get("_id"))
+            caps = _capability_defaults("twitter")
+            has_write = bool(
+                doc.get("api_key") and doc.get("api_secret")
+                and doc.get("access_token") and doc.get("access_token_secret")
+            )
+            rows.append(ConnectionSummary(
+                id=_prefix("twitter", native_id),
+                platform="twitter",
+                store="twitter_accounts",
+                display_name=doc.get("user_id"),
+                connected=bool(doc.get("user_id") and (doc.get("bearer_token") or has_write)),
+                inbound_enabled=bool(doc.get("inbound_enabled", caps["inbound_enabled"])),
+                # If no OAuth 1.0a creds, outbound is physically impossible — force off.
+                outbound_enabled=bool(doc.get("outbound_enabled", caps["outbound_enabled"])) and has_write,
+                inbound_supported=True,
+                outbound_supported=has_write,
+                config_summary={
+                    "poll_mentions": doc.get("poll_mentions", True),
+                    "poll_dms": doc.get("poll_dms", True),
+                    "has_write_creds": has_write,
+                    "keyword_count": len(doc.get("keywords", []) or []),
+                },
+                created_at=_iso(doc.get("created_at")),
+                updated_at=_iso(doc.get("updated_at")),
+            ))
+        return rows
+
+    async def _list_channel_registrations(self) -> List[ConnectionSummary]:
+        rows: List[ConnectionSummary] = []
+        coll = self.db["channel_registrations"]
+        async for doc in coll.find({"channel_type": {"$in": ["telegram", "discord"]}}):
+            platform = doc["channel_type"]
+            native_id = str(doc.get("_id"))
+            caps = _capability_defaults(platform)
+            rows.append(ConnectionSummary(
+                id=_prefix("channel", native_id),
+                platform=platform,
+                store="channel_registrations",
+                display_name=(doc.get("config") or {}).get("bot_name") or platform.title(),
+                connected=bool((doc.get("config") or {}).get("bot_token")),
+                inbound_enabled=bool(doc.get("inbound_enabled", caps["inbound_enabled"])),
+                outbound_enabled=bool(doc.get("outbound_enabled", caps["outbound_enabled"])),
+                inbound_supported=True,
+                outbound_supported=True,
+                config_summary={
+                    "has_token": bool((doc.get("config") or {}).get("bot_token")),
+                },
+                created_at=_iso(doc.get("created_at")),
+                updated_at=_iso(doc.get("updated_at")),
+            ))
+        return rows
+
+    async def _list_outbound(self) -> List[ConnectionSummary]:
+        """Blog/email/slack from distribution_channels. Skip rows that duplicate OAuth providers."""
+        rows: List[ConnectionSummary] = []
+        coll = self.db["distribution_channels"]
+        async for doc in coll.find({"channel_type": {"$in": list(DIST_CHANNEL_TYPE_TO_PLATFORM.keys())}}):
+            underlying = doc.get("channel_type")
+            platform = DIST_CHANNEL_TYPE_TO_PLATFORM.get(underlying)
+            if not platform:
+                continue
+            channel_id = doc.get("channel_id") or str(doc.get("_id"))
+            caps = _capability_defaults(platform)
+            cfg = doc.get("config") or {}
+            rows.append(ConnectionSummary(
+                id=_prefix("outbound", channel_id),
+                platform=platform,
+                store="distribution_channels",
+                display_name=doc.get("name"),
+                connected=bool(doc.get("enabled", True)),
+                inbound_enabled=bool(doc.get("inbound_enabled", caps["inbound_enabled"])),
+                outbound_enabled=bool(doc.get("outbound_enabled", caps["outbound_enabled"])),
+                inbound_supported=False,
+                outbound_supported=True,
+                config_summary=self._outbound_summary(platform, cfg),
+                created_at=doc.get("created_at"),
+                updated_at=doc.get("updated_at"),
+            ))
+        return rows
+
+    @staticmethod
+    def _outbound_summary(platform: str, cfg: Dict[str, Any]) -> Dict[str, Any]:
+        if platform == "blog":
+            return {"cms_type": cfg.get("cms_type"), "api_url": cfg.get("api_url")}
+        if platform == "email":
+            return {"provider": cfg.get("provider"), "from_email": cfg.get("from_email")}
+        if platform == "slack_webhook":
+            return {"webhook_host": _webhook_host(cfg.get("webhook_url"))}
+        return {}
+
+    # ------------------------------------------------------------------
+    # GET single
+    # ------------------------------------------------------------------
+
+    async def get_connection(self, connection_id: str) -> Optional[ConnectionSummary]:
+        store, native = _unprefix(connection_id)
+        all_rows = await self.list_connections()
+        for row in all_rows:
+            if row.id == connection_id:
+                return row
+        return None
+
+    # ------------------------------------------------------------------
+    # PATCH capabilities
+    # ------------------------------------------------------------------
+
+    async def update_capabilities(
+        self,
+        connection_id: str,
+        update: CapabilityUpdate,
+    ) -> ConnectionSummary:
+        store, native = _unprefix(connection_id)
+        existing = await self.get_connection(connection_id)
+        if not existing:
+            raise HTTPException(404, f"Connection {connection_id} not found")
+
+        # Reject toggling a capability the platform doesn't support
+        if update.inbound_enabled is True and not existing.inbound_supported:
+            raise HTTPException(
+                422,
+                f"Platform {existing.platform} does not support inbound",
+            )
+        if update.outbound_enabled is True and not existing.outbound_supported:
+            raise HTTPException(
+                422,
+                f"Platform {existing.platform} does not support outbound",
+            )
+
+        set_fields: Dict[str, Any] = {"updated_at": datetime.utcnow().isoformat()}
+        if update.inbound_enabled is not None:
+            set_fields["inbound_enabled"] = update.inbound_enabled
+        if update.outbound_enabled is not None:
+            set_fields["outbound_enabled"] = update.outbound_enabled
+
+        if store == "oauth":
+            await self.db["oauth_connections"].update_one(
+                {"_id": native}, {"$set": set_fields}
+            )
+        elif store == "reddit":
+            await self.db["reddit_accounts"].update_one(
+                _by_id(native), {"$set": set_fields}
+            )
+        elif store == "twitter":
+            await self.db["twitter_accounts"].update_one(
+                _by_id(native), {"$set": set_fields}
+            )
+        elif store == "channel":
+            await self.db["channel_registrations"].update_one(
+                _by_id(native), {"$set": set_fields}
+            )
+        elif store == "outbound":
+            await self.db["distribution_channels"].update_one(
+                {"channel_id": native}, {"$set": set_fields}
+            )
+        else:
+            raise HTTPException(400, f"Unknown connection store: {store}")
+
+        refreshed = await self.get_connection(connection_id)
+        if not refreshed:
+            raise HTTPException(500, "Failed to re-read connection after update")
+        return refreshed
+
+    # ------------------------------------------------------------------
+    # Outbound CRUD (blog / email / slack_webhook)
+    # ------------------------------------------------------------------
+
+    async def create_outbound(
+        self,
+        req: OutboundConnectionCreate,
+        user_id: str,
+    ) -> ConnectionSummary:
+        if req.platform not in OUTBOUND_ONLY_PLATFORMS:
+            raise HTTPException(400, f"Platform {req.platform} is not outbound-only")
+
+        underlying = PLATFORM_TO_DIST_CHANNEL_TYPE[req.platform]
+        doc = await self.distribution.create_channel(
+            channel_type=underlying,
+            name=req.name,
+            config=req.config,
+            organization="solo",
+            created_by=user_id,
+        )
+        # Write capability defaults so reads are stable
+        await self.db["distribution_channels"].update_one(
+            {"channel_id": doc["channel_id"]},
+            {"$set": {
+                "inbound_enabled": False,
+                "outbound_enabled": True,
+                "enabled": req.enabled,
+            }},
+        )
+        summary = await self.get_connection(_prefix("outbound", doc["channel_id"]))
+        if not summary:
+            raise HTTPException(500, "Created outbound connection could not be read back")
+        return summary
+
+    async def update_outbound(
+        self,
+        connection_id: str,
+        update: OutboundConnectionUpdate,
+    ) -> ConnectionSummary:
+        store, native = _unprefix(connection_id)
+        if store != "outbound":
+            raise HTTPException(400, "Only outbound-only connections support this update")
+        set_fields: Dict[str, Any] = {}
+        if update.name is not None:
+            set_fields["name"] = update.name
+        if update.config is not None:
+            set_fields["config"] = update.config
+        if update.enabled is not None:
+            set_fields["enabled"] = update.enabled
+        set_fields["updated_at"] = datetime.utcnow().isoformat()
+        result = await self.db["distribution_channels"].update_one(
+            {"channel_id": native}, {"$set": set_fields}
+        )
+        if result.matched_count == 0:
+            raise HTTPException(404, f"Outbound connection {connection_id} not found")
+        summary = await self.get_connection(connection_id)
+        if not summary:
+            raise HTTPException(404, f"Outbound connection {connection_id} not found")
+        return summary
+
+    async def delete_outbound(self, connection_id: str) -> None:
+        store, native = _unprefix(connection_id)
+        if store != "outbound":
+            raise HTTPException(400, "Only outbound-only connections support delete via this endpoint")
+        deleted = await self.distribution.delete_channel(native)
+        if not deleted:
+            raise HTTPException(404, f"Outbound connection {connection_id} not found")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _by_id(native_id: str) -> Dict[str, Any]:
+    """SQLite adapter stores _id as str; return a single-key filter."""
+    return {"_id": native_id}
+
+
+def _iso(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def _webhook_host(url: Optional[str]) -> Optional[str]:
+    if not url:
+        return None
+    # Only expose the host — redact the token segment for privacy.
+    try:
+        from urllib.parse import urlparse
+        return urlparse(url).hostname
+    except Exception:
+        return None

--- a/backend/tests/test_connections_aggregator.py
+++ b/backend/tests/test_connections_aggregator.py
@@ -1,0 +1,213 @@
+"""Tests for Phase 3 PR 2 — unified connections aggregator."""
+
+import pytest
+import pytest_asyncio
+
+from services.connection_service import ConnectionService
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def svc(db_proxy):
+    return ConnectionService(db_proxy)
+
+
+async def _seed_oauth(db, provider: str, connected: bool = True):
+    doc = {"_id": provider, "client_id": "x", "client_secret": "y"}
+    if connected:
+        doc.update({"access_token": "tok", "profile_name": f"{provider}-user"})
+    await db["oauth_connections"].insert_one(doc)
+
+
+async def _seed_reddit(db, _id="r1"):
+    await db["reddit_accounts"].insert_one({
+        "_id": _id,
+        "client_id": "cid",
+        "client_secret": "csec",
+        "username": "u1",
+        "password": "p",
+        "subreddits": ["LocalLLaMA"],
+        "keywords": ["pricing", "demo"],
+    })
+
+
+async def _seed_twitter(db, _id="tw1", with_write=True):
+    doc = {
+        "_id": _id,
+        "user_id": "999",
+        "bearer_token": "bearer",
+    }
+    if with_write:
+        doc.update({
+            "api_key": "k",
+            "api_secret": "s",
+            "access_token": "a",
+            "access_token_secret": "b",
+        })
+    await db["twitter_accounts"].insert_one(doc)
+
+
+async def _seed_telegram(db, _id="tg1"):
+    await db["channel_registrations"].insert_one({
+        "_id": _id,
+        "channel_type": "telegram",
+        "config": {"bot_token": "123:abc", "bot_name": "MyBot"},
+    })
+
+
+# ---------------------------------------------------------------------------
+# LIST
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_list_is_empty_when_no_records(svc):
+    rows = await svc.list_connections()
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_list_merges_all_stores(svc, db_proxy):
+    await _seed_oauth(db_proxy, "linkedin")
+    await _seed_oauth(db_proxy, "instagram", connected=False)
+    await _seed_reddit(db_proxy)
+    await _seed_twitter(db_proxy)
+    await _seed_telegram(db_proxy)
+
+    rows = await svc.list_connections()
+    platforms = sorted(r.platform for r in rows)
+    assert platforms == ["instagram", "linkedin", "reddit", "telegram", "twitter"]
+
+    by_platform = {r.platform: r for r in rows}
+    assert by_platform["linkedin"].id == "oauth:linkedin"
+    assert by_platform["linkedin"].connected is True
+    assert by_platform["instagram"].connected is False
+    assert by_platform["reddit"].id.startswith("reddit:")
+    assert by_platform["twitter"].outbound_supported is True
+    assert by_platform["telegram"].display_name == "MyBot"
+
+
+@pytest.mark.asyncio
+async def test_twitter_without_write_creds_loses_outbound(svc, db_proxy):
+    await _seed_twitter(db_proxy, with_write=False)
+    rows = await svc.list_connections()
+    tw = next(r for r in rows if r.platform == "twitter")
+    assert tw.outbound_supported is False
+    assert tw.outbound_enabled is False
+
+
+# ---------------------------------------------------------------------------
+# Outbound CRUD (blog / email / slack_webhook)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_create_slack_webhook_outbound(svc):
+    from models.connection_models import OutboundConnectionCreate
+    created = await svc.create_outbound(
+        OutboundConnectionCreate(
+            platform="slack_webhook",
+            name="Team ops",
+            config={"webhook_url": "https://hooks.slack.com/services/TXXX/BXXX/xxx"},
+        ),
+        user_id="test-user",
+    )
+    assert created.platform == "slack_webhook"
+    assert created.id.startswith("outbound:")
+    assert created.outbound_enabled is True
+    assert created.inbound_enabled is False
+    assert created.inbound_supported is False
+    assert created.config_summary.get("webhook_host") == "hooks.slack.com"
+
+
+@pytest.mark.asyncio
+async def test_create_blog_rejects_missing_api_url(svc):
+    from pydantic import ValidationError
+    from models.connection_models import OutboundConnectionCreate
+    with pytest.raises(ValidationError):
+        OutboundConnectionCreate(
+            platform="blog",
+            name="My Blog",
+            config={"cms_type": "ghost"},  # missing api_url
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_email_rejects_missing_from_email(svc):
+    from pydantic import ValidationError
+    from models.connection_models import OutboundConnectionCreate
+    with pytest.raises(ValidationError):
+        OutboundConnectionCreate(
+            platform="email",
+            name="Mailer",
+            config={"provider": "sendgrid", "api_key": "sg-xxx"},  # missing from_email
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_and_delete_outbound(svc):
+    from models.connection_models import OutboundConnectionCreate, OutboundConnectionUpdate
+    created = await svc.create_outbound(
+        OutboundConnectionCreate(
+            platform="email",
+            name="Old",
+            config={"provider": "sendgrid", "api_key": "sg-xxx", "from_email": "a@b.c"},
+        ),
+        user_id="u1",
+    )
+    updated = await svc.update_outbound(
+        created.id, OutboundConnectionUpdate(name="Renamed")
+    )
+    assert updated.display_name == "Renamed"
+
+    await svc.delete_outbound(created.id)
+    assert await svc.get_connection(created.id) is None
+
+
+# ---------------------------------------------------------------------------
+# Capability PATCH
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_patch_capabilities_toggles_reddit(svc, db_proxy):
+    await _seed_reddit(db_proxy, _id="r1")
+    rows = await svc.list_connections()
+    reddit = next(r for r in rows if r.platform == "reddit")
+    assert reddit.inbound_enabled is True
+
+    from models.connection_models import CapabilityUpdate
+    updated = await svc.update_capabilities(reddit.id, CapabilityUpdate(inbound_enabled=False))
+    assert updated.inbound_enabled is False
+
+    raw = await db_proxy["reddit_accounts"].find_one({"_id": "r1"})
+    assert raw["inbound_enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_patch_rejects_enabling_unsupported_capability(svc, db_proxy):
+    # LinkedIn is outbound-supported but not inbound-supported
+    await _seed_oauth(db_proxy, "linkedin")
+
+    from fastapi import HTTPException
+    from models.connection_models import CapabilityUpdate
+    with pytest.raises(HTTPException) as exc:
+        await svc.update_capabilities("oauth:linkedin", CapabilityUpdate(inbound_enabled=True))
+    assert exc.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_patch_capabilities_rejects_empty_update():
+    from pydantic import ValidationError
+    from models.connection_models import CapabilityUpdate
+    with pytest.raises(ValidationError):
+        CapabilityUpdate()  # both None → invalid
+
+
+@pytest.mark.asyncio
+async def test_patch_unknown_connection_is_404(svc):
+    from fastapi import HTTPException
+    from models.connection_models import CapabilityUpdate
+    with pytest.raises(HTTPException) as exc:
+        await svc.update_capabilities("reddit:nonexistent", CapabilityUpdate(inbound_enabled=True))
+    assert exc.value.status_code == 404

--- a/frontend/src/components/crews/crew-builder.tsx
+++ b/frontend/src/components/crews/crew-builder.tsx
@@ -1,8 +1,18 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { cn } from "@/lib/utils";
-import { crewsApi, type CrewAgent, type LibraryAgent, type ChannelBinding } from "@/lib/api/crews-client";
+import {
+  crewsApi,
+  type CrewAgent,
+  type LibraryAgent,
+  type ChannelBinding,
+  type ConnectionBinding,
+  type CrewTrigger,
+} from "@/lib/api/crews-client";
+import {
+  connectionsApi,
+  type ConnectionSummary,
+} from "@/lib/api/connections-client";
 import { getModels, type ModelConfig } from "@/lib/api/models-client";
-import { getOAuthStatus } from "@/lib/api/oauth-client";
 import {
   BlueprintSelector,
   type BlueprintSelection,
@@ -31,24 +41,39 @@ import {
   Eye,
   Cable,
   MessageSquare,
-  Send,
   Cpu,
+  Bell,
+  Zap,
+  Calendar,
+  ArrowDownToLine,
+  ArrowUpFromLine,
 } from "lucide-react";
 
 type ExecutionMode = "sequential" | "parallel" | "pipeline" | "autonomous";
-type WizardStep = 1 | 2 | 3 | 4 | 5;
+type WizardStep = 1 | 2 | 3 | 4 | 5 | 6 | 7;
 
-// ---------------------------------------------------------------------------
-// Available connection types with metadata
-// ---------------------------------------------------------------------------
-const CONNECTION_TYPES = [
-  { id: "telegram", name: "Telegram", icon: "paper-plane", description: "Chat bot for Telegram groups and DMs", color: "bg-sky-500" },
-  { id: "discord", name: "Discord", icon: "gamepad", description: "Bot for Discord servers and channels", color: "bg-indigo-500" },
-  { id: "linkedin", name: "LinkedIn", icon: "briefcase", description: "Post content and engage on LinkedIn", color: "bg-blue-600" },
-  { id: "twitter", name: "Twitter / X", icon: "bird", description: "Post and engage on Twitter/X", color: "bg-neutral-800 dark:bg-neutral-600" },
-  { id: "instagram", name: "Instagram", icon: "camera", description: "Share content on Instagram", color: "bg-pink-500" },
-  { id: "facebook", name: "Facebook", icon: "thumbs-up", description: "Manage Facebook page content", color: "bg-blue-500" },
-] as const;
+type Direction = "inbound" | "outbound" | "both";
+
+interface ReactiveTriggerDraft {
+  id: string; // local-only, for list keying
+  connection_id: string;
+  keywords: string[];
+  hashtags: string[];
+  mentions: string[];
+}
+
+interface ScheduledTriggerDraft {
+  id: string;
+  mode: "cron" | "run_at";
+  cron: string;
+  run_at: string;
+  connection_ids: string[];
+  content_brief: string;
+}
+
+function _newId() {
+  return Math.random().toString(36).slice(2, 10);
+}
 
 interface AgentForm {
   name: string;
@@ -375,8 +400,10 @@ const STEP_TITLES: Record<WizardStep, { title: string; subtitle: string }> = {
   1: { title: "Crew Details", subtitle: "Name your crew and describe its purpose" },
   2: { title: "Execution Mode", subtitle: "Choose how agents collaborate" },
   3: { title: "Agent Team", subtitle: "Build your agent pipeline" },
-  4: { title: "Connections", subtitle: "Choose which channels this crew handles" },
-  5: { title: "Review & Create", subtitle: "Review your crew configuration" },
+  4: { title: "Connections & Directions", subtitle: "Pick the tools this crew uses and what direction each goes" },
+  5: { title: "Trigger", subtitle: "How should this crew fire — reactive, scheduled, or manual only?" },
+  6: { title: "Approval", subtitle: "Review outbound before it's sent?" },
+  7: { title: "Review & Create", subtitle: "Review your crew configuration" },
 };
 
 // ---------------------------------------------------------------------------
@@ -394,6 +421,9 @@ interface CrewBuilderProps {
     execution_config?: { mode: ExecutionMode; max_agent_invocations?: number; budget_limit_usd?: number };
     agents?: CrewAgent[];
     channel_bindings?: ChannelBinding[];
+    connection_bindings?: ConnectionBinding[];
+    triggers?: CrewTrigger[];
+    approval_required?: boolean;
   };
 }
 
@@ -422,6 +452,43 @@ export function CrewBuilder({ open, onClose, onCreated, editCrew }: CrewBuilderP
   const [channelBindings, setChannelBindings] = useState<ChannelBinding[]>(
     editCrew?.channel_bindings ?? []
   );
+
+  // Phase 3: connection_bindings, triggers, approval_required
+  const [availableConnections, setAvailableConnections] = useState<ConnectionSummary[]>([]);
+  const [connectionBindings, setConnectionBindings] = useState<ConnectionBinding[]>(
+    editCrew?.connection_bindings ?? []
+  );
+  const [reactiveTriggers, setReactiveTriggers] = useState<ReactiveTriggerDraft[]>(
+    (editCrew?.triggers ?? [])
+      .filter((t): t is Extract<CrewTrigger, { type: "reactive" }> => t.type === "reactive")
+      .map((t) => ({
+        id: _newId(),
+        connection_id: t.connection_id,
+        keywords: t.keywords ?? [],
+        hashtags: t.hashtags ?? [],
+        mentions: t.mentions ?? [],
+      }))
+  );
+  const [scheduledTriggers, setScheduledTriggers] = useState<ScheduledTriggerDraft[]>(
+    (editCrew?.triggers ?? [])
+      .filter((t): t is Extract<CrewTrigger, { type: "scheduled" }> => t.type === "scheduled")
+      .map((t) => ({
+        id: _newId(),
+        mode: t.cron ? "cron" : "run_at",
+        cron: t.cron ?? "",
+        run_at: t.run_at ?? "",
+        connection_ids: t.connection_ids ?? [],
+        content_brief: t.content_brief ?? "",
+      }))
+  );
+  const [approvalRequired, setApprovalRequired] = useState<boolean>(
+    editCrew?.approval_required ?? false
+  );
+  const [capabilityModal, setCapabilityModal] = useState<{
+    connection: ConnectionSummary;
+    direction: Direction;
+  } | null>(null);
+
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [libraryOpen, setLibraryOpen] = useState(false);
@@ -431,18 +498,8 @@ export function CrewBuilder({ open, onClose, onCreated, editCrew }: CrewBuilderP
   const [selectedModelId, setSelectedModelId] = useState<string | null>(
     editCrew?.agents?.[0]?.model_id ?? null
   );
-  const [oauthConnected, setOauthConnected] = useState<Record<string, boolean>>({});
-
-  // Check OAuth connection status for OAuth-based channels
-  const OAUTH_CHANNELS = ["linkedin", "instagram", "facebook"] as const;
-  useEffect(() => {
-    if (!open) return;
-    for (const provider of OAUTH_CHANNELS) {
-      getOAuthStatus(provider)
-        .then((s) => setOauthConnected((prev) => ({ ...prev, [provider]: s.connected })))
-        .catch(() => setOauthConnected((prev) => ({ ...prev, [provider]: false })));
-    }
-  }, [open]);
+  // Legacy OAuth-status polling is no longer needed — the unified
+  // /api/v1/connections aggregator returns connection state directly.
 
   // Fetch available models when dialog opens
   useEffect(() => {
@@ -454,6 +511,18 @@ export function CrewBuilder({ open, onClose, onCreated, editCrew }: CrewBuilderP
         .catch(() => setModels([]));
     }
   }, [open]);
+
+  // Fetch unified connections on open (Phase 3)
+  const refreshConnections = useCallback(() => {
+    connectionsApi
+      .list()
+      .then(setAvailableConnections)
+      .catch(() => setAvailableConnections([]));
+  }, []);
+
+  useEffect(() => {
+    if (open) refreshConnections();
+  }, [open, refreshConnections]);
 
   // Reset on open
   useEffect(() => {
@@ -467,6 +536,10 @@ export function CrewBuilder({ open, onClose, onCreated, editCrew }: CrewBuilderP
         setMaxInvocations(10);
         setBudgetLimit(1.0);
         setChannelBindings([]);
+        setConnectionBindings([]);
+        setReactiveTriggers([]);
+        setScheduledTriggers([]);
+        setApprovalRequired(false);
         setSelectedBlueprint(null);
         setSelectedModelId(null);
         setError(null);
@@ -498,15 +571,30 @@ export function CrewBuilder({ open, onClose, onCreated, editCrew }: CrewBuilderP
       case 1: return !!name.trim();
       case 2: return true; // always valid, mode has a default
       case 3: return isAutonomous || agents.every((a) => a.name.trim() && a.instructions.trim());
-      case 4: return true; // connections are optional
-      case 5: return !!canSubmit;
+      case 4: return true; // connections are optional — manual-only is supported
+      case 5: {
+        // Reactive: each draft needs ≥1 keyword/hashtag/mention.
+        for (const t of reactiveTriggers) {
+          if (!t.connection_id) return false;
+          if (t.keywords.length + t.hashtags.length + t.mentions.length === 0) return false;
+        }
+        // Scheduled: exactly one of cron/run_at.
+        for (const t of scheduledTriggers) {
+          if (t.mode === "cron" && !t.cron.trim()) return false;
+          if (t.mode === "run_at" && !t.run_at.trim()) return false;
+        }
+        return true;
+      }
+      case 6: return true; // approval toggle always valid
+      case 7: return !!canSubmit;
       default: return false;
     }
   };
 
-  // Steps: 1-Details, 2-Mode, 3-Agents (skip if autonomous), 4-Connections, 5-Review
-  const totalSteps = isAutonomous ? 4 : 5;
-  const maxStep = (isAutonomous ? 4 : 5) as WizardStep;
+  // Steps: 1-Details, 2-Mode, 3-Agents (skip if autonomous), 4-Connections,
+  // 5-Trigger, 6-Approval, 7-Review. Autonomous collapses 7→6 visual steps.
+  const totalSteps = isAutonomous ? 6 : 7;
+  const maxStep = 7 as WizardStep;
 
   function nextStep() {
     if (step === 2 && isAutonomous) {
@@ -524,23 +612,122 @@ export function CrewBuilder({ open, onClose, onCreated, editCrew }: CrewBuilderP
     }
   }
 
-  // Toggle a channel binding
-  function toggleChannel(channelType: string) {
-    setChannelBindings((prev) => {
-      const existing = prev.find((b) => b.channel_type === channelType);
-      if (existing) {
-        return prev.filter((b) => b.channel_type !== channelType);
-      }
-      return [...prev, { channel_type: channelType, enabled: true, approval_required: false }];
+  // --- Phase 3 connection binding helpers ---
+
+  function hasBinding(connId: string) {
+    return connectionBindings.some((b) => b.connection_id === connId);
+  }
+
+  function getBindingDirection(connId: string): Direction | null {
+    return connectionBindings.find((b) => b.connection_id === connId)?.direction ?? null;
+  }
+
+  function addBinding(conn: ConnectionSummary, direction: Direction) {
+    setConnectionBindings((prev) => {
+      const filtered = prev.filter((b) => b.connection_id !== conn.id);
+      return [
+        ...filtered,
+        { connection_id: conn.id, platform: conn.platform, direction },
+      ];
     });
   }
 
-  function toggleChannelApproval(channelType: string) {
-    setChannelBindings((prev) =>
-      prev.map((b) =>
-        b.channel_type === channelType ? { ...b, approval_required: !b.approval_required } : b
-      )
+  function removeBinding(connId: string) {
+    setConnectionBindings((prev) => prev.filter((b) => b.connection_id !== connId));
+    // Also drop any reactive triggers tied to this connection.
+    setReactiveTriggers((prev) => prev.filter((t) => t.connection_id !== connId));
+  }
+
+  function handleDirectionPick(conn: ConnectionSummary, direction: Direction) {
+    // Block directions the platform doesn't physically support.
+    if (direction === "inbound" && !conn.inbound_supported) return;
+    if (direction === "outbound" && !conn.outbound_supported) return;
+
+    // If the user picked a direction that's disabled at the connection-level,
+    // open the inline modal to offer enabling it.
+    const capability = direction === "inbound"
+      ? conn.inbound_enabled
+      : direction === "outbound"
+        ? conn.outbound_enabled
+        : (conn.inbound_enabled && conn.outbound_enabled);
+    if (!capability) {
+      setCapabilityModal({ connection: conn, direction });
+      return;
+    }
+    addBinding(conn, direction);
+  }
+
+  async function enableCapabilityAndContinue() {
+    if (!capabilityModal) return;
+    const { connection, direction } = capabilityModal;
+    const update: { inbound_enabled?: boolean; outbound_enabled?: boolean } = {};
+    if (direction === "inbound") update.inbound_enabled = true;
+    else if (direction === "outbound") update.outbound_enabled = true;
+    else {
+      update.inbound_enabled = true;
+      update.outbound_enabled = true;
+    }
+    try {
+      await connectionsApi.updateCapabilities(connection.id, update);
+      refreshConnections();
+      addBinding(connection, direction);
+    } catch (e) {
+      console.error("Failed to enable capability", e);
+    } finally {
+      setCapabilityModal(null);
+    }
+  }
+
+  // --- Reactive trigger helpers ---
+
+  function addReactiveTrigger(connectionId: string) {
+    setReactiveTriggers((prev) => [
+      ...prev,
+      { id: _newId(), connection_id: connectionId, keywords: [], hashtags: [], mentions: [] },
+    ]);
+  }
+
+  function removeReactiveTrigger(id: string) {
+    setReactiveTriggers((prev) => prev.filter((t) => t.id !== id));
+  }
+
+  function addRuleToReactive(
+    id: string,
+    field: "keywords" | "hashtags" | "mentions",
+    value: string,
+  ) {
+    const v = value.trim();
+    if (!v) return;
+    setReactiveTriggers((prev) =>
+      prev.map((t) => (t.id === id ? { ...t, [field]: Array.from(new Set([...t[field], v])) } : t))
     );
+  }
+
+  function removeRuleFromReactive(
+    id: string,
+    field: "keywords" | "hashtags" | "mentions",
+    value: string,
+  ) {
+    setReactiveTriggers((prev) =>
+      prev.map((t) => (t.id === id ? { ...t, [field]: t[field].filter((x) => x !== value) } : t))
+    );
+  }
+
+  // --- Scheduled trigger helpers ---
+
+  function addScheduledTrigger() {
+    setScheduledTriggers((prev) => [
+      ...prev,
+      { id: _newId(), mode: "cron", cron: "0 9 * * *", run_at: "", connection_ids: [], content_brief: "" },
+    ]);
+  }
+
+  function updateScheduledTrigger(id: string, patch: Partial<ScheduledTriggerDraft>) {
+    setScheduledTriggers((prev) => prev.map((t) => (t.id === id ? { ...t, ...patch } : t)));
+  }
+
+  function removeScheduledTrigger(id: string) {
+    setScheduledTriggers((prev) => prev.filter((t) => t.id !== id));
   }
 
   const updateAgent = (index: number, field: keyof AgentForm, value: string) => {
@@ -600,6 +787,42 @@ export function CrewBuilder({ open, onClose, onCreated, editCrew }: CrewBuilderP
         payload.channel_bindings = channelBindings;
       }
 
+      // Phase 3 additions
+      if (connectionBindings.length > 0) {
+        payload.connection_bindings = connectionBindings;
+      }
+      const triggers: CrewTrigger[] = [];
+      for (const t of reactiveTriggers) {
+        triggers.push({
+          type: "reactive",
+          connection_id: t.connection_id,
+          keywords: t.keywords,
+          hashtags: t.hashtags,
+          mentions: t.mentions,
+        });
+      }
+      for (const t of scheduledTriggers) {
+        triggers.push(
+          t.mode === "cron"
+            ? {
+                type: "scheduled",
+                connection_ids: t.connection_ids,
+                cron: t.cron,
+                content_brief: t.content_brief || undefined,
+              }
+            : {
+                type: "scheduled",
+                connection_ids: t.connection_ids,
+                run_at: t.run_at,
+                content_brief: t.content_brief || undefined,
+              }
+        );
+      }
+      if (triggers.length > 0) {
+        payload.triggers = triggers;
+      }
+      payload.approval_required = approvalRequired;
+
       if (isEdit && editCrew) {
         await crewsApi.update(editCrew.crew_id, payload);
       } else {
@@ -624,8 +847,8 @@ export function CrewBuilder({ open, onClose, onCreated, editCrew }: CrewBuilderP
 
   if (!open) return null;
 
-  // For step indicator display: map to visual step number
-  // Autonomous skips step 3 (agents), so steps 4,5 become visual 3,4
+  // For step indicator display: map to visual step number.
+  // Autonomous skips step 3 (agents), so steps 4..7 each shift down by 1 visually.
   const visualStep = isAutonomous && step >= 4 ? step - 1 : step;
 
   return (
@@ -1019,125 +1242,342 @@ export function CrewBuilder({ open, onClose, onCreated, editCrew }: CrewBuilderP
             </div>
           )}
 
-          {/* ─── Step 4: Connections ─── */}
+          {/* ─── Step 4: Connections & Directions ─── */}
           {step === 4 && (
             <div className="space-y-4">
-              <div className="bg-neutral-50 dark:bg-neutral-800/50 rounded-xl border border-neutral-200 dark:border-neutral-700 p-5 space-y-4">
+              <div className="bg-neutral-50 dark:bg-neutral-800/50 rounded-xl border border-neutral-200 dark:border-neutral-700 p-5 space-y-3">
                 <h3 className="text-sm font-medium text-neutral-900 dark:text-white flex items-center gap-2">
                   <Cable className="w-4 h-4 text-primary-500" />
-                  Channel Connections
+                  Pick connections & direction
                 </h3>
-                <p className="text-xs text-neutral-500 dark:text-neutral-400 -mt-2">
-                  Select which social channels this crew should handle. The crew will process
-                  inbound messages and can publish content to these platforms.
+                <p className="text-xs text-neutral-500 dark:text-neutral-400">
+                  Choose which tools this crew uses. For each, pick a direction: <b>Inbound</b> (listen for messages), <b>Outbound</b> (publish), or <b>Both</b>. Outbound-only platforms (Blog / Email / Slack webhook) are publish-only.
                 </p>
 
-                <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-                  {CONNECTION_TYPES.map((conn) => {
-                    const isSelected = channelBindings.some((b) => b.channel_type === conn.id);
-                    const binding = channelBindings.find((b) => b.channel_type === conn.id);
-                    const isOAuth = OAUTH_CHANNELS.includes(conn.id as typeof OAUTH_CHANNELS[number]);
-                    const isConnected = isOAuth ? oauthConnected[conn.id] : true;
-                    return (
-                      <div
-                        key={conn.id}
-                        className={cn(
-                          "relative rounded-xl border-2 transition-all overflow-hidden",
-                          isSelected
-                            ? "border-primary-500 bg-primary-50/50 dark:bg-primary-500/5"
-                            : "border-neutral-200 dark:border-neutral-700 hover:border-neutral-300 dark:hover:border-neutral-600"
-                        )}
-                      >
-                        <button
-                          type="button"
-                          onClick={() => toggleChannel(conn.id)}
-                          className="w-full p-4 text-left"
-                        >
-                          <div className="flex items-center gap-3 mb-2">
-                            <div className={cn("w-8 h-8 rounded-lg flex items-center justify-center text-white", conn.color)}>
-                              <MessageSquare className="w-4 h-4" />
-                            </div>
-                            <div className="flex-1 min-w-0">
-                              <p className="text-sm font-medium text-neutral-900 dark:text-white">
-                                {conn.name}
-                              </p>
-                              {isOAuth && !isConnected && (
-                                <p className="text-[10px] text-amber-600 dark:text-amber-400 flex items-center gap-1">
-                                  <AlertCircle className="w-3 h-3" /> Not connected
-                                </p>
-                              )}
-                              {isOAuth && isConnected && (
-                                <p className="text-[10px] text-green-600 dark:text-green-400">Connected</p>
-                              )}
-                            </div>
-                            {isSelected && (
-                              <div className="w-5 h-5 rounded-full bg-primary-500 flex items-center justify-center flex-shrink-0">
-                                <Check className="w-3 h-3 text-white" />
-                              </div>
-                            )}
-                          </div>
-                          <p className="text-[11px] text-neutral-500 dark:text-neutral-400 line-clamp-2">
-                            {conn.description}
-                          </p>
-                        </button>
-
-                        {/* Approval toggle (shown when selected) */}
-                        {isSelected && (
-                          <div className="px-4 pb-3 pt-0">
-                            <label className="flex items-center gap-2 text-xs text-neutral-600 dark:text-neutral-400 cursor-pointer">
-                              <input
-                                type="checkbox"
-                                checked={binding?.approval_required ?? false}
-                                onChange={() => toggleChannelApproval(conn.id)}
-                                className="rounded border-neutral-300 dark:border-neutral-600 text-primary-500 focus:ring-primary-500/50 w-3.5 h-3.5"
-                              />
-                              Require approval before sending
-                            </label>
-                          </div>
-                        )}
-                      </div>
-                    );
-                  })}
-                </div>
-
-                {channelBindings.length === 0 && (
+                {availableConnections.length === 0 ? (
                   <p className="text-xs text-neutral-400 dark:text-neutral-500 italic">
-                    No channels selected. You can add connections later from the crew settings.
+                    No connections set up yet. Add one from <a href="/connections" className="underline text-primary-500">Connections</a> and come back.
+                  </p>
+                ) : (
+                  <div className="space-y-2">
+                    {availableConnections.map((conn) => {
+                      const current = getBindingDirection(conn.id);
+                      const selected = hasBinding(conn.id);
+                      return (
+                        <div
+                          key={conn.id}
+                          className={cn(
+                            "rounded-xl border-2 p-3 transition-colors",
+                            selected
+                              ? "border-primary-500 bg-primary-50/50 dark:bg-primary-500/5"
+                              : "border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800/50"
+                          )}
+                        >
+                          <div className="flex items-center justify-between gap-3 flex-wrap">
+                            <div className="flex items-center gap-2 min-w-0">
+                              <div className="w-8 h-8 rounded-lg flex items-center justify-center bg-neutral-100 dark:bg-neutral-700">
+                                <MessageSquare className="w-4 h-4 text-neutral-600 dark:text-neutral-300" />
+                              </div>
+                              <div className="min-w-0">
+                                <p className="text-sm font-medium text-neutral-900 dark:text-white truncate">
+                                  {conn.display_name ?? conn.platform}
+                                </p>
+                                <p className="text-[10px] text-neutral-500 dark:text-neutral-400">
+                                  {conn.platform}
+                                  {!conn.connected && <span className="ml-1 text-amber-500">• disconnected</span>}
+                                </p>
+                              </div>
+                            </div>
+                            <div className="flex items-center gap-1">
+                              <DirectionChip
+                                label="Inbound"
+                                icon={ArrowDownToLine}
+                                active={current === "inbound"}
+                                disabled={!conn.inbound_supported}
+                                onClick={() => handleDirectionPick(conn, "inbound")}
+                              />
+                              <DirectionChip
+                                label="Outbound"
+                                icon={ArrowUpFromLine}
+                                active={current === "outbound"}
+                                disabled={!conn.outbound_supported}
+                                onClick={() => handleDirectionPick(conn, "outbound")}
+                              />
+                              <DirectionChip
+                                label="Both"
+                                icon={ArrowRightLeft}
+                                active={current === "both"}
+                                disabled={!conn.inbound_supported || !conn.outbound_supported}
+                                onClick={() => handleDirectionPick(conn, "both")}
+                              />
+                              {selected && (
+                                <button
+                                  type="button"
+                                  onClick={() => removeBinding(conn.id)}
+                                  className="ml-1 p-1 rounded text-neutral-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20"
+                                  title="Remove binding"
+                                >
+                                  <X className="w-3.5 h-3.5" />
+                                </button>
+                              )}
+                            </div>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+
+                {connectionBindings.length === 0 && (
+                  <p className="text-xs text-neutral-400 dark:text-neutral-500 italic">
+                    No connections selected. This crew will run manually only (the Run button on the crew card).
                   </p>
                 )}
               </div>
 
-              {channelBindings.length > 0 && (
-                <div className="bg-neutral-50 dark:bg-neutral-800/50 rounded-xl border border-neutral-200 dark:border-neutral-700 p-4">
-                  <div className="flex items-center gap-2 mb-2">
-                    <Send className="w-3.5 h-3.5 text-primary-500" />
-                    <span className="text-xs font-medium text-neutral-700 dark:text-neutral-300">
-                      {channelBindings.length} channel{channelBindings.length !== 1 ? "s" : ""} selected
-                    </span>
-                  </div>
-                  <div className="flex flex-wrap gap-2">
-                    {channelBindings.map((b) => {
-                      const conn = CONNECTION_TYPES.find((c) => c.id === b.channel_type);
-                      return (
-                        <span
-                          key={b.channel_type}
-                          className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium bg-primary-100 dark:bg-primary-500/20 text-primary-700 dark:text-primary-300 border border-primary-200 dark:border-primary-800"
-                        >
-                          {conn?.name ?? b.channel_type}
-                          {b.approval_required && (
-                            <Shield className="w-3 h-3 text-amber-500" />
-                          )}
-                        </span>
-                      );
-                    })}
+              {/* Enable-capability inline modal */}
+              {capabilityModal && (
+                <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50 backdrop-blur-sm">
+                  <div className="bg-white dark:bg-neutral-900 rounded-xl border border-neutral-200 dark:border-neutral-700 p-5 max-w-md mx-4 shadow-xl">
+                    <div className="flex items-center gap-2 mb-3">
+                      <AlertCircle className="w-5 h-5 text-amber-500" />
+                      <h4 className="text-sm font-semibold text-neutral-900 dark:text-white">
+                        Capability disabled
+                      </h4>
+                    </div>
+                    <p className="text-sm text-neutral-600 dark:text-neutral-400 mb-4">
+                      <b className="capitalize">{capabilityModal.direction}</b> is currently disabled on{" "}
+                      <b>{capabilityModal.connection.display_name ?? capabilityModal.connection.platform}</b>.
+                      Enable it now so this crew can use it?
+                    </p>
+                    <div className="flex items-center justify-end gap-2">
+                      <button
+                        type="button"
+                        onClick={() => setCapabilityModal(null)}
+                        className="px-3 py-1.5 rounded-lg text-sm font-medium text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-800"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        type="button"
+                        onClick={enableCapabilityAndContinue}
+                        className="px-3 py-1.5 rounded-lg text-sm font-medium bg-primary-500 text-white hover:bg-primary-600"
+                      >
+                        Enable & continue
+                      </button>
+                    </div>
                   </div>
                 </div>
               )}
             </div>
           )}
 
-          {/* ─── Step 5: Review ─── */}
+          {/* ─── Step 5: Trigger ─── */}
           {step === 5 && (
+            <div className="space-y-4">
+              <div className="bg-neutral-50 dark:bg-neutral-800/50 rounded-xl border border-neutral-200 dark:border-neutral-700 p-5 space-y-4">
+                <h3 className="text-sm font-medium text-neutral-900 dark:text-white flex items-center gap-2">
+                  <Zap className="w-4 h-4 text-primary-500" />
+                  Reactive triggers
+                </h3>
+                <p className="text-xs text-neutral-500 dark:text-neutral-400 -mt-2">
+                  Fire this crew when an inbound message matches any keyword, hashtag, or @mention.
+                </p>
+                {reactiveTriggers.length === 0 && connectionBindings.filter((b) => b.direction === "inbound" || b.direction === "both").length === 0 && (
+                  <p className="text-xs text-neutral-400 dark:text-neutral-500 italic">
+                    Bind at least one inbound connection on the previous step to enable reactive triggers.
+                  </p>
+                )}
+                <div className="space-y-3">
+                  {reactiveTriggers.map((trigger) => {
+                    const conn = availableConnections.find((c) => c.id === trigger.connection_id);
+                    return (
+                      <div key={trigger.id} className="rounded-lg border border-neutral-200 dark:border-neutral-700 p-3 bg-white dark:bg-neutral-800 space-y-2">
+                        <div className="flex items-center justify-between">
+                          <div className="flex items-center gap-2">
+                            <ArrowDownToLine className="w-3.5 h-3.5 text-primary-500" />
+                            <span className="text-sm font-medium text-neutral-900 dark:text-white">
+                              {conn?.display_name ?? conn?.platform ?? trigger.connection_id}
+                            </span>
+                          </div>
+                          <button
+                            type="button"
+                            onClick={() => removeReactiveTrigger(trigger.id)}
+                            className="text-neutral-400 hover:text-red-500"
+                          >
+                            <Trash2 className="w-3.5 h-3.5" />
+                          </button>
+                        </div>
+                        <RuleChips
+                          label="Keywords"
+                          values={trigger.keywords}
+                          onAdd={(v) => addRuleToReactive(trigger.id, "keywords", v)}
+                          onRemove={(v) => removeRuleFromReactive(trigger.id, "keywords", v)}
+                        />
+                        <RuleChips
+                          label="Hashtags"
+                          values={trigger.hashtags}
+                          placeholderPrefix="#"
+                          onAdd={(v) => addRuleToReactive(trigger.id, "hashtags", v)}
+                          onRemove={(v) => removeRuleFromReactive(trigger.id, "hashtags", v)}
+                        />
+                        <RuleChips
+                          label="Mentions"
+                          values={trigger.mentions}
+                          placeholderPrefix="@"
+                          onAdd={(v) => addRuleToReactive(trigger.id, "mentions", v)}
+                          onRemove={(v) => removeRuleFromReactive(trigger.id, "mentions", v)}
+                        />
+                        {trigger.keywords.length + trigger.hashtags.length + trigger.mentions.length === 0 && (
+                          <p className="text-[11px] text-red-500">
+                            Add at least one keyword, hashtag, or mention.
+                          </p>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {connectionBindings
+                    .filter((b) => b.direction === "inbound" || b.direction === "both")
+                    .map((b) => {
+                      const conn = availableConnections.find((c) => c.id === b.connection_id);
+                      return (
+                        <button
+                          key={b.connection_id}
+                          type="button"
+                          onClick={() => addReactiveTrigger(b.connection_id)}
+                          className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full border border-dashed border-neutral-300 dark:border-neutral-600 text-xs text-neutral-600 dark:text-neutral-300 hover:border-primary-500 hover:text-primary-500"
+                        >
+                          <Plus className="w-3 h-3" />
+                          {conn?.display_name ?? conn?.platform ?? b.connection_id}
+                        </button>
+                      );
+                    })}
+                </div>
+              </div>
+
+              <div className="bg-neutral-50 dark:bg-neutral-800/50 rounded-xl border border-neutral-200 dark:border-neutral-700 p-5 space-y-3">
+                <div className="flex items-center justify-between">
+                  <h3 className="text-sm font-medium text-neutral-900 dark:text-white flex items-center gap-2">
+                    <Calendar className="w-4 h-4 text-primary-500" />
+                    Scheduled triggers
+                  </h3>
+                  <button
+                    type="button"
+                    onClick={addScheduledTrigger}
+                    className="inline-flex items-center gap-1 text-xs text-primary-500 hover:text-primary-600"
+                  >
+                    <Plus className="w-3 h-3" />
+                    Add schedule
+                  </button>
+                </div>
+                <p className="text-xs text-neutral-500 dark:text-neutral-400 -mt-1">
+                  Fire on a cron schedule (recurring) or a specific datetime (one-shot).
+                </p>
+                {scheduledTriggers.length === 0 && (
+                  <p className="text-xs text-neutral-400 dark:text-neutral-500 italic">
+                    No schedules set. Add one if you want this crew to fire automatically on a timer.
+                  </p>
+                )}
+                <div className="space-y-3">
+                  {scheduledTriggers.map((trigger) => (
+                    <div key={trigger.id} className="rounded-lg border border-neutral-200 dark:border-neutral-700 p-3 bg-white dark:bg-neutral-800 space-y-2">
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2 text-xs">
+                          <label className="inline-flex items-center gap-1 cursor-pointer">
+                            <input
+                              type="radio"
+                              name={`mode-${trigger.id}`}
+                              checked={trigger.mode === "cron"}
+                              onChange={() => updateScheduledTrigger(trigger.id, { mode: "cron" })}
+                            />
+                            Recurring (cron)
+                          </label>
+                          <label className="inline-flex items-center gap-1 cursor-pointer ml-2">
+                            <input
+                              type="radio"
+                              name={`mode-${trigger.id}`}
+                              checked={trigger.mode === "run_at"}
+                              onChange={() => updateScheduledTrigger(trigger.id, { mode: "run_at" })}
+                            />
+                            One-shot
+                          </label>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => removeScheduledTrigger(trigger.id)}
+                          className="text-neutral-400 hover:text-red-500"
+                        >
+                          <Trash2 className="w-3.5 h-3.5" />
+                        </button>
+                      </div>
+                      {trigger.mode === "cron" ? (
+                        <input
+                          type="text"
+                          value={trigger.cron}
+                          onChange={(e) => updateScheduledTrigger(trigger.id, { cron: e.target.value })}
+                          placeholder="0 9 * * *"
+                          className="w-full px-2.5 py-1.5 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-white text-xs font-mono"
+                        />
+                      ) : (
+                        <input
+                          type="datetime-local"
+                          value={trigger.run_at}
+                          onChange={(e) => updateScheduledTrigger(trigger.id, { run_at: e.target.value })}
+                          className="w-full px-2.5 py-1.5 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-white text-xs"
+                        />
+                      )}
+                      <textarea
+                        value={trigger.content_brief}
+                        onChange={(e) => updateScheduledTrigger(trigger.id, { content_brief: e.target.value })}
+                        placeholder="What should this crew produce? (optional)"
+                        rows={2}
+                        className="w-full px-2.5 py-1.5 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-white text-xs resize-none"
+                      />
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {reactiveTriggers.length === 0 && scheduledTriggers.length === 0 && (
+                <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-xl p-3 text-xs text-amber-800 dark:text-amber-300">
+                  No triggers configured — this crew will only fire when you click <b>Run</b> on its card.
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* ─── Step 6: Approval ─── */}
+          {step === 6 && (
+            <div className="space-y-4">
+              <div className="bg-neutral-50 dark:bg-neutral-800/50 rounded-xl border border-neutral-200 dark:border-neutral-700 p-5 space-y-3">
+                <h3 className="text-sm font-medium text-neutral-900 dark:text-white flex items-center gap-2">
+                  <Bell className="w-4 h-4 text-primary-500" />
+                  Approval
+                </h3>
+                <label className="flex items-start gap-3 cursor-pointer p-3 rounded-lg bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700">
+                  <input
+                    type="checkbox"
+                    checked={approvalRequired}
+                    onChange={(e) => setApprovalRequired(e.target.checked)}
+                    className="mt-0.5 rounded border-neutral-300 dark:border-neutral-600 text-primary-500 focus:ring-primary-500/50 w-4 h-4"
+                  />
+                  <div>
+                    <p className="text-sm font-medium text-neutral-900 dark:text-white">
+                      Review outbound before sending
+                    </p>
+                    <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-0.5">
+                      When on, this crew's output is queued in the <a href="/approvals" className="underline text-primary-500">Approvals</a> page instead of publishing immediately. You edit / approve / reject there before it goes out.
+                    </p>
+                  </div>
+                </label>
+              </div>
+            </div>
+          )}
+
+          {/* ─── Step 7: Review ─── */}
+          {step === 7 && (
             <div className="space-y-4">
               <div className="bg-neutral-50 dark:bg-neutral-800/50 rounded-xl border border-neutral-200 dark:border-neutral-700 p-5 space-y-3">
                 <h3 className="text-sm font-medium text-neutral-900 dark:text-white flex items-center gap-2">
@@ -1248,34 +1688,91 @@ export function CrewBuilder({ open, onClose, onCreated, editCrew }: CrewBuilderP
                 </div>
               )}
 
-              {/* Connections summary */}
-              {channelBindings.length > 0 && (
+              {/* Connections & Directions summary */}
+              {connectionBindings.length > 0 && (
                 <div className="bg-neutral-50 dark:bg-neutral-800/50 rounded-xl border border-neutral-200 dark:border-neutral-700 p-5 space-y-3">
                   <h3 className="text-sm font-medium text-neutral-900 dark:text-white flex items-center gap-2">
                     <Cable className="w-4 h-4 text-primary-500" />
-                    Connections ({channelBindings.length})
+                    Connections & Directions ({connectionBindings.length})
                   </h3>
                   <div className="flex flex-wrap gap-2">
-                    {channelBindings.map((b) => {
-                      const conn = CONNECTION_TYPES.find((c) => c.id === b.channel_type);
+                    {connectionBindings.map((b) => {
+                      const conn = availableConnections.find((c) => c.id === b.connection_id);
+                      const dirLabel = b.direction === "both" ? "Both" : b.direction === "inbound" ? "Inbound" : "Outbound";
+                      const DirIcon = b.direction === "both" ? ArrowRightLeft : b.direction === "inbound" ? ArrowDownToLine : ArrowUpFromLine;
                       return (
                         <span
-                          key={b.channel_type}
+                          key={b.connection_id}
                           className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 text-neutral-700 dark:text-neutral-300"
                         >
-                          <div className={cn("w-4 h-4 rounded flex items-center justify-center text-white", conn?.color ?? "bg-neutral-500")}>
-                            <MessageSquare className="w-2.5 h-2.5" />
-                          </div>
-                          {conn?.name ?? b.channel_type}
-                          {b.approval_required && (
-                            <span className="text-[10px] text-amber-500 font-medium">(approval)</span>
-                          )}
+                          {conn?.display_name ?? conn?.platform ?? b.platform}
+                          <span className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded bg-primary-100 dark:bg-primary-500/20 text-primary-700 dark:text-primary-300">
+                            <DirIcon className="w-2.5 h-2.5" />
+                            {dirLabel}
+                          </span>
                         </span>
                       );
                     })}
                   </div>
                 </div>
               )}
+
+              {/* Triggers summary */}
+              <div className="bg-neutral-50 dark:bg-neutral-800/50 rounded-xl border border-neutral-200 dark:border-neutral-700 p-5 space-y-3">
+                <h3 className="text-sm font-medium text-neutral-900 dark:text-white flex items-center gap-2">
+                  <Zap className="w-4 h-4 text-primary-500" />
+                  Triggers
+                </h3>
+                {reactiveTriggers.length === 0 && scheduledTriggers.length === 0 ? (
+                  <p className="text-xs text-neutral-500 dark:text-neutral-400 italic">
+                    Manual only — fires when you click Run on the crew card.
+                  </p>
+                ) : (
+                  <div className="space-y-2 text-xs">
+                    {reactiveTriggers.map((t) => {
+                      const conn = availableConnections.find((c) => c.id === t.connection_id);
+                      const rules = [...t.keywords, ...t.hashtags, ...t.mentions];
+                      return (
+                        <div key={t.id} className="flex items-start gap-2 p-2 rounded-lg bg-white dark:bg-neutral-800 border border-neutral-100 dark:border-neutral-700">
+                          <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-orange-100 dark:bg-orange-500/20 text-orange-700 dark:text-orange-400 text-[10px] font-medium">
+                            <Zap className="w-2.5 h-2.5" /> Reactive
+                          </span>
+                          <span className="text-neutral-700 dark:text-neutral-300">
+                            on <b>{conn?.display_name ?? t.connection_id}</b> matching <span className="text-neutral-500 dark:text-neutral-400">{rules.join(", ") || "(none)"}</span>
+                          </span>
+                        </div>
+                      );
+                    })}
+                    {scheduledTriggers.map((t) => (
+                      <div key={t.id} className="flex items-start gap-2 p-2 rounded-lg bg-white dark:bg-neutral-800 border border-neutral-100 dark:border-neutral-700">
+                        <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-blue-100 dark:bg-blue-500/20 text-blue-700 dark:text-blue-400 text-[10px] font-medium">
+                          <Calendar className="w-2.5 h-2.5" /> Scheduled
+                        </span>
+                        <span className="text-neutral-700 dark:text-neutral-300 font-mono">
+                          {t.mode === "cron" ? t.cron : `at ${t.run_at}`}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {/* Approval summary */}
+              <div className={cn(
+                "rounded-xl border p-4 text-xs",
+                approvalRequired
+                  ? "bg-amber-50 dark:bg-amber-900/20 border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-300"
+                  : "bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800 text-green-800 dark:text-green-300"
+              )}>
+                <div className="flex items-center gap-2">
+                  {approvalRequired ? <Shield className="w-4 h-4" /> : <Check className="w-4 h-4" />}
+                  <span className="font-medium">
+                    {approvalRequired
+                      ? "Review outbound before sending — output queued in Approvals."
+                      : "Auto-publish — crew output goes out immediately."}
+                  </span>
+                </div>
+              </div>
             </div>
           )}
         </div>
@@ -1328,6 +1825,99 @@ export function CrewBuilder({ open, onClose, onCreated, editCrew }: CrewBuilderP
             )}
           </div>
         </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Small UI helpers used inside the wizard
+// ---------------------------------------------------------------------------
+
+function DirectionChip({
+  label,
+  icon: Icon,
+  active,
+  disabled,
+  onClick,
+}: {
+  label: string;
+  icon: React.ElementType;
+  active: boolean;
+  disabled: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        "inline-flex items-center gap-1 px-2 py-1 rounded-md border text-[11px] font-medium transition-colors",
+        active
+          ? "border-primary-500 bg-primary-500 text-white"
+          : "border-neutral-200 dark:border-neutral-700 text-neutral-600 dark:text-neutral-300 hover:border-primary-400",
+        disabled && "opacity-40 cursor-not-allowed hover:border-neutral-200 dark:hover:border-neutral-700"
+      )}
+      title={disabled ? `${label} not supported on this platform` : undefined}
+    >
+      <Icon className="w-3 h-3" />
+      {label}
+    </button>
+  );
+}
+
+function RuleChips({
+  label,
+  values,
+  placeholderPrefix,
+  onAdd,
+  onRemove,
+}: {
+  label: string;
+  values: string[];
+  placeholderPrefix?: string;
+  onAdd: (value: string) => void;
+  onRemove: (value: string) => void;
+}) {
+  const [draft, setDraft] = useState("");
+  const submit = () => {
+    const v = draft.trim();
+    if (!v) return;
+    onAdd(v);
+    setDraft("");
+  };
+  return (
+    <div className="space-y-1">
+      <label className="text-[11px] font-medium text-neutral-500 dark:text-neutral-400">
+        {label}
+      </label>
+      <div className="flex flex-wrap items-center gap-1.5">
+        {values.map((v) => (
+          <span
+            key={v}
+            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-primary-50 dark:bg-primary-500/10 text-primary-700 dark:text-primary-300 text-[11px] border border-primary-200 dark:border-primary-800"
+          >
+            {v}
+            <button type="button" onClick={() => onRemove(v)} className="hover:text-red-500">
+              <X className="w-2.5 h-2.5" />
+            </button>
+          </span>
+        ))}
+        <input
+          type="text"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              submit();
+            }
+          }}
+          onBlur={submit}
+          placeholder={`+ ${placeholderPrefix ?? ""}${label.toLowerCase().slice(0, -1)}`}
+          className="flex-1 min-w-[120px] px-2 py-0.5 text-[11px] rounded border border-transparent hover:border-neutral-200 dark:hover:border-neutral-700 focus:border-primary-500 bg-transparent outline-none"
+        />
       </div>
     </div>
   );

--- a/frontend/src/lib/api/connections-client.ts
+++ b/frontend/src/lib/api/connections-client.ts
@@ -1,0 +1,112 @@
+import { api } from "@/lib/transport";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ConnectionPlatform =
+  | "telegram"
+  | "discord"
+  | "reddit"
+  | "twitter"
+  | "linkedin"
+  | "instagram"
+  | "facebook"
+  | "blog"
+  | "email"
+  | "slack_webhook";
+
+export type ConnectionStore =
+  | "oauth_connections"
+  | "reddit_accounts"
+  | "twitter_accounts"
+  | "channel_registrations"
+  | "distribution_channels";
+
+export interface ConnectionSummary {
+  id: string;
+  platform: ConnectionPlatform;
+  store: ConnectionStore;
+  display_name?: string | null;
+  connected: boolean;
+  inbound_enabled: boolean;
+  outbound_enabled: boolean;
+  inbound_supported: boolean;
+  outbound_supported: boolean;
+  config_summary: Record<string, unknown>;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface ConnectionListResponse {
+  success: boolean;
+  connections: ConnectionSummary[];
+  total_count: number;
+}
+
+export interface CapabilityUpdate {
+  inbound_enabled?: boolean;
+  outbound_enabled?: boolean;
+}
+
+export type OutboundPlatform = "blog" | "email" | "slack_webhook";
+
+export interface OutboundConnectionCreate {
+  platform: OutboundPlatform;
+  name: string;
+  config: Record<string, unknown>;
+  enabled?: boolean;
+}
+
+export interface OutboundConnectionUpdate {
+  name?: string;
+  config?: Record<string, unknown>;
+  enabled?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// API client
+// ---------------------------------------------------------------------------
+
+export const connectionsApi = {
+  list: async (): Promise<ConnectionSummary[]> => {
+    const { data } = await api.get<ConnectionListResponse>("/connections");
+    return data.connections ?? [];
+  },
+
+  get: async (id: string): Promise<ConnectionSummary> => {
+    const { data } = await api.get<ConnectionSummary>(`/connections/${encodeURIComponent(id)}`);
+    return data;
+  },
+
+  updateCapabilities: async (
+    id: string,
+    update: CapabilityUpdate,
+  ): Promise<ConnectionSummary> => {
+    const { data } = await api.patch<ConnectionSummary>(
+      `/connections/${encodeURIComponent(id)}/capabilities`,
+      update,
+    );
+    return data;
+  },
+
+  createOutbound: async (payload: OutboundConnectionCreate): Promise<ConnectionSummary> => {
+    const { data } = await api.post<ConnectionSummary>("/connections/outbound", payload);
+    return data;
+  },
+
+  updateOutbound: async (
+    id: string,
+    update: OutboundConnectionUpdate,
+  ): Promise<ConnectionSummary> => {
+    const { data } = await api.put<ConnectionSummary>(
+      `/connections/outbound/${encodeURIComponent(id)}`,
+      update,
+    );
+    return data;
+  },
+
+  deleteOutbound: async (id: string): Promise<void> => {
+    await api.delete(`/connections/outbound/${encodeURIComponent(id)}`);
+  },
+};

--- a/frontend/src/routes/connections.tsx
+++ b/frontend/src/routes/connections.tsx
@@ -21,6 +21,9 @@ import {
   LogIn,
   User,
   Copy,
+  FileText,
+  Mail,
+  Hash,
 } from "lucide-react";
 import {
   configureOAuthClient,
@@ -38,10 +41,25 @@ import {
   deleteTrigger,
   type Trigger,
 } from "@/lib/api/triggers-client";
+import {
+  connectionsApi,
+  type ConnectionSummary,
+  type OutboundPlatform,
+} from "@/lib/api/connections-client";
 
 // ─── Types ──────────────────────────────────────────────────────
 
-type ConnectionId = "telegram" | "discord" | "linkedin" | "twitter" | "instagram" | "facebook" | "reddit";
+type ConnectionId =
+  | "telegram"
+  | "discord"
+  | "linkedin"
+  | "twitter"
+  | "instagram"
+  | "facebook"
+  | "reddit"
+  | "blog"
+  | "email"
+  | "slack_webhook";
 
 interface ConnectionConfig {
   id: ConnectionId;
@@ -63,6 +81,8 @@ interface ConnectionConfig {
   supportsOutbound: boolean;
   defaultInbound: boolean;
   defaultOutbound: boolean;
+  /** True for blog/email/slack_webhook — stored in backend via /connections/outbound. */
+  outboundOnly?: boolean;
 }
 
 interface SavedConnection {
@@ -273,6 +293,67 @@ const CONNECTIONS: ConnectionConfig[] = [
       { key: "keywords", label: "Keywords (comma-separated)", placeholder: "local LLM, ollama, gguf" },
     ],
   },
+  {
+    id: "blog",
+    name: "Blog",
+    description: "Publish to Ghost, WordPress, or any custom REST endpoint.",
+    icon: FileText,
+    iconBg: "bg-amber-100 dark:bg-amber-500/20",
+    iconColor: "text-amber-600 dark:text-amber-400",
+    docsUrl: "https://ghost.org/docs/content-api/",
+    oauthProvider: null,
+    supportsInbound: false,
+    supportsOutbound: true,
+    defaultInbound: false,
+    defaultOutbound: true,
+    outboundOnly: true,
+    fields: [
+      { key: "name", label: "Connection Name", placeholder: "My Blog" },
+      { key: "cms_type", label: "CMS Type (ghost | wordpress | custom)", placeholder: "ghost" },
+      { key: "api_url", label: "API URL", placeholder: "https://my-blog.com/ghost/api/v3/admin/posts" },
+      { key: "api_key", label: "API Key (optional)", placeholder: "Admin API key", secret: true },
+    ],
+  },
+  {
+    id: "email",
+    name: "Email",
+    description: "Send AI-generated content by email (SendGrid, SES, or SMTP).",
+    icon: Mail,
+    iconBg: "bg-rose-100 dark:bg-rose-500/20",
+    iconColor: "text-rose-600 dark:text-rose-400",
+    docsUrl: "https://docs.sendgrid.com/api-reference/mail-send/mail-send",
+    oauthProvider: null,
+    supportsInbound: false,
+    supportsOutbound: true,
+    defaultInbound: false,
+    defaultOutbound: true,
+    outboundOnly: true,
+    fields: [
+      { key: "name", label: "Connection Name", placeholder: "Newsletter sender" },
+      { key: "provider", label: "Provider (sendgrid | ses | smtp)", placeholder: "sendgrid" },
+      { key: "api_key", label: "API Key", placeholder: "SG.xxxx...", secret: true },
+      { key: "from_email", label: "From Address", placeholder: "hello@example.com" },
+    ],
+  },
+  {
+    id: "slack_webhook",
+    name: "Slack Webhook",
+    description: "Post to a Slack channel via an incoming webhook URL.",
+    icon: Hash,
+    iconBg: "bg-violet-100 dark:bg-violet-500/20",
+    iconColor: "text-violet-600 dark:text-violet-400",
+    docsUrl: "https://api.slack.com/messaging/webhooks",
+    oauthProvider: null,
+    supportsInbound: false,
+    supportsOutbound: true,
+    defaultInbound: false,
+    defaultOutbound: true,
+    outboundOnly: true,
+    fields: [
+      { key: "name", label: "Connection Name", placeholder: "Team ops" },
+      { key: "webhook_url", label: "Webhook URL", placeholder: "https://hooks.slack.com/services/T.../B.../xxx", secret: true },
+    ],
+  },
 ];
 
 // ─── Helpers ────────────────────────────────────────────────────
@@ -387,9 +468,87 @@ export default function ConnectionsPage() {
     setShowSecrets({});
   };
 
-  // Token-paste save (Telegram/Discord/Reddit)
+  // Load existing outbound-only connections from the aggregator on mount so
+  // blog/email/slack_webhook cards reflect real backend state (not localStorage).
+  useEffect(() => {
+    let cancelled = false;
+    connectionsApi
+      .list()
+      .then((rows: ConnectionSummary[]) => {
+        if (cancelled) return;
+        const outboundRows = rows.filter(
+          (r) => r.platform === "blog" || r.platform === "email" || r.platform === "slack_webhook",
+        );
+        if (outboundRows.length === 0) return;
+        setConnections((prev) => {
+          const filtered = prev.filter(
+            (c) => c.id !== "blog" && c.id !== "email" && c.id !== "slack_webhook",
+          );
+          for (const row of outboundRows) {
+            filtered.push({
+              id: row.platform as ConnectionId,
+              config: { _backend_id: row.id, name: row.display_name ?? "" },
+              inbound: row.inbound_enabled,
+              outbound: row.outbound_enabled,
+              status: row.connected ? "connected" : "disconnected",
+              connectedAt: row.created_at ?? undefined,
+              profileName: row.display_name ?? undefined,
+            });
+          }
+          saveConnections(filtered);
+          return filtered;
+        });
+      })
+      .catch(() => {
+        // Backend may not yet know about /connections — non-fatal for localStorage-based cards.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Token-paste save (Telegram/Discord/Reddit/Blog/Email/Slack webhook)
   const handleSave = async (connId: ConnectionId) => {
     setTesting(connId);
+
+    const conf = CONNECTIONS.find((c) => c.id === connId);
+
+    // Outbound-only connections (blog / email / slack_webhook) go to the unified backend.
+    if (conf?.outboundOnly) {
+      try {
+        const name = (formData.name || conf.name).trim();
+        const cfg: Record<string, unknown> = {};
+        for (const field of conf.fields) {
+          if (field.key === "name") continue;
+          const value = (formData[field.key] || "").trim();
+          if (value) cfg[field.key] = value;
+        }
+        const created = await connectionsApi.createOutbound({
+          platform: conf.id as OutboundPlatform,
+          name,
+          config: cfg,
+        });
+
+        const updated = connections.filter((c) => c.id !== connId);
+        updated.push({
+          id: connId,
+          config: { _backend_id: created.id, name },
+          inbound: false,
+          outbound: true,
+          status: "connected",
+          connectedAt: created.created_at ?? new Date().toISOString(),
+          profileName: name,
+        });
+        setConnections(updated);
+        saveConnections(updated);
+      } catch (e) {
+        console.error("Outbound connection save failed", e);
+      }
+      setTesting(null);
+      setEditing(null);
+      setFormData({});
+      return;
+    }
 
     // Reddit has a dedicated backend endpoint — save there too so the poller picks it up.
     if (connId === "reddit") {
@@ -486,6 +645,19 @@ export default function ConnectionsPage() {
   };
 
   const handleDisconnect = async (conn: ConnectionConfig) => {
+    // Outbound-only connections live in the backend — delete there.
+    if (conn.outboundOnly) {
+      const saved = getConnection(conn.id);
+      const backendId = saved?.config._backend_id;
+      if (backendId) {
+        try {
+          await connectionsApi.deleteOutbound(backendId);
+        } catch {
+          // proceed with local cleanup anyway
+        }
+      }
+    }
+
     // If OAuth provider, also disconnect on backend
     if (conn.oauthProvider) {
       try {


### PR DESCRIPTION
## Summary

Final frontend piece of Phase 3. The crew builder wizard now exposes Phase 3's full data model: `connection_bindings[]` with direction chips, reactive + scheduled `triggers[]`, and top-level `approval_required`. 5 steps → 7 steps (autonomous stays 6 by skipping Agent Team as before).

## New step layout

| # | Step | What's new |
|---|---|---|
| 1 | Crew Details | unchanged |
| 2 | Execution Mode | unchanged |
| 3 | Agent Team | unchanged (skipped for autonomous) |
| 4 | **Connections & Directions** | Real connection list from `GET /api/v1/connections`. Three direction chips per row (Inbound / Outbound / Both), disabled when the platform doesn't support that direction. Picking a direction whose capability flag is off opens an inline "Enable outbound on Telegram so this crew can send?" modal → calls `connectionsApi.updateCapabilities`, refreshes, binds. |
| 5 | **Trigger (new)** | Reactive sub-section per inbound-bound connection (chip-input for keywords / hashtags / mentions). Scheduled sub-section (cron OR one-shot datetime picker + optional content brief). Both lists optional. No triggers = manual only. Validation blocks Next on incomplete drafts. |
| 6 | **Approval (new)** | Single "Review outbound before sending" toggle. Copy links to `/approvals`. |
| 7 | Review & Create | Extended summary with Connections & Directions (with direction icons), Triggers, Approval. |

## handleSubmit payload gains

```ts
payload.connection_bindings = connectionBindings;
payload.triggers = [...reactive, ...scheduled];
payload.approval_required = approvalRequired;
```

Legacy `channel_bindings` still emitted — PR 4 retires it.

## Dead code removed

- Hardcoded 6-channel `CONNECTION_TYPES` array (aggregator supplies the real list)
- OAuth status polling loop (aggregator includes connection state)
- Legacy `toggleChannel` / `toggleChannelApproval` helpers

## Depends on / stacked

- #21 data model
- #22 aggregator + `connections-client.ts`
- #23 runtime wiring + Crew type extensions

This PR is stacked off `feat/phase3-pr3-triggers-and-routing` with `feat/phase3-pr2-connections-aggregator` merged in, so it opens against PR #23 as the base (not main). Merge order: #21 → #22 → #23 → this → PR 4.

## Test plan

- [x] `cd frontend && npm run build` → clean
- [x] Full backend suite: **755 passed** (no backend changes; number = PR 3a's 744 + PR 2's 11)
- [ ] Manual smoke once branches stack locally:
  - New Crew → step through all 7. Pick Reddit → Inbound → Both. If capability is off, modal offers to enable; click Enable & continue.
  - Step 5: add a reactive trigger on Reddit with keyword `pricing`. Add a scheduled trigger `0 9 * * MON`.
  - Step 6: toggle approval on.
  - Step 7: review shows all three sections. Create.
  - Verify payload in Network tab contains `connection_bindings`, `triggers`, `approval_required`. Existing Crews page renders the new filter chips correctly.

## What's left for Phase 3

| PR | Status |
|---|---|
| #21 data model | open |
| #22 aggregator | open |
| #23 runtime wiring | open |
| **this (PR 3b)** | open |
| PR 4 — sidebar cleanup + flip `UNIFIED_CREWS` | not started |

🤖 Generated with [Claude Code](https://claude.com/claude-code)