### PR TITLE
feat: Phase 3 PR 4 of 4 — remove Distribution + Schedule from sidebar, flip UNIFIED_CREWS on

### DIFF
--- a/backend/services/feature_flags.py
+++ b/backend/services/feature_flags.py
@@ -22,5 +22,10 @@ def _env_truthy(name: str, default: bool = False) -> bool:
 
 
 def unified_crews_enabled() -> bool:
-    """Read at call time so tests can monkeypatch the env var per-case."""
-    return _env_truthy("UNIFIED_CREWS", default=False)
+    """Read at call time so tests can monkeypatch the env var per-case.
+
+    Phase 3 PR 4 flipped the default to True — the unified inbound_router +
+    scheduled_runner + direction-aware outbound publishing is now the primary
+    code path. Set UNIFIED_CREWS=0 to fall back to the legacy paths.
+    """
+    return _env_truthy("UNIFIED_CREWS", default=True)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,8 +16,6 @@ import ConnectionsPage from "@/routes/connections";
 import ModelsPage from "@/routes/models";
 import SettingsPage from "@/routes/settings";
 import ApprovalsPage from "@/routes/approvals";
-import SchedulePage from "@/routes/schedule";
-import DistributionPage from "@/routes/distribution";
 import BlueprintsPage from "@/routes/blueprints";
 import WizardPage from "@/routes/wizard";
 import { UpdateNotifier } from "@/components/update-notifier";
@@ -118,8 +116,6 @@ export default function App() {
                 <Route path="/workspace/:id" element={<WorkspacePage />} />
                 <Route path="/connections" element={<ConnectionsPage />} />
                 <Route path="/approvals" element={<ApprovalsPage />} />
-                <Route path="/schedule" element={<SchedulePage />} />
-                <Route path="/distribution" element={<DistributionPage />} />
                 <Route path="/analytics" element={<AnalyticsPage />} />
                 <Route path="/settings" element={<SettingsPage />} />
               </Route>

--- a/frontend/src/components/navigation/desktop-sidebar.tsx
+++ b/frontend/src/components/navigation/desktop-sidebar.tsx
@@ -9,8 +9,6 @@ import {
   FlaskConical,
   Cable,
   ClipboardCheck,
-  Clock,
-  Send,
   Settings,
   ChevronLeft,
   ChevronRight,
@@ -40,8 +38,6 @@ const navItems: NavItem[] = [
   { label: "Workspace", path: "/workspace", icon: FlaskConical },
   { label: "Connections", path: "/connections", icon: Cable },
   { label: "Approvals", path: "/approvals", icon: ClipboardCheck },
-  { label: "Schedule", path: "/schedule", icon: Clock },
-  { label: "Distribution", path: "/distribution", icon: Send },
   { label: "Settings", path: "/settings", icon: Settings },
 ];
 

--- a/frontend/tests/e2e/connections/connections.spec.ts
+++ b/frontend/tests/e2e/connections/connections.spec.ts
@@ -23,8 +23,8 @@ test.beforeEach(async ({ page }) => {
 // ==========================================================================
 
 test.describe("CRUD via UI", () => {
-  // DC-CONN-01: View all 7 connection cards
-  test("DC-CONN-01: view all 7 connection cards", async ({ page }) => {
+  // DC-CONN-01: View all 10 connection cards (7 socials + Blog + Email + Slack webhook)
+  test("DC-CONN-01: view all 10 connection cards", async ({ page }) => {
     await expect(page.locator("h1", { hasText: "Connections" })).toBeVisible();
 
     await expect(page.locator("h3", { hasText: "Telegram Bot" })).toBeVisible();
@@ -34,9 +34,13 @@ test.describe("CRUD via UI", () => {
     await expect(page.locator("h3", { hasText: "Twitter / X" })).toBeVisible();
     await expect(page.locator("h3", { hasText: "Instagram" })).toBeVisible();
     await expect(page.locator("h3", { hasText: "Facebook" })).toBeVisible();
+    // Phase 3: outbound-only additions.
+    await expect(page.locator("h3", { hasText: "Blog" })).toBeVisible();
+    await expect(page.locator("h3", { hasText: "Email" })).toBeVisible();
+    await expect(page.locator("h3", { hasText: "Slack Webhook" })).toBeVisible();
 
     const count = await connections.connectionCards.count();
-    expect(count).toBe(7);
+    expect(count).toBe(10);
   });
 
   // DC-CONN-02: Expand Telegram connection form
@@ -48,9 +52,11 @@ test.describe("CRUD via UI", () => {
     // Bot Token field should be visible
     await expect(page.locator("input[placeholder*='123456']")).toBeVisible();
 
-    // Direction toggles should be visible
-    await expect(page.locator("text=Inbound")).toBeVisible();
-    await expect(page.locator("text=Outbound")).toBeVisible();
+    // Direction toggles should be visible inside the Telegram card.
+    // Scoped to the card to avoid strict-mode collisions with other cards'
+    // Inbound/Outbound labels (e.g. Blog / Email / Slack webhook).
+    await expect(telegramCard.locator("text=Inbound").first()).toBeVisible();
+    await expect(telegramCard.locator("text=Outbound").first()).toBeVisible();
   });
 
   // DC-CONN-03: Expand Discord connection form
@@ -96,8 +102,10 @@ test.describe("CRUD via UI", () => {
     await expect(page.locator("input[placeholder*='Access Token']").first()).toBeVisible();
     await expect(page.locator("input[placeholder*='Access Token Secret']")).toBeVisible();
 
-    // Twitter/X supports outbound only — no Inbound toggle
-    await expect(page.locator("text=Outbound")).toBeVisible();
+    // Twitter/X supports outbound only — no Inbound toggle.
+    // Scoped to the Twitter card so Blog / Email / Slack Outbound labels
+    // don't trigger strict-mode violations.
+    await expect(twitterCard.locator("text=Outbound").first()).toBeVisible();
   });
 
   // DC-CONN-13: Save Twitter/X credentials
@@ -165,11 +173,11 @@ test.describe("Positive Workflows", () => {
     await expect(page.locator("button", { hasText: "Sign in with LinkedIn" })).toBeVisible();
   });
 
-  // DC-CONN-09: External docs links are present
+  // DC-CONN-09: External docs links are present (10 total after Phase 3)
   test("DC-CONN-09: external docs links are present", async ({ page }) => {
     const docsLinks = page.locator("a[title='Setup guide']");
     const count = await docsLinks.count();
-    expect(count).toBe(7);
+    expect(count).toBe(10);
 
     const links = await docsLinks.all();
     for (const link of links) {

--- a/frontend/tests/e2e/crews/crews.spec.ts
+++ b/frontend/tests/e2e/crews/crews.spec.ts
@@ -100,10 +100,10 @@ test.describe("Wizard Flow", () => {
   test("DC-CREW-WIZ-01: wizard shows step indicator", async () => {
     await crews.openBuilder();
 
-    // Should have 4 step indicator circles
+    // Post-Phase-3 the wizard is 7 steps (6 for autonomous).
     const indicators = crews.stepIndicators;
     const count = await indicators.count();
-    expect(count).toBeGreaterThanOrEqual(3); // 3 for autonomous, 4 for others
+    expect(count).toBeGreaterThanOrEqual(6);
   });
 
   // DC-CREW-WIZ-02: Step 1 shows crew name and description
@@ -149,20 +149,30 @@ test.describe("Wizard Flow", () => {
     await crews.nextButton.click();
     await page.waitForTimeout(300);
 
-    // Step 4: Connections
-    await expect(page.locator("text=Channel Connections").first()).toBeVisible();
+    // Step 4: Connections & Directions (Phase 3)
+    await expect(page.locator("text=/Pick connections/i").first()).toBeVisible();
     await crews.nextButton.click();
     await page.waitForTimeout(300);
 
-    // Step 5: Review
-    await expect(page.locator("text=Review Configuration").first()).toBeVisible();
+    // Step 5: Trigger (Phase 3)
+    await expect(page.locator("text=/Reactive triggers/i").first()).toBeVisible();
+    await crews.nextButton.click();
+    await page.waitForTimeout(300);
+
+    // Step 6: Approval (Phase 3)
+    await expect(page.locator("text=/Review outbound before sending/i").first()).toBeVisible();
+    await crews.nextButton.click();
+    await page.waitForTimeout(300);
+
+    // Step 7: Review
+    await expect(page.locator("text=/Review Configuration/i").first()).toBeVisible();
   });
 
-  // DC-CREW-WIZ-05: Connections step shows channel cards
-  test("DC-CREW-WIZ-05: connections step shows channel cards", async ({ page }) => {
+  // DC-CREW-WIZ-05: Connections & Directions step shows connection rows
+  test("DC-CREW-WIZ-05: connections step shows connection rows", async ({ page }) => {
     await crews.openBuilder();
 
-    // Navigate to step 4 (Connections)
+    // Navigate to step 4 (Connections & Directions)
     await crews.crewNameInput.fill("Connections Test");
     await crews.nextButton.click(); // → Step 2
     await page.waitForTimeout(200);
@@ -174,25 +184,27 @@ test.describe("Wizard Flow", () => {
     const agentInstructions = crews.agentInstructionTextareas.first();
     await agentName.fill("Bot Agent");
     await agentInstructions.fill("Handle messages");
-    await crews.nextButton.click(); // → Step 4 (Connections)
+    await crews.nextButton.click(); // → Step 4 (Connections & Directions)
     await page.waitForTimeout(300);
 
-    // Should show Channel Connections heading
-    await expect(page.locator("text=Channel Connections").first()).toBeVisible();
+    // Phase 3: heading is now "Pick connections & direction".
+    await expect(page.locator("text=/Pick connections/i").first()).toBeVisible();
 
-    // Should have connection cards (Telegram, Discord, LinkedIn, Twitter, Instagram, Facebook)
-    const connectionCards = page.locator(".grid button").filter({
-      has: page.locator("p.text-sm.font-medium"),
-    });
-    const count = await connectionCards.count();
-    expect(count).toBeGreaterThanOrEqual(6);
+    // Connections now come from GET /api/v1/connections. On a clean test
+    // env the list may be empty — in that case the "no connections" hint
+    // shows. Either way, the step should render without error.
+    const emptyHint = page.locator("text=/No connections set up yet/i");
+    const directionChips = page.locator("button", { hasText: /^(Inbound|Outbound|Both)$/ });
+    const hasEmpty = await emptyHint.isVisible().catch(() => false);
+    const chipCount = await directionChips.count();
 
-    // Click Telegram to select it
-    await page.locator("text=Telegram").first().click();
-    await page.waitForTimeout(200);
+    if (!hasEmpty) {
+      // At least one connection row → at least 3 direction chips per row.
+      expect(chipCount).toBeGreaterThanOrEqual(3);
+    }
 
-    // Should show selected count
-    await expect(page.locator("text=1 channel selected")).toBeVisible();
+    // The legacy "1 channel selected" assertion no longer applies — that
+    // summary line came from the removed hardcoded channel grid.
   });
 
   // DC-CREW-WIZ-06: Back button navigates backwards

--- a/frontend/tests/e2e/fixtures/page-objects/crews.page.ts
+++ b/frontend/tests/e2e/fixtures/page-objects/crews.page.ts
@@ -10,11 +10,14 @@ import { type Page, type Locator, expect } from "@playwright/test";
  * - Tabs: Crews | Runs
  * - Status filter and mode filter selects (crews tab only)
  * - Crew cards with Run buttons
- * - CrewBuilder wizard (4-step):
+ * - CrewBuilder wizard (7-step after Phase 3 PR 3b):
  *   Step 1: Crew Details (name, description)
  *   Step 2: Execution Mode
- *   Step 3: Agent Team
- *   Step 4: Review & Create
+ *   Step 3: Agent Team (skipped for autonomous)
+ *   Step 4: Connections & Directions
+ *   Step 5: Trigger
+ *   Step 6: Approval
+ *   Step 7: Review & Create
  */
 export class CrewsPage {
   readonly page: Page;
@@ -116,7 +119,7 @@ export class CrewsPage {
     return this.builderDialog.getByRole("button", { name: /back/i });
   }
 
-  /** Create Crew submit button (step 4). */
+  /** Create Crew submit button (step 7). */
   get submitButton(): Locator {
     return this.builderDialog.getByRole("button", { name: /create crew|save changes/i });
   }
@@ -181,6 +184,10 @@ export class CrewsPage {
 
   /**
    * Open the wizard and create a crew through all steps.
+   *
+   * Post-Phase-3 wizard is 7 steps. Agent fields must be filled on step 3
+   * before Next is enabled (non-autonomous modes). All other steps have
+   * sensible defaults, so we can click through them quickly.
    */
   async createCrew(data: {
     name: string;
@@ -196,19 +203,32 @@ export class CrewsPage {
       await this.crewDescriptionInput.fill(data.description);
     }
 
-    // Next → Step 2 (Execution Mode)
+    // → Step 2 (Execution Mode)
     await this.nextButton.click();
     await this.page.waitForTimeout(300);
 
-    // Next → Step 3 (Agents)
+    // → Step 3 (Agents) — fill minimal agent so Next unlocks.
+    await this.nextButton.click();
+    await this.page.waitForTimeout(300);
+    const agentName = this.agentNameInputs.first();
+    if (await agentName.isVisible().catch(() => false)) {
+      await agentName.fill("Test Agent");
+      await this.agentInstructionTextareas.first().fill("Run the task.");
+    }
+
+    // → Step 4 (Connections & Directions)
     await this.nextButton.click();
     await this.page.waitForTimeout(300);
 
-    // Next → Step 4 (Connections)
+    // → Step 5 (Trigger)
     await this.nextButton.click();
     await this.page.waitForTimeout(300);
 
-    // Next → Step 5 (Review)
+    // → Step 6 (Approval)
+    await this.nextButton.click();
+    await this.page.waitForTimeout(300);
+
+    // → Step 7 (Review)
     await this.nextButton.click();
     await this.page.waitForTimeout(300);
 

--- a/frontend/tests/e2e/navigation/navigation.spec.ts
+++ b/frontend/tests/e2e/navigation/navigation.spec.ts
@@ -19,13 +19,13 @@ test("DC-NAV-01: sidebar shows all navigation items", async () => {
   await expect(nav.sidebar).toBeVisible();
 
   const labels = await nav.getNavLabels();
-  const expectedItems = ["Chat", "Model Hub", "Personas", "Agents", "Crews", "Blueprints", "Workspace", "Connections", "Approvals", "Schedule", "Distribution", "Settings"];
+  const expectedItems = ["Chat", "Model Hub", "Personas", "Agents", "Crews", "Blueprints", "Workspace", "Connections", "Approvals", "Settings"];
 
   for (const item of expectedItems) {
     expect(labels).toContain(item);
   }
 
-  expect(labels.length).toBe(12);
+  expect(labels.length).toBe(10);
 });
 
 // DC-NAV-02: Navigate to each page and verify heading
@@ -40,8 +40,6 @@ test("DC-NAV-02: navigate to each page and verify heading", async ({ page }) => 
     { label: "Workspace", heading: "Workspace" },
     { label: "Connections", heading: "Connections" },
     { label: "Approvals", heading: "Approval Queue" },
-    { label: "Schedule", heading: "Scheduled Jobs" },
-    { label: "Distribution", heading: "Distribution" },
     { label: "Settings", heading: "Settings" },
   ];
 
@@ -103,12 +101,12 @@ test("DC-NAV-04: sidebar collapse/expand toggle works", async ({ page }) => {
   expect(expandedBox!.width).toBeGreaterThan(100);
 
   const expandedLabels = await nav.getNavLabels();
-  expect(expandedLabels.length).toBe(12);
+  expect(expandedLabels.length).toBe(10);
 });
 
 // DC-NAV-05: Page transitions are smooth (no flash)
 test("DC-NAV-05: page transitions are smooth", async ({ page }) => {
-  const routes = ["Personas", "Agents", "Crews", "Blueprints", "Workspace", "Connections", "Approvals", "Schedule", "Distribution", "Settings", "Chat"];
+  const routes = ["Personas", "Agents", "Crews", "Blueprints", "Workspace", "Connections", "Approvals", "Settings", "Chat"];
 
   for (const route of routes) {
     await nav.navigateTo(route);


### PR DESCRIPTION
## Summary

Final Phase 3 PR. Retires the Distribution + Schedule sidebar entries (their functionality lives inside Crews now) and flips `UNIFIED_CREWS` on by default so the new routing paths take over.

## Changes

**Frontend — 10-item sidebar**
- `desktop-sidebar.tsx` — drop Schedule + Distribution nav items; sidebar 12 → 10. Removed unused `Clock` + `Send` icon imports.
- `App.tsx` — drop `/schedule` + `/distribution` route registrations and their page imports. Page files themselves stay on disk for one release cycle as dead code; FUTURE cleanup (TODO.md line 427) deletes them after soak.
- `tests/e2e/navigation/navigation.spec.ts` — all four places that hard-coded 12 items updated to 10 (DC-NAV-01 expected list + count, DC-NAV-02 routes list, DC-NAV-04 expanded count, DC-NAV-05 routes list).

**Backend — default flip**
- `feature_flags.py` — `UNIFIED_CREWS` default flipped `False` → `True`. Opt out via `UNIFIED_CREWS=0`.

## What's now the default runtime behaviour

| Path | New default |
|---|---|
| Inbound message | `inbound_router.route_inbound` matches against `crew.triggers[type=reactive]` first; LLM disambiguates ties; legacy `trigger_service` runs only when no reactive match. |
| Scheduled crew | `scheduled_runner` boots on startup and registers APScheduler jobs from `crew.triggers[type=scheduled]`. |
| Crew outbound | `crew_orchestrator._publish_via_connection_bindings` — direction-aware; honours top-level `crew.approval_required`. |

## Dependency / merge order

| PR | Scope |
|---|---|
| #21 | Data model + migration |
| #22 | Connections aggregator + Blog/Email/Slack |
| #23 | Runtime wiring (inbound_router + scheduled_runner + Runs badge) |
| #24 | Crew-builder 7-step revamp |
| **this (PR 4)** | Sidebar cleanup + flag flip |

This branch is stacked off PR #24, so it opens against that as the base. Final merge order: #21 → #22 → #23 → #24 → this → main.

## Test plan

- [x] `cd backend && pytest tests/ -q` → **755 passed** (no tests referenced `UNIFIED_CREWS`; flag flip is transparent)
- [x] `cd frontend && npm run build` → clean
- [ ] Playwright E2E — `navigation.spec.ts` will now pass (expects 10 items). Run before merge.
- [ ] Manual smoke: open app → sidebar shows 10 items, no Schedule or Distribution. Create a Reddit reactive crew in the new 7-step wizard. Post a matching comment / send an inbound test message → the crew dispatches (not the legacy trigger path). Runs tab badge says "Reactive".

## Phase 3 is feature-complete with this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)