### PR TITLE
feat: Phase 3 — unify Connections + Crews (IA refactor, full release)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -295,7 +295,7 @@
 ### Confirmed decisions (do not revisit)
 1. **Manual trigger** = the existing "Run" button on each crew card (`frontend/src/routes/crews.tsx:481`). Not a new trigger-type selection in the builder. Always available on every crew.
 2. **Runs view** = the existing `Runs` tab on the Crews page (`frontend/src/routes/crews.tsx:130` — tab state `activeTab: "crews" | "runs"`). Extend the existing `CrewRun` type with trigger metadata; do not build a new component.
-3. **Distribution & Schedule stay in the sidebar** but route to a shared **"Coming Soon"** page. Sidebar remains at 12 items; nav E2E test (`frontend/tests/e2e/navigation/navigation.spec.ts`) does not need changing. Future phase removes them entirely.
+3. **Distribution & Schedule are removed from the sidebar.** Their functionality lives entirely inside Crews now (outbound publishing via `connection_bindings`, scheduling via `triggers[type=scheduled]`); a Coming Soon stop would be redundant. Sidebar drops from 12 → 10 items; nav E2E test (`frontend/tests/e2e/navigation/navigation.spec.ts`) updated accordingly.
 4. **Blog / Email / Slack webhook** ship as new Connection types (outbound-only) inside the same Connections grid as the social platforms.
 5. **Inbound keyword-match ties** → LLM disambiguates. No per-crew priority UI.
 6. **Connection-level fallback crew** for unmatched inbound → **not in v1**. Drop messages silently; reconsider if users complain.
@@ -375,11 +375,11 @@
   - **New Step 6 "Approval"**: single toggle "Review outbound before sending."
   - Existing Review step becomes Step 7 — update summary to reflect new fields.
 
-**New**
-- [ ] `frontend/src/routes/coming-soon.tsx` — simple placeholder component:
-  - Takes a `feature: string` prop.
-  - Shows icon + "<Feature> is moving into Crews — coming soon" + link to Crews page + link to docs/TODO.md entry.
-- [ ] Update `App.tsx` to route `/distribution` and `/schedule` to `ComingSoon` with the appropriate prop.
+**Removed (PR 4)**
+- [ ] Drop `/distribution` and `/schedule` route registrations from `App.tsx`.
+- [ ] Drop the Distribution + Schedule sidebar entries from `frontend/src/components/navigation/desktop-sidebar.tsx` (sidebar 12 → 10 items).
+- [ ] Update nav E2E test in `frontend/tests/e2e/navigation/navigation.spec.ts` to expect 10 items.
+- [ ] Page files `frontend/src/routes/distribution.tsx` and `frontend/src/routes/schedule.tsx` can stay on disk for one release cycle as dead code — the FUTURE cleanup task deletes them.
 
 **Modified**
 - [ ] `frontend/src/routes/crews.tsx` — **Crews tab**: add new filter chips alongside existing `statusFilter` and `modeFilter`: `Inbound`, `Outbound`, `Scheduled`, `Reactive`, `Approval-required`. Filter logic hooks into `filteredCrews` (line 179). **Runs tab**: render `trigger_type` badge on each row of `RunsList` (line 498).
@@ -387,8 +387,7 @@
 - [ ] `frontend/src/lib/api/distribution-client.ts` — can stay but is no longer consumed by the active UI. Delete in the future-cleanup phase.
 
 **Not changed**
-- Sidebar (`frontend/src/components/navigation/desktop-sidebar.tsx`) — still 12 items.
-- Nav E2E tests — still expect 12.
+- Sidebar entries other than Distribution + Schedule — order, icons, labels untouched.
 
 ### Migration
 
@@ -420,12 +419,11 @@ Must be idempotent, dry-run capable (`MIGRATE_DRY_RUN=1` env var), and must writ
 | 1 | Data model additions (connection_bindings, triggers, approval_required, capability flags) + migration script (dry-run capable) + extended CrewRun schema. Backend only; no UI change; existing flows keep working. | — (additive) |
 | 2 | Unified `/api/v1/connections` aggregator + rewritten Connections page (capability toggles, Blog/Email/Slack new types). Old Distribution page still lives. | — |
 | 3 | Crew builder: Trigger step + Direction chips + Approval toggle + "enable capability at connection level" modal. Backend: `inbound_router.py` + `scheduled_runner.py`. Runs tab displays trigger_type badge. | `UNIFIED_CREWS` env flag |
-| 4 | Swap `/distribution` and `/schedule` routes to ComingSoon. Add TODO entries referencing this plan. Flip `UNIFIED_CREWS` on by default. | Flag default → true |
+| 4 | Remove `/distribution` + `/schedule` from sidebar and route registry; nav E2E test 12 → 10. Flip `UNIFIED_CREWS` on by default. | Flag default → true |
 
 ### Follow-up TODOs (track after Phase 3 ships)
 
-- [ ] FUTURE: Re-retire Distribution page (delete `frontend/src/routes/distribution.tsx`, `backend/routers/distribution.py`, `backend/services/distribution_service.py` entirely) once Coming Soon has been live one release cycle.
-- [ ] FUTURE: Re-retire Schedule page (delete `frontend/src/routes/schedule.tsx` + standalone scheduler backend).
+- [ ] FUTURE: Delete dead code one release cycle after PR 4 — `frontend/src/routes/distribution.tsx`, `frontend/src/routes/schedule.tsx`, `backend/routers/distribution.py`, the standalone scheduler backend. `backend/services/distribution_service.py` stays — its outbound adapters (LinkedIn/Twitter/IG/FB/Blog/Email/Slack publishers) are reused by `agent_runner.py`.
 - [ ] FUTURE: Connection-level fallback crew for unmatched inbound messages (skipped in v1 per user decision).
 - [ ] FUTURE: Global Activity/Runs view across all crews (skipped in v1 — per-crew Runs tab covers the need).
 - [ ] FUTURE: Per-crew priority ordering for keyword-match ties (skipped — LLM disambiguation handles v1).

--- a/backend/app.py
+++ b/backend/app.py
@@ -470,6 +470,15 @@ async def startup_event():
         # Seed model configs for any already-downloaded local GGUF models
         await _seed_local_models(proxy)
 
+        # Phase 3 PR 1: backfill crew.connection_bindings / triggers / approval_required
+        try:
+            from services.migrations.unify_connections_migration import (
+                run_unify_connections_migration,
+            )
+            await run_unify_connections_migration(proxy)
+        except Exception:
+            logger.exception("unify_connections migration failed; continuing startup")
+
         # Start Reddit poller (runs only when a Reddit account is configured)
         from services.reddit_poller import get_poller
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -45,6 +45,7 @@ from routers.blueprints import router as blueprints_router
 from routers.reddit import router as reddit_router
 from routers.twitter import router as twitter_router
 from routers.scheduled_jobs import router as scheduled_jobs_router
+from routers.connections import router as connections_router
 
 # ---------------------------------------------------------------------------
 # Logging
@@ -96,6 +97,7 @@ app.include_router(blueprints_router)
 app.include_router(reddit_router)
 app.include_router(twitter_router)
 app.include_router(scheduled_jobs_router)
+app.include_router(connections_router)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app.py
+++ b/backend/app.py
@@ -488,6 +488,18 @@ async def startup_event():
         await scheduler_service.load_all()
         app.state.scheduler_service = scheduler_service
 
+        # Phase 3 PR 3: scheduled_runner registers crew.triggers[type=scheduled]
+        # Only active when UNIFIED_CREWS=on so legacy flows keep running by default.
+        try:
+            from services.feature_flags import unified_crews_enabled
+            if unified_crews_enabled():
+                from services.scheduled_runner import ScheduledRunner
+                runner = ScheduledRunner(proxy, scheduler)
+                await runner.load_all()
+                app.state.scheduled_runner = runner
+        except Exception:
+            logger.exception("ScheduledRunner failed to load — continuing startup")
+
         logger.info("ContextuAI Solo backend ready")
 
     except Exception:

--- a/backend/models/connection_models.py
+++ b/backend/models/connection_models.py
@@ -1,0 +1,160 @@
+"""
+Connection Models — unified shape across every credential store.
+
+Phase 3 PR 2 introduces a single `/api/v1/connections` aggregator that reads
+from oauth_connections (LinkedIn/IG/FB), reddit_accounts, twitter_accounts,
+channel_registrations (Telegram/Discord), and distribution_channels
+(blog/email/slack_webhook). This module defines the request/response models
+for that surface.
+
+Existing per-platform credential endpoints (OAuth callback, Reddit CRUD,
+Twitter CRUD, channels/register) are unchanged — the aggregator is a
+read-plus-capability-toggle layer on top.
+"""
+
+from enum import Enum
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+
+# =============================================================================
+# Platform catalog
+# =============================================================================
+
+class Platform(str, Enum):
+    """All supported connection platforms. Includes PR 2's new outbound-only types."""
+    TELEGRAM = "telegram"
+    DISCORD = "discord"
+    REDDIT = "reddit"
+    TWITTER = "twitter"
+    LINKEDIN = "linkedin"
+    INSTAGRAM = "instagram"
+    FACEBOOK = "facebook"
+    BLOG = "blog"
+    EMAIL = "email"
+    SLACK_WEBHOOK = "slack_webhook"
+
+
+# Platform capabilities — what direction(s) each platform supports.
+PLATFORM_CAPABILITIES: Dict[str, Dict[str, bool]] = {
+    Platform.TELEGRAM.value:      {"inbound_supported": True,  "outbound_supported": True},
+    Platform.DISCORD.value:       {"inbound_supported": True,  "outbound_supported": True},
+    Platform.REDDIT.value:        {"inbound_supported": True,  "outbound_supported": True},
+    Platform.TWITTER.value:       {"inbound_supported": True,  "outbound_supported": True},
+    Platform.LINKEDIN.value:      {"inbound_supported": False, "outbound_supported": True},
+    Platform.INSTAGRAM.value:     {"inbound_supported": False, "outbound_supported": True},
+    Platform.FACEBOOK.value:      {"inbound_supported": False, "outbound_supported": True},
+    Platform.BLOG.value:          {"inbound_supported": False, "outbound_supported": True},
+    Platform.EMAIL.value:         {"inbound_supported": False, "outbound_supported": True},
+    Platform.SLACK_WEBHOOK.value: {"inbound_supported": False, "outbound_supported": True},
+}
+
+OUTBOUND_ONLY_PLATFORMS = {
+    Platform.BLOG.value,
+    Platform.EMAIL.value,
+    Platform.SLACK_WEBHOOK.value,
+}
+
+
+# =============================================================================
+# Aggregator response
+# =============================================================================
+
+class ConnectionSummary(BaseModel):
+    """Unified view of one connection across all stores.
+
+    `id` is the store-native identifier (OAuth provider id, reddit_accounts
+    _id, channel_registrations _id, distribution_channels channel_id, etc.).
+    The aggregator stamps a `store` hint so writes can route back to the
+    originating collection.
+    """
+    id: str
+    platform: str
+    store: Literal[
+        "oauth_connections",
+        "reddit_accounts",
+        "twitter_accounts",
+        "channel_registrations",
+        "distribution_channels",
+    ]
+    display_name: Optional[str] = None
+    connected: bool = True
+    inbound_enabled: bool = True
+    outbound_enabled: bool = True
+    inbound_supported: bool = False
+    outbound_supported: bool = False
+    config_summary: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Non-sensitive subset safe to show in UI (e.g. profile_name, subreddits count, from_email).",
+    )
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+class ConnectionListResponse(BaseModel):
+    success: bool = True
+    connections: List[ConnectionSummary]
+    total_count: int
+
+
+# =============================================================================
+# Capability PATCH
+# =============================================================================
+
+class CapabilityUpdate(BaseModel):
+    """Toggle inbound/outbound on an existing connection. Omitted fields untouched."""
+    inbound_enabled: Optional[bool] = None
+    outbound_enabled: Optional[bool] = None
+
+    @model_validator(mode="after")
+    def at_least_one_field(self):
+        if self.inbound_enabled is None and self.outbound_enabled is None:
+            raise ValueError("Specify inbound_enabled and/or outbound_enabled")
+        return self
+
+
+# =============================================================================
+# Outbound-only connections (blog / email / slack_webhook)
+# =============================================================================
+
+class OutboundConnectionCreate(BaseModel):
+    """Create a blog / email / slack_webhook connection.
+
+    Type-specific fields live in `config`; the validator enforces required
+    keys per platform.
+    """
+    platform: Literal["blog", "email", "slack_webhook"]
+    name: str = Field(..., min_length=1, max_length=200)
+    config: Dict[str, Any] = Field(default_factory=dict)
+    enabled: bool = True
+
+    @model_validator(mode="after")
+    def validate_config_for_platform(self):
+        cfg = self.config or {}
+        if self.platform == "blog":
+            if not cfg.get("api_url"):
+                raise ValueError("blog config requires api_url")
+            if not cfg.get("cms_type"):
+                raise ValueError("blog config requires cms_type (ghost | wordpress | custom)")
+        elif self.platform == "email":
+            for key in ("provider", "api_key", "from_email"):
+                if not cfg.get(key):
+                    raise ValueError(f"email config requires {key}")
+        elif self.platform == "slack_webhook":
+            if not cfg.get("webhook_url"):
+                raise ValueError("slack_webhook config requires webhook_url")
+        return self
+
+
+class OutboundConnectionUpdate(BaseModel):
+    """Partial update for an outbound-only connection."""
+    name: Optional[str] = Field(None, min_length=1, max_length=200)
+    config: Optional[Dict[str, Any]] = None
+    enabled: Optional[bool] = None
+
+    @model_validator(mode="after")
+    def at_least_one_field(self):
+        if self.name is None and self.config is None and self.enabled is None:
+            raise ValueError("Specify at least one field to update")
+        return self

--- a/backend/models/crew_models.py
+++ b/backend/models/crew_models.py
@@ -6,8 +6,8 @@ and maintain shared memory across runs.
 """
 
 from enum import Enum
-from typing import Optional, List, Dict, Any
-from pydantic import BaseModel, Field, model_validator
+from typing import Optional, List, Dict, Any, Literal, Union, Annotated
+from pydantic import BaseModel, Field, model_validator, Discriminator
 
 
 # =============================================================================
@@ -116,6 +116,50 @@ class DistributionChannel(BaseModel):
     enabled: bool = True
 
 
+class ConnectionBinding(BaseModel):
+    """Binds a crew to a connection (platform auth) with a direction.
+
+    Direction controls whether the crew listens on inbound messages from this
+    connection, publishes outbound via it, or both.
+    """
+    connection_id: str = Field(..., description="ID of the underlying connection record (oauth_tokens.id, reddit_accounts.id, etc.)")
+    platform: str = Field(..., description="telegram | discord | reddit | linkedin | twitter | instagram | facebook | blog | email | slack_webhook")
+    direction: Literal["inbound", "outbound", "both"] = "both"
+
+
+class ReactiveTrigger(BaseModel):
+    """Fires when an inbound message on `connection_id` matches any keyword/hashtag/mention."""
+    type: Literal["reactive"] = "reactive"
+    connection_id: str
+    keywords: List[str] = Field(default_factory=list)
+    hashtags: List[str] = Field(default_factory=list)
+    mentions: List[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def require_at_least_one_match(self):
+        if not (self.keywords or self.hashtags or self.mentions):
+            raise ValueError("Reactive trigger requires at least one of keywords, hashtags, or mentions")
+        return self
+
+
+class ScheduledTrigger(BaseModel):
+    """Fires on a cron schedule (repeating) or at `run_at` (one-shot)."""
+    type: Literal["scheduled"] = "scheduled"
+    connection_ids: List[str] = Field(default_factory=list)
+    cron: Optional[str] = None
+    run_at: Optional[str] = Field(None, description="ISO-8601 datetime for one-shot scheduling")
+    content_brief: Optional[str] = None
+
+    @model_validator(mode="after")
+    def require_exactly_one_schedule(self):
+        if bool(self.cron) == bool(self.run_at):
+            raise ValueError("Scheduled trigger requires exactly one of `cron` or `run_at`")
+        return self
+
+
+CrewTrigger = Annotated[Union[ReactiveTrigger, ScheduledTrigger], Discriminator("type")]
+
+
 # =============================================================================
 # Request Models
 # =============================================================================
@@ -129,6 +173,9 @@ class CreateCrewRequest(BaseModel):
     schedule: Optional[CrewSchedule] = None
     channel_bindings: List[ChannelBinding] = Field(default_factory=list)
     distribution_channels: List[DistributionChannel] = Field(default_factory=list)
+    connection_bindings: List[ConnectionBinding] = Field(default_factory=list)
+    triggers: List[CrewTrigger] = Field(default_factory=list)
+    approval_required: bool = False
     memory_enabled: bool = True
     tags: List[str] = Field(default_factory=list)
 
@@ -177,6 +224,9 @@ class UpdateCrewRequest(BaseModel):
     schedule: Optional[CrewSchedule] = None
     channel_bindings: Optional[List[ChannelBinding]] = None
     distribution_channels: Optional[List[DistributionChannel]] = None
+    connection_bindings: Optional[List[ConnectionBinding]] = None
+    triggers: Optional[List[CrewTrigger]] = None
+    approval_required: Optional[bool] = None
     memory_enabled: Optional[bool] = None
     tags: Optional[List[str]] = None
     status: Optional[CrewStatus] = None
@@ -206,6 +256,9 @@ class CrewResponse(BaseModel):
     schedule: Optional[CrewSchedule] = None
     channel_bindings: List[ChannelBinding] = Field(default_factory=list)
     distribution_channels: List[DistributionChannel] = Field(default_factory=list)
+    connection_bindings: List[ConnectionBinding] = Field(default_factory=list)
+    triggers: List[CrewTrigger] = Field(default_factory=list)
+    approval_required: bool = False
     memory_enabled: bool = True
     tags: List[str] = Field(default_factory=list)
     total_runs: int = 0
@@ -281,6 +334,11 @@ class CrewRunResponse(BaseModel):
     completed_at: Optional[str] = None
     created_at: Optional[str] = None
     duration_ms: Optional[int] = None
+    trigger_type: Literal["reactive", "scheduled", "manual"] = "manual"
+    trigger_source: Optional[str] = Field(
+        None,
+        description="connection_id (reactive), cron expression or run_at (scheduled), or 'manual' (button)"
+    )
 
     class Config:
         from_attributes = True
@@ -298,6 +356,8 @@ class CrewRunListItem(BaseModel):
     completed_at: Optional[str] = None
     duration_ms: Optional[int] = None
     created_at: Optional[str] = None
+    trigger_type: Literal["reactive", "scheduled", "manual"] = "manual"
+    trigger_source: Optional[str] = None
 
 
 class CrewRunListResponse(BaseModel):

--- a/backend/models/reddit_models.py
+++ b/backend/models/reddit_models.py
@@ -24,6 +24,9 @@ class RedditAccount(BaseModel):
     enabled: bool = Field(default=True)
     last_seen_ids: dict = Field(default_factory=dict)
 
+    inbound_enabled: bool = Field(default=True)
+    outbound_enabled: bool = Field(default=True)
+
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
 
@@ -44,6 +47,8 @@ class RedditAccountUpdate(BaseModel):
     keywords: Optional[List[str]] = None
     poll_inbox: Optional[bool] = None
     enabled: Optional[bool] = None
+    inbound_enabled: Optional[bool] = None
+    outbound_enabled: Optional[bool] = None
 
 
 class RedditPostReply(BaseModel):

--- a/backend/models/twitter_models.py
+++ b/backend/models/twitter_models.py
@@ -37,6 +37,9 @@ class TwitterAccount(BaseModel):
     enabled: bool = Field(default=True)
     last_seen_ids: dict = Field(default_factory=dict)
 
+    inbound_enabled: bool = Field(default=True)
+    outbound_enabled: bool = Field(default=True)
+
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
 
@@ -58,6 +61,8 @@ class TwitterAccountUpdate(BaseModel):
     poll_mentions: Optional[bool] = None
     poll_dms: Optional[bool] = None
     enabled: Optional[bool] = None
+    inbound_enabled: Optional[bool] = None
+    outbound_enabled: Optional[bool] = None
 
 
 class TwitterPostReply(BaseModel):

--- a/backend/routers/channels.py
+++ b/backend/routers/channels.py
@@ -100,6 +100,19 @@ async def register_channel(
     return {"status": "success", "data": reg}
 
 
+@router.delete("/registrations/{registration_id}", dependencies=[Depends(require_admin)])
+async def delete_registration(
+    registration_id: str,
+    svc: ChannelService = Depends(get_channel_service),
+):
+    """Remove a channel registration by its native _id."""
+    coll = svc.db["channel_registrations"]
+    result = await coll.delete_one({"_id": registration_id})
+    if result.deleted_count == 0:
+        raise HTTPException(404, f"Registration {registration_id} not found")
+    return {"status": "success"}
+
+
 @router.get("/conversations", dependencies=[Depends(require_admin)])
 async def list_conversations(
     channel_type: Optional[str] = Query(None),

--- a/backend/routers/connections.py
+++ b/backend/routers/connections.py
@@ -1,0 +1,103 @@
+"""Unified Connections REST API (Phase 3 PR 2).
+
+Surfaces all credential stores — OAuth (LinkedIn/IG/FB), Reddit, Twitter,
+token-paste channels (Telegram/Discord), and outbound-only types (Blog,
+Email, Slack webhook) — behind one endpoint.
+
+  GET    /api/v1/connections                      — unified list
+  GET    /api/v1/connections/{id}                 — single summary
+  PATCH  /api/v1/connections/{id}/capabilities    — toggle inbound/outbound
+  POST   /api/v1/connections/outbound             — create blog/email/slack_webhook
+  PUT    /api/v1/connections/outbound/{id}        — update
+  DELETE /api/v1/connections/outbound/{id}        — remove
+
+Per-platform credential endpoints (reddit, twitter, oauth, channels) stay
+unchanged — this router is a read-plus-capability-toggle layer on top.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from database import get_database
+from models.connection_models import (
+    CapabilityUpdate,
+    ConnectionListResponse,
+    ConnectionSummary,
+    OutboundConnectionCreate,
+    OutboundConnectionUpdate,
+)
+from services.auth_service import get_current_user
+from services.connection_service import ConnectionService
+
+router = APIRouter(prefix="/api/v1/connections", tags=["connections"])
+
+
+def _svc(db=Depends(get_database)) -> ConnectionService:
+    return ConnectionService(db)
+
+
+def _user_id(user: dict) -> str:
+    return user.get("user_id") or user.get("sub") or "desktop"
+
+
+# ---------------------------------------------------------------------------
+# List + single read
+# ---------------------------------------------------------------------------
+
+@router.get("", response_model=ConnectionListResponse)
+async def list_connections(svc: ConnectionService = Depends(_svc)):
+    rows = await svc.list_connections()
+    return ConnectionListResponse(connections=rows, total_count=len(rows))
+
+
+@router.get("/{connection_id}", response_model=ConnectionSummary)
+async def get_connection(
+    connection_id: str,
+    svc: ConnectionService = Depends(_svc),
+):
+    row = await svc.get_connection(connection_id)
+    if not row:
+        raise HTTPException(404, f"Connection {connection_id} not found")
+    return row
+
+
+# ---------------------------------------------------------------------------
+# PATCH capabilities
+# ---------------------------------------------------------------------------
+
+@router.patch("/{connection_id}/capabilities", response_model=ConnectionSummary)
+async def patch_capabilities(
+    connection_id: str,
+    update: CapabilityUpdate,
+    svc: ConnectionService = Depends(_svc),
+):
+    return await svc.update_capabilities(connection_id, update)
+
+
+# ---------------------------------------------------------------------------
+# Outbound-only CRUD (blog / email / slack_webhook)
+# ---------------------------------------------------------------------------
+
+@router.post("/outbound", response_model=ConnectionSummary, status_code=201)
+async def create_outbound(
+    request: OutboundConnectionCreate,
+    svc: ConnectionService = Depends(_svc),
+    user: dict = Depends(get_current_user),
+):
+    return await svc.create_outbound(request, _user_id(user))
+
+
+@router.put("/outbound/{connection_id}", response_model=ConnectionSummary)
+async def update_outbound(
+    connection_id: str,
+    update: OutboundConnectionUpdate,
+    svc: ConnectionService = Depends(_svc),
+):
+    return await svc.update_outbound(connection_id, update)
+
+
+@router.delete("/outbound/{connection_id}", status_code=204)
+async def delete_outbound(
+    connection_id: str,
+    svc: ConnectionService = Depends(_svc),
+):
+    await svc.delete_outbound(connection_id)

--- a/backend/services/channels/channel_service.py
+++ b/backend/services/channels/channel_service.py
@@ -572,6 +572,27 @@ class ChannelService:
             },
         )
 
+        # --- Phase 3 PR 3: unified inbound router (gated on UNIFIED_CREWS) ---
+        try:
+            from services.feature_flags import unified_crews_enabled
+            if unified_crews_enabled():
+                from services.inbound_router import route_inbound
+                routed = await route_inbound(self.db, msg)
+                if routed is not None:
+                    return {
+                        "session_id": session["session_id"],
+                        "channel_type": msg.channel_type.value,
+                        "sender": msg.sender_name,
+                        "text": msg.text,
+                        "message_id": msg.message_id,
+                        "status": routed.get("status", "dispatched"),
+                        "response": routed.get("response", ""),
+                        "run_id": routed.get("run_id"),
+                        "crew_id": routed.get("crew_id"),
+                    }
+        except Exception as e:
+            logger.warning("Inbound router failed, falling through to legacy triggers: %s", e)
+
         # --- Check for a trigger (crew dispatch) ---
         try:
             from services.trigger_service import TriggerService

--- a/backend/services/connection_service.py
+++ b/backend/services/connection_service.py
@@ -1,0 +1,419 @@
+"""
+ConnectionService — unified read/write over every credential store.
+
+Surfaces a single list of `ConnectionSummary` records merging:
+  - oauth_connections (linkedin / instagram / facebook — OAuth2)
+  - reddit_accounts (token-paste)
+  - twitter_accounts (OAuth 1.0a + bearer)
+  - channel_registrations (telegram / discord — token-paste)
+  - distribution_channels (blog / email / slack_webhook — the new outbound-only types)
+
+Each summary carries a `store` discriminator and a prefixed `id`
+(e.g. `oauth:linkedin`, `reddit:abc123`) so PATCH/DELETE can route back
+to the originating collection without ambiguity.
+
+Capability flags (`inbound_enabled` / `outbound_enabled`) are read from
+raw records with `.get(..., default)` — works whether PR 1's typed-model
+defaults have migrated yet or not.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+from fastapi import HTTPException
+
+from models.connection_models import (
+    OUTBOUND_ONLY_PLATFORMS,
+    PLATFORM_CAPABILITIES,
+    CapabilityUpdate,
+    ConnectionSummary,
+    OutboundConnectionCreate,
+    OutboundConnectionUpdate,
+)
+from services.distribution_service import DistributionService
+
+
+# Map ConnectionService platform slug → distribution_service.channel_type
+# (slack_webhook is our platform name; the underlying publisher in
+# distribution_service keys the record as "slack".)
+PLATFORM_TO_DIST_CHANNEL_TYPE = {
+    "blog": "blog",
+    "email": "email",
+    "slack_webhook": "slack",
+}
+DIST_CHANNEL_TYPE_TO_PLATFORM = {v: k for k, v in PLATFORM_TO_DIST_CHANNEL_TYPE.items()}
+
+OAUTH_PROVIDERS = ("linkedin", "instagram", "facebook")
+
+
+def _prefix(store: str, native_id: str) -> str:
+    return f"{store}:{native_id}"
+
+
+def _unprefix(prefixed_id: str) -> Tuple[str, str]:
+    if ":" not in prefixed_id:
+        raise HTTPException(400, f"Invalid connection id: {prefixed_id!r}")
+    store, native = prefixed_id.split(":", 1)
+    return store, native
+
+
+def _capability_defaults(platform: str) -> Dict[str, bool]:
+    """Return (inbound_enabled, outbound_enabled) defaults for a platform.
+
+    Outbound-only platforms default inbound off. Everything else defaults
+    both on — these are the flags applied when a record has never been
+    touched by a capability PATCH.
+    """
+    caps = PLATFORM_CAPABILITIES.get(platform, {})
+    return {
+        "inbound_enabled": caps.get("inbound_supported", False),
+        "outbound_enabled": caps.get("outbound_supported", False),
+    }
+
+
+def _mask(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    if len(value) <= 4:
+        return "****"
+    return value[:2] + "****" + value[-2:]
+
+
+class ConnectionService:
+    def __init__(self, db):
+        self.db = db
+        self.distribution = DistributionService(db)
+
+    # ------------------------------------------------------------------
+    # LIST
+    # ------------------------------------------------------------------
+
+    async def list_connections(self) -> List[ConnectionSummary]:
+        out: List[ConnectionSummary] = []
+        out.extend(await self._list_oauth())
+        out.extend(await self._list_reddit())
+        out.extend(await self._list_twitter())
+        out.extend(await self._list_channel_registrations())
+        out.extend(await self._list_outbound())
+        return out
+
+    async def _list_oauth(self) -> List[ConnectionSummary]:
+        rows: List[ConnectionSummary] = []
+        coll = self.db["oauth_connections"]
+        async for doc in coll.find({}):
+            provider = doc.get("_id") if isinstance(doc.get("_id"), str) else None
+            if provider not in OAUTH_PROVIDERS:
+                continue
+            connected = bool(doc.get("access_token"))
+            caps = _capability_defaults(provider)
+            rows.append(ConnectionSummary(
+                id=_prefix("oauth", provider),
+                platform=provider,
+                store="oauth_connections",
+                display_name=doc.get("profile_name") or provider.title(),
+                connected=connected,
+                inbound_enabled=bool(doc.get("inbound_enabled", caps["inbound_enabled"])),
+                outbound_enabled=bool(doc.get("outbound_enabled", caps["outbound_enabled"])),
+                inbound_supported=PLATFORM_CAPABILITIES[provider]["inbound_supported"],
+                outbound_supported=PLATFORM_CAPABILITIES[provider]["outbound_supported"],
+                config_summary={
+                    "profile_id": doc.get("profile_id"),
+                    "scopes": doc.get("scopes", []),
+                    "org_id": doc.get("org_id"),
+                    "expires_in": doc.get("expires_in"),
+                },
+                created_at=doc.get("connected_at") or doc.get("updated_at"),
+                updated_at=doc.get("updated_at"),
+            ))
+        return rows
+
+    async def _list_reddit(self) -> List[ConnectionSummary]:
+        rows: List[ConnectionSummary] = []
+        coll = self.db["reddit_accounts"]
+        async for doc in coll.find({}):
+            native_id = str(doc.get("_id"))
+            caps = _capability_defaults("reddit")
+            rows.append(ConnectionSummary(
+                id=_prefix("reddit", native_id),
+                platform="reddit",
+                store="reddit_accounts",
+                display_name=doc.get("username"),
+                connected=bool(doc.get("client_id") and doc.get("client_secret")),
+                inbound_enabled=bool(doc.get("inbound_enabled", caps["inbound_enabled"])),
+                outbound_enabled=bool(doc.get("outbound_enabled", caps["outbound_enabled"])),
+                inbound_supported=True,
+                outbound_supported=True,
+                config_summary={
+                    "subreddits": doc.get("subreddits", []),
+                    "keyword_count": len(doc.get("keywords", []) or []),
+                    "poll_inbox": doc.get("poll_inbox", True),
+                },
+                created_at=_iso(doc.get("created_at")),
+                updated_at=_iso(doc.get("updated_at")),
+            ))
+        return rows
+
+    async def _list_twitter(self) -> List[ConnectionSummary]:
+        rows: List[ConnectionSummary] = []
+        coll = self.db["twitter_accounts"]
+        async for doc in coll.find({}):
+            native_id = str(doc.get("_id"))
+            caps = _capability_defaults("twitter")
+            has_write = bool(
+                doc.get("api_key") and doc.get("api_secret")
+                and doc.get("access_token") and doc.get("access_token_secret")
+            )
+            rows.append(ConnectionSummary(
+                id=_prefix("twitter", native_id),
+                platform="twitter",
+                store="twitter_accounts",
+                display_name=doc.get("user_id"),
+                connected=bool(doc.get("user_id") and (doc.get("bearer_token") or has_write)),
+                inbound_enabled=bool(doc.get("inbound_enabled", caps["inbound_enabled"])),
+                # If no OAuth 1.0a creds, outbound is physically impossible — force off.
+                outbound_enabled=bool(doc.get("outbound_enabled", caps["outbound_enabled"])) and has_write,
+                inbound_supported=True,
+                outbound_supported=has_write,
+                config_summary={
+                    "poll_mentions": doc.get("poll_mentions", True),
+                    "poll_dms": doc.get("poll_dms", True),
+                    "has_write_creds": has_write,
+                    "keyword_count": len(doc.get("keywords", []) or []),
+                },
+                created_at=_iso(doc.get("created_at")),
+                updated_at=_iso(doc.get("updated_at")),
+            ))
+        return rows
+
+    async def _list_channel_registrations(self) -> List[ConnectionSummary]:
+        rows: List[ConnectionSummary] = []
+        coll = self.db["channel_registrations"]
+        async for doc in coll.find({"channel_type": {"$in": ["telegram", "discord"]}}):
+            platform = doc["channel_type"]
+            native_id = str(doc.get("_id"))
+            caps = _capability_defaults(platform)
+            rows.append(ConnectionSummary(
+                id=_prefix("channel", native_id),
+                platform=platform,
+                store="channel_registrations",
+                display_name=(doc.get("config") or {}).get("bot_name") or platform.title(),
+                connected=bool((doc.get("config") or {}).get("bot_token")),
+                inbound_enabled=bool(doc.get("inbound_enabled", caps["inbound_enabled"])),
+                outbound_enabled=bool(doc.get("outbound_enabled", caps["outbound_enabled"])),
+                inbound_supported=True,
+                outbound_supported=True,
+                config_summary={
+                    "has_token": bool((doc.get("config") or {}).get("bot_token")),
+                },
+                created_at=_iso(doc.get("created_at")),
+                updated_at=_iso(doc.get("updated_at")),
+            ))
+        return rows
+
+    async def _list_outbound(self) -> List[ConnectionSummary]:
+        """Blog/email/slack from distribution_channels. Skip rows that duplicate OAuth providers."""
+        rows: List[ConnectionSummary] = []
+        coll = self.db["distribution_channels"]
+        async for doc in coll.find({"channel_type": {"$in": list(DIST_CHANNEL_TYPE_TO_PLATFORM.keys())}}):
+            underlying = doc.get("channel_type")
+            platform = DIST_CHANNEL_TYPE_TO_PLATFORM.get(underlying)
+            if not platform:
+                continue
+            channel_id = doc.get("channel_id") or str(doc.get("_id"))
+            caps = _capability_defaults(platform)
+            cfg = doc.get("config") or {}
+            rows.append(ConnectionSummary(
+                id=_prefix("outbound", channel_id),
+                platform=platform,
+                store="distribution_channels",
+                display_name=doc.get("name"),
+                connected=bool(doc.get("enabled", True)),
+                inbound_enabled=bool(doc.get("inbound_enabled", caps["inbound_enabled"])),
+                outbound_enabled=bool(doc.get("outbound_enabled", caps["outbound_enabled"])),
+                inbound_supported=False,
+                outbound_supported=True,
+                config_summary=self._outbound_summary(platform, cfg),
+                created_at=doc.get("created_at"),
+                updated_at=doc.get("updated_at"),
+            ))
+        return rows
+
+    @staticmethod
+    def _outbound_summary(platform: str, cfg: Dict[str, Any]) -> Dict[str, Any]:
+        if platform == "blog":
+            return {"cms_type": cfg.get("cms_type"), "api_url": cfg.get("api_url")}
+        if platform == "email":
+            return {"provider": cfg.get("provider"), "from_email": cfg.get("from_email")}
+        if platform == "slack_webhook":
+            return {"webhook_host": _webhook_host(cfg.get("webhook_url"))}
+        return {}
+
+    # ------------------------------------------------------------------
+    # GET single
+    # ------------------------------------------------------------------
+
+    async def get_connection(self, connection_id: str) -> Optional[ConnectionSummary]:
+        store, native = _unprefix(connection_id)
+        all_rows = await self.list_connections()
+        for row in all_rows:
+            if row.id == connection_id:
+                return row
+        return None
+
+    # ------------------------------------------------------------------
+    # PATCH capabilities
+    # ------------------------------------------------------------------
+
+    async def update_capabilities(
+        self,
+        connection_id: str,
+        update: CapabilityUpdate,
+    ) -> ConnectionSummary:
+        store, native = _unprefix(connection_id)
+        existing = await self.get_connection(connection_id)
+        if not existing:
+            raise HTTPException(404, f"Connection {connection_id} not found")
+
+        # Reject toggling a capability the platform doesn't support
+        if update.inbound_enabled is True and not existing.inbound_supported:
+            raise HTTPException(
+                422,
+                f"Platform {existing.platform} does not support inbound",
+            )
+        if update.outbound_enabled is True and not existing.outbound_supported:
+            raise HTTPException(
+                422,
+                f"Platform {existing.platform} does not support outbound",
+            )
+
+        set_fields: Dict[str, Any] = {"updated_at": datetime.utcnow().isoformat()}
+        if update.inbound_enabled is not None:
+            set_fields["inbound_enabled"] = update.inbound_enabled
+        if update.outbound_enabled is not None:
+            set_fields["outbound_enabled"] = update.outbound_enabled
+
+        if store == "oauth":
+            await self.db["oauth_connections"].update_one(
+                {"_id": native}, {"$set": set_fields}
+            )
+        elif store == "reddit":
+            await self.db["reddit_accounts"].update_one(
+                _by_id(native), {"$set": set_fields}
+            )
+        elif store == "twitter":
+            await self.db["twitter_accounts"].update_one(
+                _by_id(native), {"$set": set_fields}
+            )
+        elif store == "channel":
+            await self.db["channel_registrations"].update_one(
+                _by_id(native), {"$set": set_fields}
+            )
+        elif store == "outbound":
+            await self.db["distribution_channels"].update_one(
+                {"channel_id": native}, {"$set": set_fields}
+            )
+        else:
+            raise HTTPException(400, f"Unknown connection store: {store}")
+
+        refreshed = await self.get_connection(connection_id)
+        if not refreshed:
+            raise HTTPException(500, "Failed to re-read connection after update")
+        return refreshed
+
+    # ------------------------------------------------------------------
+    # Outbound CRUD (blog / email / slack_webhook)
+    # ------------------------------------------------------------------
+
+    async def create_outbound(
+        self,
+        req: OutboundConnectionCreate,
+        user_id: str,
+    ) -> ConnectionSummary:
+        if req.platform not in OUTBOUND_ONLY_PLATFORMS:
+            raise HTTPException(400, f"Platform {req.platform} is not outbound-only")
+
+        underlying = PLATFORM_TO_DIST_CHANNEL_TYPE[req.platform]
+        doc = await self.distribution.create_channel(
+            channel_type=underlying,
+            name=req.name,
+            config=req.config,
+            organization="solo",
+            created_by=user_id,
+        )
+        # Write capability defaults so reads are stable
+        await self.db["distribution_channels"].update_one(
+            {"channel_id": doc["channel_id"]},
+            {"$set": {
+                "inbound_enabled": False,
+                "outbound_enabled": True,
+                "enabled": req.enabled,
+            }},
+        )
+        summary = await self.get_connection(_prefix("outbound", doc["channel_id"]))
+        if not summary:
+            raise HTTPException(500, "Created outbound connection could not be read back")
+        return summary
+
+    async def update_outbound(
+        self,
+        connection_id: str,
+        update: OutboundConnectionUpdate,
+    ) -> ConnectionSummary:
+        store, native = _unprefix(connection_id)
+        if store != "outbound":
+            raise HTTPException(400, "Only outbound-only connections support this update")
+        set_fields: Dict[str, Any] = {}
+        if update.name is not None:
+            set_fields["name"] = update.name
+        if update.config is not None:
+            set_fields["config"] = update.config
+        if update.enabled is not None:
+            set_fields["enabled"] = update.enabled
+        set_fields["updated_at"] = datetime.utcnow().isoformat()
+        result = await self.db["distribution_channels"].update_one(
+            {"channel_id": native}, {"$set": set_fields}
+        )
+        if result.matched_count == 0:
+            raise HTTPException(404, f"Outbound connection {connection_id} not found")
+        summary = await self.get_connection(connection_id)
+        if not summary:
+            raise HTTPException(404, f"Outbound connection {connection_id} not found")
+        return summary
+
+    async def delete_outbound(self, connection_id: str) -> None:
+        store, native = _unprefix(connection_id)
+        if store != "outbound":
+            raise HTTPException(400, "Only outbound-only connections support delete via this endpoint")
+        deleted = await self.distribution.delete_channel(native)
+        if not deleted:
+            raise HTTPException(404, f"Outbound connection {connection_id} not found")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _by_id(native_id: str) -> Dict[str, Any]:
+    """SQLite adapter stores _id as str; return a single-key filter."""
+    return {"_id": native_id}
+
+
+def _iso(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def _webhook_host(url: Optional[str]) -> Optional[str]:
+    if not url:
+        return None
+    # Only expose the host — redact the token segment for privacy.
+    try:
+        from urllib.parse import urlparse
+        return urlparse(url).hostname
+    except Exception:
+        return None

--- a/backend/services/crew_orchestrator.py
+++ b/backend/services/crew_orchestrator.py
@@ -826,14 +826,24 @@ class CrewOrchestrator:
         self, crew: Dict[str, Any], content: str, run_id: str
     ) -> List[Dict[str, Any]]:
         """
-        Publish crew output to all enabled channel_bindings.
+        Publish crew output.
 
-        For each binding, finds a matching distribution channel (by channel_type)
-        and publishes the raw agent output. If approval_required, routes to the
-        approval queue instead.
+        When UNIFIED_CREWS is on AND the crew has `connection_bindings[]`,
+        publishes to every binding whose direction is "outbound" or "both",
+        and honours the crew-level `approval_required` flag.
 
-        Returns a list of publish result dicts for tracking.
+        Otherwise falls back to the legacy `channel_bindings[]` path.
         """
+        try:
+            from services.feature_flags import unified_crews_enabled
+            unified = unified_crews_enabled()
+        except Exception:
+            unified = False
+
+        connection_bindings = crew.get("connection_bindings") or []
+        if unified and connection_bindings:
+            return await self._publish_via_connection_bindings(crew, content, run_id)
+
         bindings = crew.get("channel_bindings", [])
         if not bindings:
             return []
@@ -938,5 +948,110 @@ class CrewOrchestrator:
                     "error": str(e),
                 })
                 logger.warning(f"Failed to publish to {channel_type}: {e}")
+
+        return publish_results
+
+    async def _publish_via_connection_bindings(
+        self, crew: Dict[str, Any], content: str, run_id: str
+    ) -> List[Dict[str, Any]]:
+        """Phase 3 outbound: publish via crew.connection_bindings (direction-aware).
+
+        Iterates `connection_bindings[]` filtering for direction in
+        ("outbound", "both"). Each binding's `platform` is mapped onto a
+        distribution channel by channel_type (the same id namespace today's
+        DistributionService uses). `crew.approval_required` (top-level on
+        the crew) routes the output to the approval queue instead of
+        publishing directly.
+        """
+        from database import get_database
+        from services.distribution_service import DistributionService
+
+        db = await get_database()
+        dist_svc = DistributionService(db)
+        publish_results: List[Dict[str, Any]] = []
+        approval_required = bool(crew.get("approval_required"))
+
+        # `slack_webhook` is stored as `slack` in distribution_channels.
+        platform_to_channel_type = {
+            "slack_webhook": "slack",
+        }
+
+        for binding in (crew.get("connection_bindings") or []):
+            direction = (binding or {}).get("direction") or "both"
+            if direction not in ("outbound", "both"):
+                continue
+            platform = binding.get("platform")
+            if not platform:
+                continue
+            channel_type = platform_to_channel_type.get(platform, platform)
+
+            channel_doc = await db["distribution_channels"].find_one({
+                "channel_type": channel_type,
+                "enabled": True,
+            })
+            if not channel_doc:
+                logger.info(
+                    "No distribution channel for platform '%s' — skipping outbound for crew '%s'",
+                    platform, crew.get("name"),
+                )
+                continue
+
+            channel_id = channel_doc.get("channel_id")
+
+            if approval_required:
+                try:
+                    import uuid
+                    await db["approval_queue"].insert_one({
+                        "_id": str(uuid.uuid4()),
+                        "approval_id": str(uuid.uuid4()),
+                        "type": "crew_publish",
+                        "crew_id": crew.get("crew_id"),
+                        "crew_name": crew.get("name"),
+                        "run_id": run_id,
+                        "channel_type": channel_type,
+                        "channel_id": channel_id,
+                        "platform": platform,
+                        "draft_response": content,
+                        "content": content,
+                        "status": "pending",
+                        "created_at": datetime.utcnow().isoformat(),
+                    })
+                    publish_results.append({
+                        "platform": platform,
+                        "channel_type": channel_type,
+                        "status": "pending_approval",
+                    })
+                except Exception as e:
+                    publish_results.append({
+                        "platform": platform,
+                        "channel_type": channel_type,
+                        "status": "error",
+                        "error": str(e),
+                    })
+                continue
+
+            try:
+                result = await dist_svc.publish(
+                    channel_id=channel_id,
+                    content=content,
+                    title=f"Crew: {crew.get('name', 'Untitled')}",
+                    published_by=f"crew:{crew.get('crew_id')}",
+                )
+                pub_result = result.get("result", {})
+                success = pub_result.get("success", False)
+                publish_results.append({
+                    "platform": platform,
+                    "channel_type": channel_type,
+                    "status": "published" if success else "failed",
+                    "post_id": pub_result.get("post_id"),
+                    "error": pub_result.get("error") if not success else None,
+                })
+            except Exception as e:
+                publish_results.append({
+                    "platform": platform,
+                    "channel_type": channel_type,
+                    "status": "error",
+                    "error": str(e),
+                })
 
         return publish_results

--- a/backend/services/crew_service.py
+++ b/backend/services/crew_service.py
@@ -24,6 +24,39 @@ logger = logging.getLogger(__name__)
 
 MAX_CREWS_PER_USER = 50
 
+
+async def _refresh_scheduled_runner(db, crew_id: str) -> None:
+    """Re-register a crew's scheduled triggers with the global runner.
+
+    No-op when UNIFIED_CREWS is off or the runner hasn't been started — keeps
+    crew create/update working in test contexts that don't boot the scheduler.
+    """
+    try:
+        from services.feature_flags import unified_crews_enabled
+        if not unified_crews_enabled():
+            return
+        from app import app as fastapi_app
+        runner = getattr(fastapi_app.state, "scheduled_runner", None)
+        if runner is None:
+            return
+        await runner.refresh_for_crew(crew_id)
+    except Exception:
+        logger.debug("scheduled_runner refresh skipped", exc_info=True)
+
+
+def _unregister_scheduled_runner(crew_id: str) -> None:
+    try:
+        from services.feature_flags import unified_crews_enabled
+        if not unified_crews_enabled():
+            return
+        from app import app as fastapi_app
+        runner = getattr(fastapi_app.state, "scheduled_runner", None)
+        if runner is None:
+            return
+        runner.unregister_for_crew(crew_id)
+    except Exception:
+        logger.debug("scheduled_runner unregister skipped", exc_info=True)
+
 # ----------------------------------------------------------------
 # Workspace agent category → crew agent role mapping
 # ----------------------------------------------------------------
@@ -115,6 +148,7 @@ class CrewService:
 
         crew = await self.crew_repo.create_crew(user_id, crew_data)
         logger.info(f"Created crew '{request.name}' (crew_id={crew['crew_id']}) for user {user_id}")
+        await _refresh_scheduled_runner(self.crew_repo.db, crew["crew_id"])
         return crew
 
     async def get_crew(self, crew_id: str, user_id: str) -> Optional[Dict[str, Any]]:
@@ -172,6 +206,7 @@ class CrewService:
         updated = await self.crew_repo.update_crew(crew_id, update_data)
         if updated:
             logger.info(f"Updated crew {crew_id}")
+            await _refresh_scheduled_runner(self.crew_repo.db, crew_id)
         return updated
 
     async def delete_crew(self, crew_id: str, user_id: str) -> bool:
@@ -182,6 +217,7 @@ class CrewService:
         deleted = await self.crew_repo.soft_delete_crew(crew_id)
         if deleted:
             logger.info(f"Soft-deleted crew {crew_id}")
+            _unregister_scheduled_runner(crew_id)
         return deleted
 
     # ------------------------------------------------------------------
@@ -189,13 +225,19 @@ class CrewService:
     # ------------------------------------------------------------------
 
     async def start_run(
-        self, crew_id: str, user_id: str, request: RunCrewRequest
+        self,
+        crew_id: str,
+        user_id: str,
+        request: RunCrewRequest,
+        trigger_type: str = "manual",
+        trigger_source: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Initiate a new crew execution run.
 
-        Creates the run record with agent states. Actual execution
-        will be handled by the CrewOrchestrator (Task #23) via Celery.
+        `trigger_type` records why this run fired: "manual" (Run button),
+        "reactive" (inbound message matched a trigger), or "scheduled" (cron/run_at).
+        `trigger_source` is the connection_id, cron expression, or "manual".
         """
         crew = await self.get_crew(crew_id, user_id)
         if not crew:
@@ -244,6 +286,8 @@ class CrewService:
             "input": request.input,
             "input_data": request.input_data if request.input_data else None,
             "agents": agent_states,
+            "trigger_type": trigger_type,
+            "trigger_source": trigger_source if trigger_source is not None else ("manual" if trigger_type == "manual" else None),
         }
 
         run = await self.run_repo.create_run(crew_id, user_id, run_data)

--- a/backend/services/crew_service.py
+++ b/backend/services/crew_service.py
@@ -189,13 +189,19 @@ class CrewService:
     # ------------------------------------------------------------------
 
     async def start_run(
-        self, crew_id: str, user_id: str, request: RunCrewRequest
+        self,
+        crew_id: str,
+        user_id: str,
+        request: RunCrewRequest,
+        trigger_type: str = "manual",
+        trigger_source: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Initiate a new crew execution run.
 
-        Creates the run record with agent states. Actual execution
-        will be handled by the CrewOrchestrator (Task #23) via Celery.
+        `trigger_type` records why this run fired: "manual" (Run button),
+        "reactive" (inbound message matched a trigger), or "scheduled" (cron/run_at).
+        `trigger_source` is the connection_id, cron expression, or "manual".
         """
         crew = await self.get_crew(crew_id, user_id)
         if not crew:
@@ -244,6 +250,8 @@ class CrewService:
             "input": request.input,
             "input_data": request.input_data if request.input_data else None,
             "agents": agent_states,
+            "trigger_type": trigger_type,
+            "trigger_source": trigger_source if trigger_source is not None else ("manual" if trigger_type == "manual" else None),
         }
 
         run = await self.run_repo.create_run(crew_id, user_id, run_data)

--- a/backend/services/feature_flags.py
+++ b/backend/services/feature_flags.py
@@ -22,5 +22,10 @@ def _env_truthy(name: str, default: bool = False) -> bool:
 
 
 def unified_crews_enabled() -> bool:
-    """Read at call time so tests can monkeypatch the env var per-case."""
-    return _env_truthy("UNIFIED_CREWS", default=False)
+    """Read at call time so tests can monkeypatch the env var per-case.
+
+    Phase 3 PR 4 flipped the default to True — the unified inbound_router +
+    scheduled_runner + direction-aware outbound publishing is now the primary
+    code path. Set UNIFIED_CREWS=0 to fall back to the legacy paths.
+    """
+    return _env_truthy("UNIFIED_CREWS", default=True)

--- a/backend/services/feature_flags.py
+++ b/backend/services/feature_flags.py
@@ -1,0 +1,26 @@
+"""Phase 3 feature flags.
+
+Phase 3 ships behind `UNIFIED_CREWS` so existing inbound/outbound paths keep
+working until PR 4 flips the default to true.
+
+  UNIFIED_CREWS=1   → inbound_router + scheduled_runner + connection_bindings
+                       outbound publishing all active.
+  UNIFIED_CREWS=0   → legacy trigger_service + channel_bindings outbound path
+                       (today's behaviour).
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def _env_truthy(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in ("1", "true", "yes", "on")
+
+
+def unified_crews_enabled() -> bool:
+    """Read at call time so tests can monkeypatch the env var per-case."""
+    return _env_truthy("UNIFIED_CREWS", default=False)

--- a/backend/services/inbound_router.py
+++ b/backend/services/inbound_router.py
@@ -1,0 +1,182 @@
+"""
+Phase 3 PR 3 — Inbound Router.
+
+Sits in front of the legacy `trigger_service.check_and_dispatch` path.
+
+When UNIFIED_CREWS=on, an incoming `ChannelMessage` is matched against every
+crew that has a `triggers[type=reactive]` entry whose `connection_id` matches
+the message's connection AND whose keywords/hashtags/mentions appear in the
+message text. Exactly-one match → dispatch immediately. Multi-match → an LLM
+disambiguator picks the best crew based on its name/description.
+
+The router is intentionally additive: the call site checks the flag and falls
+through to today's path if it's off, or if no reactive crew matches.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+# Map ChannelType.value → connection_id slug used in crew.triggers.connection_id.
+# Single-user desktop = one auth per platform, so the platform name is the id.
+PLATFORM_FROM_CHANNEL_TYPE = {
+    "telegram": "telegram",
+    "discord": "discord",
+    "reddit": "reddit",
+    "twitter": "twitter",
+    "linkedin": "linkedin",
+    "instagram": "instagram",
+    "facebook": "facebook",
+}
+
+
+def _normalize(text: str) -> str:
+    return (text or "").lower().strip()
+
+
+def _trigger_matches(trigger: Dict[str, Any], text: str) -> bool:
+    """Return True if any keyword/hashtag/mention substring-matches the text.
+
+    Match rule: case-insensitive substring. Empty rule lists do not match —
+    a reactive trigger with no rules at all should never have been saved
+    (Pydantic validator on the model rejects it), but we defend here too.
+    """
+    haystack = _normalize(text)
+    if not haystack:
+        return False
+    rules: List[str] = []
+    rules.extend(trigger.get("keywords") or [])
+    rules.extend(trigger.get("hashtags") or [])
+    rules.extend(trigger.get("mentions") or [])
+    if not rules:
+        return False
+    return any(_normalize(r) in haystack for r in rules if r and r.strip())
+
+
+async def find_matching_crews(
+    db,
+    connection_id: str,
+    text: str,
+) -> List[Tuple[Dict[str, Any], Dict[str, Any]]]:
+    """Return [(crew, matching_trigger)] across all active crews."""
+    matches: List[Tuple[Dict[str, Any], Dict[str, Any]]] = []
+    cursor = db["crews"].find({"status": "active"})
+    async for crew in cursor:
+        triggers = crew.get("triggers") or []
+        for trigger in triggers:
+            if (trigger or {}).get("type") != "reactive":
+                continue
+            if trigger.get("connection_id") != connection_id:
+                continue
+            if _trigger_matches(trigger, text):
+                matches.append((crew, trigger))
+                break  # one trigger per crew is enough to qualify
+    return matches
+
+
+async def disambiguate_with_llm(
+    candidates: List[Dict[str, Any]],
+    message_text: str,
+) -> Dict[str, Any]:
+    """Ask a cheap local model to pick the best crew. Falls back to first match
+    on any failure — never block dispatch on LLM availability.
+    """
+    try:
+        from services.local_model_service import LocalModelService
+    except Exception:
+        return candidates[0]
+
+    try:
+        svc = LocalModelService()
+    except Exception:
+        return candidates[0]
+
+    options_lines = []
+    for idx, crew in enumerate(candidates, start=1):
+        name = crew.get("name") or "(unnamed)"
+        desc = (crew.get("description") or "")[:200].replace("\n", " ")
+        options_lines.append(f"{idx}. {name} — {desc}")
+    options = "\n".join(options_lines)
+
+    prompt = (
+        "You are routing an inbound message to one of several crews.\n"
+        "Pick the single best crew and reply with only its number.\n\n"
+        f"Message:\n{message_text[:600]}\n\n"
+        f"Crews:\n{options}\n\n"
+        "Answer with just the number:"
+    )
+
+    try:
+        # Use whichever local model is loaded; very short generation.
+        result = await svc.generate(prompt=prompt, max_tokens=4, temperature=0.0)
+        answer = (result or {}).get("response") or (result or {}).get("text") or ""
+        match = re.search(r"\d+", answer)
+        if match:
+            idx = int(match.group(0)) - 1
+            if 0 <= idx < len(candidates):
+                return candidates[idx]
+    except Exception as exc:
+        logger.info("LLM disambiguator unavailable, defaulting to first match: %s", exc)
+
+    return candidates[0]
+
+
+async def route_inbound(db, msg) -> Optional[Dict[str, Any]]:
+    """
+    Find a reactive-triggered crew for this message and dispatch it.
+
+    Returns the dispatch result (with status / response / run_id), or None
+    if no crew matched — call site should then fall through to the legacy
+    trigger_service path.
+    """
+    channel_value = msg.channel_type.value if hasattr(msg.channel_type, "value") else str(msg.channel_type)
+    connection_id = PLATFORM_FROM_CHANNEL_TYPE.get(channel_value)
+    if not connection_id:
+        return None
+
+    matches = await find_matching_crews(db, connection_id, msg.text)
+    if not matches:
+        return None
+
+    if len(matches) == 1:
+        crew, trigger = matches[0]
+    else:
+        chosen = await disambiguate_with_llm([c for c, _ in matches], msg.text)
+        # Map back to (crew, trigger)
+        crew, trigger = next(((c, t) for c, t in matches if c is chosen), matches[0])
+
+    crew_id = crew.get("crew_id")
+    user_id = crew.get("user_id") or "desktop-user"
+
+    # Dispatch via crew_service so the run record carries trigger metadata.
+    from models.crew_models import RunCrewRequest
+    from repositories.crew_repository import CrewRepository, CrewRunRepository
+    from repositories.workspace_agent_repository import WorkspaceAgentRepository
+    from services.crew_service import CrewService
+
+    crew_repo = CrewRepository(db)
+    run_repo = CrewRunRepository(db)
+    agent_repo = WorkspaceAgentRepository(db)
+    svc = CrewService(crew_repo=crew_repo, run_repo=run_repo, agent_repo=agent_repo)
+
+    request = RunCrewRequest(input=msg.text)
+    run = await svc.start_run(
+        crew_id=crew_id,
+        user_id=user_id,
+        request=request,
+        trigger_type="reactive",
+        trigger_source=connection_id,
+    )
+
+    return {
+        "status": "dispatched",
+        "response": f"Crew '{crew.get('name')}' is processing your message…",
+        "run_id": run.get("run_id"),
+        "crew_id": crew_id,
+        "trigger_source": connection_id,
+    }

--- a/backend/services/migrations/unify_connections_migration.py
+++ b/backend/services/migrations/unify_connections_migration.py
@@ -1,0 +1,145 @@
+"""
+Phase 3 PR 1 migration: backfill connection_bindings, triggers, approval_required.
+
+Idempotent. Inline at startup. Tracks completion in the `migrations_applied`
+collection. Set MIGRATE_DRY_RUN=1 to log the diff without writing.
+
+What it does
+------------
+1. For every crew with non-empty legacy `channel_bindings` and empty
+   `connection_bindings`, convert each binding to the new schema with
+   `direction="both"` (preserves current behavior — bound channels were
+   implicitly bidirectional).
+2. If any legacy binding had `approval_required=true`, set the new
+   top-level `crew.approval_required=true`.
+3. Defaults `triggers=[]`, `connection_bindings=[]`, `approval_required=false`
+   on any crew missing the fields entirely.
+4. Records orphan `distribution_channels` (no matching crew) for follow-up.
+
+The migration does NOT delete `channel_bindings` — they stay alongside the new
+fields until PR 4 retires the legacy code path.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+MIGRATION_NAME = "unify_connections_v1"
+MARKER_COLLECTION = "migrations_applied"
+
+
+def _is_dry_run() -> bool:
+    return os.environ.get("MIGRATE_DRY_RUN", "").strip() in ("1", "true", "True")
+
+
+def _connection_id_for(channel_type: str) -> str:
+    """For legacy bindings, the channel_type is the de-facto connection identifier
+    (single-user app: one Telegram, one Discord, etc.). PR 2's connection_service
+    normalises this to real record IDs."""
+    return channel_type
+
+
+async def run_unify_connections_migration(db) -> Dict[str, Any]:
+    """Run the migration. Returns a stats dict (always — even on dry run / no-op)."""
+    dry_run = _is_dry_run()
+    stats: Dict[str, Any] = {
+        "name": MIGRATION_NAME,
+        "dry_run": dry_run,
+        "skipped": False,
+        "crews_processed": 0,
+        "bindings_converted": 0,
+        "crews_marked_approval_required": 0,
+        "crews_initialised_empty": 0,
+        "distribution_channels_orphaned": 0,
+    }
+
+    marker_collection = db[MARKER_COLLECTION]
+    existing = await marker_collection.find_one({"name": MIGRATION_NAME})
+    if existing:
+        stats["skipped"] = True
+        logger.info("Migration %s already applied at %s — skipping",
+                    MIGRATION_NAME, existing.get("applied_at"))
+        return stats
+
+    crews_collection = db["crews"]
+    cursor = crews_collection.find({})
+    diff_log = []
+
+    async for crew in cursor:
+        stats["crews_processed"] += 1
+        crew_id = crew.get("crew_id") or str(crew.get("_id"))
+        legacy_bindings = crew.get("channel_bindings") or []
+        new_bindings = crew.get("connection_bindings") or []
+        crew_changes: Dict[str, Any] = {}
+
+        if legacy_bindings and not new_bindings:
+            converted = []
+            any_approval = False
+            for binding in legacy_bindings:
+                channel_type = binding.get("channel_type")
+                if not channel_type:
+                    continue
+                converted.append({
+                    "connection_id": _connection_id_for(channel_type),
+                    "platform": channel_type,
+                    "direction": "both",
+                })
+                if binding.get("approval_required"):
+                    any_approval = True
+
+            if converted:
+                crew_changes["connection_bindings"] = converted
+                stats["bindings_converted"] += len(converted)
+
+            if any_approval and not crew.get("approval_required"):
+                crew_changes["approval_required"] = True
+                stats["crews_marked_approval_required"] += 1
+
+        if "connection_bindings" not in crew:
+            crew_changes.setdefault("connection_bindings", new_bindings)
+            stats["crews_initialised_empty"] += 1
+        if "triggers" not in crew:
+            crew_changes.setdefault("triggers", crew.get("triggers") or [])
+        if "approval_required" not in crew:
+            crew_changes.setdefault("approval_required", bool(crew.get("approval_required")))
+
+        if crew_changes:
+            diff_log.append({"crew_id": crew_id, "changes": crew_changes})
+            if not dry_run:
+                await crews_collection.update_one(
+                    {"_id": crew["_id"]},
+                    {"$set": crew_changes},
+                )
+
+    # Orphan check: distribution_channels with no crew tied to them.
+    # In v1 we just count and log — PR 2 wires real ownership.
+    try:
+        dc_collection = db["distribution_channels"]
+        dc_count = await dc_collection.count_documents({})
+        stats["distribution_channels_orphaned"] = dc_count
+    except Exception:
+        # Collection may not exist yet on a fresh install
+        pass
+
+    if dry_run:
+        logger.info(
+            "[DRY RUN] %s would touch %d crew(s); diff:\n%s",
+            MIGRATION_NAME,
+            len(diff_log),
+            json.dumps(diff_log, indent=2, default=str)[:4000],
+        )
+        return stats
+
+    await marker_collection.insert_one({
+        "name": MIGRATION_NAME,
+        "applied_at": datetime.utcnow().isoformat(),
+        "stats": {k: v for k, v in stats.items() if k != "name"},
+    })
+    logger.info("Migration %s applied: %s", MIGRATION_NAME, stats)
+    return stats

--- a/backend/services/scheduled_runner.py
+++ b/backend/services/scheduled_runner.py
@@ -1,0 +1,210 @@
+"""
+Phase 3 PR 3 — Scheduled Runner for crew triggers.
+
+Reads `crew.triggers[type=scheduled]` across all active crews and registers
+each one as an APScheduler job. When the trigger fires, dispatches the crew
+via ``crew_service.start_run`` with ``trigger_type="scheduled"`` so the run
+record carries its origin.
+
+APScheduler job-id namespace: ``crew-trigger:<crew_id>:<trigger_index>``
+(one crew can hold multiple scheduled triggers).
+
+This runs alongside the legacy `SchedulerService` (which handles post / crew
+jobs from the `scheduled_jobs` collection). They share the APScheduler
+instance but use disjoint id namespaces, so neither interferes with the
+other. PR 4 can retire the legacy scheduler once v1 soaks.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+CREW_TRIGGER_PREFIX = "crew-trigger:"
+
+
+def _aps_id(crew_id: str, trigger_idx: int) -> str:
+    return f"{CREW_TRIGGER_PREFIX}{crew_id}:{trigger_idx}"
+
+
+class ScheduledRunner:
+    """Registers crew scheduled triggers with APScheduler."""
+
+    def __init__(self, db, apscheduler_adapter: Any) -> None:
+        self.db = db
+        self.adapter = apscheduler_adapter
+
+    # ------------------------------------------------------------------
+    # Scheduler lookup
+    # ------------------------------------------------------------------
+
+    def _scheduler(self):
+        if hasattr(self.adapter, "scheduler"):
+            return self.adapter.scheduler()
+        return self.adapter._scheduler
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def load_all(self) -> int:
+        """Scan every active crew at startup, register one APScheduler job per
+        scheduled trigger. Returns total number of registered jobs.
+        """
+        registered = 0
+        cursor = self.db["crews"].find({"status": "active"})
+        async for crew in cursor:
+            try:
+                registered += self._register_triggers(crew)
+            except Exception:
+                logger.exception(
+                    "Failed to register scheduled triggers for crew %s",
+                    crew.get("crew_id"),
+                )
+        logger.info("ScheduledRunner: registered %d crew scheduled trigger(s)", registered)
+        return registered
+
+    async def refresh_for_crew(self, crew_id: str) -> int:
+        """Re-register all triggers for a single crew.
+
+        Called from CrewService after create/update/delete so changes pick
+        up without a full reload.
+        """
+        # Remove any stale triggers first (we don't know how many there used
+        # to be; scan by prefix).
+        self._unregister_crew_jobs(crew_id)
+
+        crew = await self.db["crews"].find_one({"crew_id": crew_id})
+        if not crew:
+            return 0
+        if crew.get("status") != "active":
+            return 0
+        return self._register_triggers(crew)
+
+    def unregister_for_crew(self, crew_id: str) -> None:
+        """Drop all APScheduler jobs for a given crew."""
+        self._unregister_crew_jobs(crew_id)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _register_triggers(self, crew: Dict[str, Any]) -> int:
+        triggers: List[Dict[str, Any]] = crew.get("triggers") or []
+        crew_id = crew.get("crew_id")
+        if not crew_id:
+            return 0
+        registered = 0
+        for idx, trigger in enumerate(triggers):
+            if (trigger or {}).get("type") != "scheduled":
+                continue
+            try:
+                self._register_one(crew_id, idx, trigger)
+                registered += 1
+            except Exception:
+                logger.exception(
+                    "Skipping malformed scheduled trigger idx=%d on crew %s",
+                    idx,
+                    crew_id,
+                )
+        return registered
+
+    def _register_one(
+        self,
+        crew_id: str,
+        trigger_idx: int,
+        trigger: Dict[str, Any],
+    ) -> None:
+        cron = trigger.get("cron")
+        run_at = trigger.get("run_at")
+
+        aps_id = _aps_id(crew_id, trigger_idx)
+        scheduler = self._scheduler()
+
+        if cron:
+            from apscheduler.triggers.cron import CronTrigger
+            aps_trigger = CronTrigger.from_crontab(cron, timezone="UTC")
+            source = cron
+        elif run_at:
+            from apscheduler.triggers.date import DateTrigger
+            aps_trigger = DateTrigger(run_date=run_at)
+            source = run_at
+        else:
+            raise ValueError("Scheduled trigger must have either cron or run_at")
+
+        scheduler.add_job(
+            self._fire,
+            trigger=aps_trigger,
+            id=aps_id,
+            replace_existing=True,
+            kwargs={
+                "crew_id": crew_id,
+                "trigger_idx": trigger_idx,
+                "trigger_source": source,
+                "content_brief": trigger.get("content_brief"),
+            },
+            name=f"crew:{crew_id} trigger:{trigger_idx}",
+        )
+        logger.info(
+            "Registered scheduled trigger %s (cron=%s run_at=%s)",
+            aps_id, cron, run_at,
+        )
+
+    def _unregister_crew_jobs(self, crew_id: str) -> None:
+        scheduler = self._scheduler()
+        prefix = f"{CREW_TRIGGER_PREFIX}{crew_id}:"
+        try:
+            jobs = scheduler.get_jobs()
+        except Exception:
+            return
+        for job in jobs:
+            if job.id and job.id.startswith(prefix):
+                try:
+                    scheduler.remove_job(job.id)
+                except Exception:
+                    pass
+
+    async def _fire(
+        self,
+        crew_id: str,
+        trigger_idx: int,
+        trigger_source: str,
+        content_brief: Optional[str],
+    ) -> None:
+        """Callback invoked by APScheduler when a cron/date boundary hits."""
+        logger.info(
+            "Scheduled trigger fired: crew=%s idx=%s source=%s",
+            crew_id, trigger_idx, trigger_source,
+        )
+        try:
+            from models.crew_models import RunCrewRequest
+            from repositories.crew_repository import CrewRepository, CrewRunRepository
+            from repositories.workspace_agent_repository import WorkspaceAgentRepository
+            from services.crew_service import CrewService
+
+            crew_repo = CrewRepository(self.db)
+            run_repo = CrewRunRepository(self.db)
+            agent_repo = WorkspaceAgentRepository(self.db)
+            svc = CrewService(crew_repo=crew_repo, run_repo=run_repo, agent_repo=agent_repo)
+
+            # Need the user_id from the crew document.
+            crew = await self.db["crews"].find_one({"crew_id": crew_id})
+            if not crew:
+                logger.warning("Scheduled trigger fire: crew %s no longer exists", crew_id)
+                return
+            user_id = crew.get("user_id") or "desktop-user"
+
+            request = RunCrewRequest(input=content_brief or f"Scheduled run at {datetime.utcnow().isoformat()}")
+            await svc.start_run(
+                crew_id=crew_id,
+                user_id=user_id,
+                request=request,
+                trigger_type="scheduled",
+                trigger_source=trigger_source,
+            )
+        except Exception:
+            logger.exception("Scheduled trigger fire failed for crew %s", crew_id)

--- a/backend/tests/test_connections_aggregator.py
+++ b/backend/tests/test_connections_aggregator.py
@@ -1,0 +1,213 @@
+"""Tests for Phase 3 PR 2 — unified connections aggregator."""
+
+import pytest
+import pytest_asyncio
+
+from services.connection_service import ConnectionService
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def svc(db_proxy):
+    return ConnectionService(db_proxy)
+
+
+async def _seed_oauth(db, provider: str, connected: bool = True):
+    doc = {"_id": provider, "client_id": "x", "client_secret": "y"}
+    if connected:
+        doc.update({"access_token": "tok", "profile_name": f"{provider}-user"})
+    await db["oauth_connections"].insert_one(doc)
+
+
+async def _seed_reddit(db, _id="r1"):
+    await db["reddit_accounts"].insert_one({
+        "_id": _id,
+        "client_id": "cid",
+        "client_secret": "csec",
+        "username": "u1",
+        "password": "p",
+        "subreddits": ["LocalLLaMA"],
+        "keywords": ["pricing", "demo"],
+    })
+
+
+async def _seed_twitter(db, _id="tw1", with_write=True):
+    doc = {
+        "_id": _id,
+        "user_id": "999",
+        "bearer_token": "bearer",
+    }
+    if with_write:
+        doc.update({
+            "api_key": "k",
+            "api_secret": "s",
+            "access_token": "a",
+            "access_token_secret": "b",
+        })
+    await db["twitter_accounts"].insert_one(doc)
+
+
+async def _seed_telegram(db, _id="tg1"):
+    await db["channel_registrations"].insert_one({
+        "_id": _id,
+        "channel_type": "telegram",
+        "config": {"bot_token": "123:abc", "bot_name": "MyBot"},
+    })
+
+
+# ---------------------------------------------------------------------------
+# LIST
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_list_is_empty_when_no_records(svc):
+    rows = await svc.list_connections()
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_list_merges_all_stores(svc, db_proxy):
+    await _seed_oauth(db_proxy, "linkedin")
+    await _seed_oauth(db_proxy, "instagram", connected=False)
+    await _seed_reddit(db_proxy)
+    await _seed_twitter(db_proxy)
+    await _seed_telegram(db_proxy)
+
+    rows = await svc.list_connections()
+    platforms = sorted(r.platform for r in rows)
+    assert platforms == ["instagram", "linkedin", "reddit", "telegram", "twitter"]
+
+    by_platform = {r.platform: r for r in rows}
+    assert by_platform["linkedin"].id == "oauth:linkedin"
+    assert by_platform["linkedin"].connected is True
+    assert by_platform["instagram"].connected is False
+    assert by_platform["reddit"].id.startswith("reddit:")
+    assert by_platform["twitter"].outbound_supported is True
+    assert by_platform["telegram"].display_name == "MyBot"
+
+
+@pytest.mark.asyncio
+async def test_twitter_without_write_creds_loses_outbound(svc, db_proxy):
+    await _seed_twitter(db_proxy, with_write=False)
+    rows = await svc.list_connections()
+    tw = next(r for r in rows if r.platform == "twitter")
+    assert tw.outbound_supported is False
+    assert tw.outbound_enabled is False
+
+
+# ---------------------------------------------------------------------------
+# Outbound CRUD (blog / email / slack_webhook)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_create_slack_webhook_outbound(svc):
+    from models.connection_models import OutboundConnectionCreate
+    created = await svc.create_outbound(
+        OutboundConnectionCreate(
+            platform="slack_webhook",
+            name="Team ops",
+            config={"webhook_url": "https://hooks.slack.com/services/TXXX/BXXX/xxx"},
+        ),
+        user_id="test-user",
+    )
+    assert created.platform == "slack_webhook"
+    assert created.id.startswith("outbound:")
+    assert created.outbound_enabled is True
+    assert created.inbound_enabled is False
+    assert created.inbound_supported is False
+    assert created.config_summary.get("webhook_host") == "hooks.slack.com"
+
+
+@pytest.mark.asyncio
+async def test_create_blog_rejects_missing_api_url(svc):
+    from pydantic import ValidationError
+    from models.connection_models import OutboundConnectionCreate
+    with pytest.raises(ValidationError):
+        OutboundConnectionCreate(
+            platform="blog",
+            name="My Blog",
+            config={"cms_type": "ghost"},  # missing api_url
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_email_rejects_missing_from_email(svc):
+    from pydantic import ValidationError
+    from models.connection_models import OutboundConnectionCreate
+    with pytest.raises(ValidationError):
+        OutboundConnectionCreate(
+            platform="email",
+            name="Mailer",
+            config={"provider": "sendgrid", "api_key": "sg-xxx"},  # missing from_email
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_and_delete_outbound(svc):
+    from models.connection_models import OutboundConnectionCreate, OutboundConnectionUpdate
+    created = await svc.create_outbound(
+        OutboundConnectionCreate(
+            platform="email",
+            name="Old",
+            config={"provider": "sendgrid", "api_key": "sg-xxx", "from_email": "a@b.c"},
+        ),
+        user_id="u1",
+    )
+    updated = await svc.update_outbound(
+        created.id, OutboundConnectionUpdate(name="Renamed")
+    )
+    assert updated.display_name == "Renamed"
+
+    await svc.delete_outbound(created.id)
+    assert await svc.get_connection(created.id) is None
+
+
+# ---------------------------------------------------------------------------
+# Capability PATCH
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_patch_capabilities_toggles_reddit(svc, db_proxy):
+    await _seed_reddit(db_proxy, _id="r1")
+    rows = await svc.list_connections()
+    reddit = next(r for r in rows if r.platform == "reddit")
+    assert reddit.inbound_enabled is True
+
+    from models.connection_models import CapabilityUpdate
+    updated = await svc.update_capabilities(reddit.id, CapabilityUpdate(inbound_enabled=False))
+    assert updated.inbound_enabled is False
+
+    raw = await db_proxy["reddit_accounts"].find_one({"_id": "r1"})
+    assert raw["inbound_enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_patch_rejects_enabling_unsupported_capability(svc, db_proxy):
+    # LinkedIn is outbound-supported but not inbound-supported
+    await _seed_oauth(db_proxy, "linkedin")
+
+    from fastapi import HTTPException
+    from models.connection_models import CapabilityUpdate
+    with pytest.raises(HTTPException) as exc:
+        await svc.update_capabilities("oauth:linkedin", CapabilityUpdate(inbound_enabled=True))
+    assert exc.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_patch_capabilities_rejects_empty_update():
+    from pydantic import ValidationError
+    from models.connection_models import CapabilityUpdate
+    with pytest.raises(ValidationError):
+        CapabilityUpdate()  # both None → invalid
+
+
+@pytest.mark.asyncio
+async def test_patch_unknown_connection_is_404(svc):
+    from fastapi import HTTPException
+    from models.connection_models import CapabilityUpdate
+    with pytest.raises(HTTPException) as exc:
+        await svc.update_capabilities("reddit:nonexistent", CapabilityUpdate(inbound_enabled=True))
+    assert exc.value.status_code == 404

--- a/backend/tests/test_crew_connection_bindings.py
+++ b/backend/tests/test_crew_connection_bindings.py
@@ -1,0 +1,175 @@
+"""Schema tests for Phase 3 PR 1 — ConnectionBinding, triggers, CrewRun trigger fields."""
+
+import pytest
+from pydantic import ValidationError
+
+from models.crew_models import (
+    ConnectionBinding,
+    CreateCrewRequest,
+    CrewAgentConfig,
+    CrewRunListItem,
+    CrewRunResponse,
+    ReactiveTrigger,
+    ScheduledTrigger,
+)
+
+
+# ---------------------------------------------------------------------------
+# ConnectionBinding
+# ---------------------------------------------------------------------------
+def test_connection_binding_defaults_direction_to_both():
+    cb = ConnectionBinding(connection_id="telegram", platform="telegram")
+    assert cb.direction == "both"
+
+
+def test_connection_binding_rejects_invalid_direction():
+    with pytest.raises(ValidationError):
+        ConnectionBinding(
+            connection_id="telegram",
+            platform="telegram",
+            direction="sideways",
+        )
+
+
+# ---------------------------------------------------------------------------
+# ReactiveTrigger
+# ---------------------------------------------------------------------------
+def test_reactive_trigger_requires_at_least_one_match_rule():
+    with pytest.raises(ValidationError):
+        ReactiveTrigger(connection_id="reddit")
+
+
+def test_reactive_trigger_accepts_keywords_only():
+    t = ReactiveTrigger(connection_id="reddit", keywords=["demo"])
+    assert t.type == "reactive"
+    assert t.keywords == ["demo"]
+
+
+def test_reactive_trigger_accepts_hashtags_or_mentions():
+    t = ReactiveTrigger(connection_id="twitter", hashtags=["#launch"])
+    assert t.hashtags == ["#launch"]
+    t2 = ReactiveTrigger(connection_id="twitter", mentions=["@me"])
+    assert t2.mentions == ["@me"]
+
+
+# ---------------------------------------------------------------------------
+# ScheduledTrigger
+# ---------------------------------------------------------------------------
+def test_scheduled_trigger_requires_exactly_one_of_cron_or_run_at():
+    # Neither
+    with pytest.raises(ValidationError):
+        ScheduledTrigger(connection_ids=["linkedin"])
+    # Both
+    with pytest.raises(ValidationError):
+        ScheduledTrigger(
+            connection_ids=["linkedin"],
+            cron="0 9 * * *",
+            run_at="2026-05-01T09:00:00Z",
+        )
+
+
+def test_scheduled_trigger_accepts_cron():
+    t = ScheduledTrigger(connection_ids=["linkedin"], cron="0 9 * * *")
+    assert t.cron == "0 9 * * *"
+    assert t.run_at is None
+
+
+def test_scheduled_trigger_accepts_run_at():
+    t = ScheduledTrigger(connection_ids=["linkedin"], run_at="2026-05-01T09:00:00Z")
+    assert t.run_at == "2026-05-01T09:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# CreateCrewRequest — new additive fields
+# ---------------------------------------------------------------------------
+def _min_agent():
+    return CrewAgentConfig(name="Writer", instructions="Write a post")
+
+
+def test_create_crew_defaults_connection_bindings_and_triggers_to_empty():
+    req = CreateCrewRequest(name="C1", agents=[_min_agent()])
+    assert req.connection_bindings == []
+    assert req.triggers == []
+    assert req.approval_required is False
+
+
+def test_create_crew_accepts_reactive_and_scheduled_triggers():
+    req = CreateCrewRequest(
+        name="Multi",
+        agents=[_min_agent()],
+        connection_bindings=[
+            ConnectionBinding(
+                connection_id="reddit",
+                platform="reddit",
+                direction="both",
+            )
+        ],
+        triggers=[
+            ReactiveTrigger(connection_id="reddit", keywords=["pricing"]),
+            ScheduledTrigger(connection_ids=["linkedin"], cron="0 9 * * MON"),
+        ],
+        approval_required=True,
+    )
+    assert len(req.triggers) == 2
+    assert req.triggers[0].type == "reactive"
+    assert req.triggers[1].type == "scheduled"
+    assert req.approval_required is True
+
+
+def test_create_crew_round_trips_through_dict():
+    req = CreateCrewRequest(
+        name="RT",
+        agents=[_min_agent()],
+        connection_bindings=[
+            ConnectionBinding(connection_id="discord", platform="discord")
+        ],
+    )
+    roundtrip = CreateCrewRequest(**req.model_dump())
+    assert roundtrip.connection_bindings[0].connection_id == "discord"
+
+
+# ---------------------------------------------------------------------------
+# CrewRun trigger metadata
+# ---------------------------------------------------------------------------
+def test_crew_run_response_defaults_to_manual():
+    run = CrewRunResponse(
+        run_id="r1",
+        crew_id="c1",
+        user_id="u1",
+    )
+    assert run.trigger_type == "manual"
+    assert run.trigger_source is None
+
+
+def test_crew_run_response_accepts_reactive_metadata():
+    run = CrewRunResponse(
+        run_id="r2",
+        crew_id="c1",
+        user_id="u1",
+        trigger_type="reactive",
+        trigger_source="reddit",
+    )
+    assert run.trigger_type == "reactive"
+    assert run.trigger_source == "reddit"
+
+
+def test_crew_run_list_item_accepts_scheduled_metadata():
+    item = CrewRunListItem(
+        run_id="r3",
+        crew_id="c1",
+        status="completed",
+        trigger_type="scheduled",
+        trigger_source="0 9 * * *",
+    )
+    assert item.trigger_type == "scheduled"
+    assert item.trigger_source == "0 9 * * *"
+
+
+def test_crew_run_response_rejects_invalid_trigger_type():
+    with pytest.raises(ValidationError):
+        CrewRunResponse(
+            run_id="r4",
+            crew_id="c1",
+            user_id="u1",
+            trigger_type="webhook",  # not in the allowed literal
+        )

--- a/backend/tests/test_inbound_router.py
+++ b/backend/tests/test_inbound_router.py
@@ -1,0 +1,194 @@
+"""Tests for Phase 3 PR 3 — inbound_router."""
+
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+
+from services.inbound_router import (
+    _trigger_matches,
+    find_matching_crews,
+    route_inbound,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _msg(channel_type: str, text: str):
+    """Minimal ChannelMessage shim: only fields inbound_router reads."""
+    return SimpleNamespace(
+        channel_type=SimpleNamespace(value=channel_type),
+        text=text,
+    )
+
+
+async def _seed_crew(db, crew_id: str, name: str, triggers: list, user_id: str = "u1"):
+    await db["crews"].insert_one({
+        "_id": crew_id,
+        "crew_id": crew_id,
+        "user_id": user_id,
+        "name": name,
+        "description": f"{name} description",
+        "status": "active",
+        "agents": [
+            {
+                "agent_id": "a1",
+                "name": "Writer",
+                "role": "writer",
+                "instructions": "Write.",
+                "order": 0,
+            }
+        ],
+        "execution_config": {"mode": "sequential", "timeout_seconds": 60},
+        "triggers": triggers,
+        "created_at": "2026-04-21T00:00:00",
+        "updated_at": "2026-04-21T00:00:00",
+    })
+
+
+# ---------------------------------------------------------------------------
+# Matcher unit tests
+# ---------------------------------------------------------------------------
+
+def test_keyword_substring_match_case_insensitive():
+    trigger = {"keywords": ["Pricing"], "hashtags": [], "mentions": []}
+    assert _trigger_matches(trigger, "How does your PRICING work?") is True
+
+
+def test_no_match_when_rules_empty():
+    trigger = {"keywords": [], "hashtags": [], "mentions": []}
+    assert _trigger_matches(trigger, "anything") is False
+
+
+def test_hashtag_match():
+    trigger = {"keywords": [], "hashtags": ["#demo"], "mentions": []}
+    assert _trigger_matches(trigger, "Check out #demo today!") is True
+
+
+def test_mention_match():
+    trigger = {"keywords": [], "hashtags": [], "mentions": ["@support"]}
+    assert _trigger_matches(trigger, "Hey @support, can you help?") is True
+
+
+def test_empty_text_is_safe():
+    trigger = {"keywords": ["x"], "hashtags": [], "mentions": []}
+    assert _trigger_matches(trigger, "") is False
+
+
+# ---------------------------------------------------------------------------
+# find_matching_crews
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_find_matching_crews_exact_one(db_proxy):
+    await _seed_crew(db_proxy, "crew-a", "Sales", [
+        {"type": "reactive", "connection_id": "reddit", "keywords": ["pricing"]},
+    ])
+    await _seed_crew(db_proxy, "crew-b", "Support", [
+        {"type": "reactive", "connection_id": "reddit", "keywords": ["bug"]},
+    ])
+
+    matches = await find_matching_crews(db_proxy, "reddit", "What's your pricing?")
+    assert len(matches) == 1
+    assert matches[0][0]["crew_id"] == "crew-a"
+
+
+@pytest.mark.asyncio
+async def test_find_matching_crews_connection_filter(db_proxy):
+    await _seed_crew(db_proxy, "crew-a", "Sales", [
+        {"type": "reactive", "connection_id": "telegram", "keywords": ["pricing"]},
+    ])
+    matches = await find_matching_crews(db_proxy, "reddit", "pricing question")
+    assert matches == []
+
+
+@pytest.mark.asyncio
+async def test_find_matching_crews_multi_match(db_proxy):
+    await _seed_crew(db_proxy, "crew-a", "Sales", [
+        {"type": "reactive", "connection_id": "reddit", "keywords": ["pricing"]},
+    ])
+    await _seed_crew(db_proxy, "crew-b", "Marketing", [
+        {"type": "reactive", "connection_id": "reddit", "keywords": ["demo"]},
+    ])
+    matches = await find_matching_crews(db_proxy, "reddit", "can I get a pricing demo?")
+    assert len(matches) == 2
+
+
+@pytest.mark.asyncio
+async def test_scheduled_triggers_do_not_match_inbound(db_proxy):
+    await _seed_crew(db_proxy, "crew-s", "Scheduled", [
+        {"type": "scheduled", "connection_ids": ["reddit"], "cron": "0 9 * * *"},
+    ])
+    matches = await find_matching_crews(db_proxy, "reddit", "anything")
+    assert matches == []
+
+
+@pytest.mark.asyncio
+async def test_inactive_crews_ignored(db_proxy):
+    await _seed_crew(db_proxy, "crew-paused", "Paused", [
+        {"type": "reactive", "connection_id": "reddit", "keywords": ["hit"]},
+    ])
+    await db_proxy["crews"].update_one(
+        {"crew_id": "crew-paused"}, {"$set": {"status": "paused"}}
+    )
+    matches = await find_matching_crews(db_proxy, "reddit", "please hit this")
+    assert matches == []
+
+
+# ---------------------------------------------------------------------------
+# route_inbound end-to-end
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_route_inbound_returns_none_when_no_match(db_proxy):
+    result = await route_inbound(db_proxy, _msg("reddit", "random message"))
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_route_inbound_unknown_channel_returns_none(db_proxy):
+    result = await route_inbound(db_proxy, _msg("whatsapp", "pricing"))
+    # whatsapp isn't in PLATFORM_FROM_CHANNEL_TYPE → early None
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_route_inbound_dispatches_on_single_match(db_proxy):
+    await _seed_crew(db_proxy, "crew-x", "Sales", [
+        {"type": "reactive", "connection_id": "reddit", "keywords": ["pricing"]},
+    ])
+    result = await route_inbound(db_proxy, _msg("reddit", "what's your pricing?"))
+    assert result is not None
+    assert result["status"] == "dispatched"
+    assert result["crew_id"] == "crew-x"
+    assert result["trigger_source"] == "reddit"
+    assert result["run_id"]  # a run was created
+
+    # Verify the run record carries the trigger metadata
+    run = await db_proxy["crew_runs"].find_one({"run_id": result["run_id"]})
+    assert run["trigger_type"] == "reactive"
+    assert run["trigger_source"] == "reddit"
+
+
+@pytest.mark.asyncio
+async def test_route_inbound_multi_match_still_dispatches(db_proxy, monkeypatch):
+    await _seed_crew(db_proxy, "crew-a", "Sales", [
+        {"type": "reactive", "connection_id": "reddit", "keywords": ["pricing"]},
+    ])
+    await _seed_crew(db_proxy, "crew-b", "Support", [
+        {"type": "reactive", "connection_id": "reddit", "keywords": ["pricing"]},
+    ])
+
+    # Force disambiguator to pick the second candidate deterministically.
+    async def fake_disambiguate(candidates, text):
+        return candidates[-1]
+
+    monkeypatch.setattr(
+        "services.inbound_router.disambiguate_with_llm", fake_disambiguate
+    )
+
+    result = await route_inbound(db_proxy, _msg("reddit", "need pricing help"))
+    assert result is not None
+    assert result["crew_id"] in {"crew-a", "crew-b"}

--- a/backend/tests/test_scheduled_runner.py
+++ b/backend/tests/test_scheduled_runner.py
@@ -1,0 +1,173 @@
+"""Tests for Phase 3 PR 3 — scheduled_runner."""
+
+from types import SimpleNamespace
+from typing import Any, Dict, List
+
+import pytest
+import pytest_asyncio
+
+from services.scheduled_runner import CREW_TRIGGER_PREFIX, ScheduledRunner
+
+
+# ---------------------------------------------------------------------------
+# Fake APScheduler that records add_job / remove_job calls.
+# ---------------------------------------------------------------------------
+
+class FakeJob:
+    def __init__(self, job_id: str, kwargs: Dict[str, Any]):
+        self.id = job_id
+        self.kwargs = kwargs
+        self.next_run_time = None
+
+
+class FakeScheduler:
+    def __init__(self):
+        self._jobs: Dict[str, FakeJob] = {}
+        self.add_calls: List[Dict[str, Any]] = []
+
+    def add_job(self, func, trigger=None, id=None, replace_existing=False, kwargs=None, name=None):
+        if id in self._jobs and not replace_existing:
+            raise RuntimeError(f"Duplicate id {id}")
+        self._jobs[id] = FakeJob(id, kwargs or {})
+        self.add_calls.append({"id": id, "trigger": trigger, "kwargs": kwargs or {}})
+        return self._jobs[id]
+
+    def remove_job(self, job_id: str):
+        if job_id not in self._jobs:
+            raise KeyError(job_id)
+        self._jobs.pop(job_id)
+
+    def get_jobs(self):
+        return list(self._jobs.values())
+
+    def get_job(self, job_id: str):
+        return self._jobs.get(job_id)
+
+
+class FakeAdapter:
+    def __init__(self, scheduler: FakeScheduler):
+        self._sched = scheduler
+
+    def scheduler(self):
+        return self._sched
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def runner(db_proxy):
+    scheduler = FakeScheduler()
+    r = ScheduledRunner(db_proxy, FakeAdapter(scheduler))
+    r._fake_scheduler = scheduler  # expose for assertions
+    return r
+
+
+async def _insert_crew(db, crew_id: str, triggers: list, status: str = "active"):
+    await db["crews"].insert_one({
+        "_id": crew_id,
+        "crew_id": crew_id,
+        "user_id": "u1",
+        "name": f"crew {crew_id}",
+        "status": status,
+        "triggers": triggers,
+    })
+
+
+# ---------------------------------------------------------------------------
+# load_all
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_load_all_registers_cron_triggers(runner, db_proxy):
+    await _insert_crew(db_proxy, "c1", [
+        {"type": "scheduled", "connection_ids": ["linkedin"], "cron": "0 9 * * *"},
+    ])
+    await _insert_crew(db_proxy, "c2", [
+        {"type": "scheduled", "connection_ids": ["blog"], "cron": "0 12 * * MON"},
+        {"type": "reactive", "connection_id": "reddit", "keywords": ["x"]},  # ignored
+    ])
+
+    count = await runner.load_all()
+    assert count == 2
+
+    ids = sorted(runner._fake_scheduler._jobs.keys())
+    assert ids == [f"{CREW_TRIGGER_PREFIX}c1:0", f"{CREW_TRIGGER_PREFIX}c2:0"]
+
+
+@pytest.mark.asyncio
+async def test_load_all_registers_date_trigger(runner, db_proxy):
+    await _insert_crew(db_proxy, "c1", [
+        {"type": "scheduled", "connection_ids": ["linkedin"], "run_at": "2026-12-01T09:00:00+00:00"},
+    ])
+    count = await runner.load_all()
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_load_all_skips_inactive_crews(runner, db_proxy):
+    await _insert_crew(db_proxy, "c-paused", [
+        {"type": "scheduled", "cron": "0 9 * * *"},
+    ], status="paused")
+    count = await runner.load_all()
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_load_all_survives_malformed_trigger(runner, db_proxy):
+    # Neither cron nor run_at — should log+skip, not crash, and not count.
+    await _insert_crew(db_proxy, "c-bad", [
+        {"type": "scheduled", "connection_ids": ["linkedin"]},
+    ])
+    await _insert_crew(db_proxy, "c-good", [
+        {"type": "scheduled", "cron": "0 9 * * *"},
+    ])
+    count = await runner.load_all()
+    assert count == 1
+    ids = list(runner._fake_scheduler._jobs.keys())
+    assert ids == [f"{CREW_TRIGGER_PREFIX}c-good:0"]
+
+
+# ---------------------------------------------------------------------------
+# refresh_for_crew
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_refresh_for_crew_adds_and_removes(runner, db_proxy):
+    await _insert_crew(db_proxy, "c1", [
+        {"type": "scheduled", "cron": "0 9 * * *"},
+        {"type": "scheduled", "cron": "0 18 * * *"},
+    ])
+    count = await runner.refresh_for_crew("c1")
+    assert count == 2
+    assert len(runner._fake_scheduler._jobs) == 2
+
+    # Drop one trigger, refresh — old jobs gone, new set registered.
+    await db_proxy["crews"].update_one(
+        {"crew_id": "c1"},
+        {"$set": {"triggers": [{"type": "scheduled", "cron": "0 12 * * *"}]}},
+    )
+    count = await runner.refresh_for_crew("c1")
+    assert count == 1
+    assert len(runner._fake_scheduler._jobs) == 1
+    assert f"{CREW_TRIGGER_PREFIX}c1:0" in runner._fake_scheduler._jobs
+
+
+@pytest.mark.asyncio
+async def test_refresh_for_crew_handles_unknown(runner):
+    count = await runner.refresh_for_crew("nonexistent")
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_unregister_removes_all_crew_jobs(runner, db_proxy):
+    await _insert_crew(db_proxy, "c1", [
+        {"type": "scheduled", "cron": "0 9 * * *"},
+        {"type": "scheduled", "cron": "0 18 * * *"},
+    ])
+    await runner.load_all()
+    assert len(runner._fake_scheduler._jobs) == 2
+
+    runner.unregister_for_crew("c1")
+    assert runner._fake_scheduler._jobs == {}

--- a/backend/tests/test_unify_migration.py
+++ b/backend/tests/test_unify_migration.py
@@ -1,0 +1,140 @@
+"""Tests for Phase 3 PR 1 unify_connections migration."""
+
+import os
+
+import pytest
+import pytest_asyncio
+
+from services.migrations.unify_connections_migration import (
+    MARKER_COLLECTION,
+    MIGRATION_NAME,
+    run_unify_connections_migration,
+)
+
+
+@pytest_asyncio.fixture
+async def seeded_db(db_proxy):
+    """Seed the test DB with a few legacy crews and a distribution channel."""
+    crews = db_proxy["crews"]
+
+    # Crew 1: legacy channel_bindings, one with approval_required
+    await crews.insert_one({
+        "crew_id": "crew-1",
+        "user_id": "u1",
+        "name": "Legacy Telegram",
+        "status": "active",
+        "channel_bindings": [
+            {"channel_type": "telegram", "enabled": True, "approval_required": True},
+            {"channel_type": "discord", "enabled": True, "approval_required": False},
+        ],
+    })
+
+    # Crew 2: no bindings at all, missing new fields entirely
+    await crews.insert_one({
+        "crew_id": "crew-2",
+        "user_id": "u1",
+        "name": "Bare",
+        "status": "active",
+    })
+
+    # Crew 3: already migrated (has connection_bindings) — must not double-convert
+    await crews.insert_one({
+        "crew_id": "crew-3",
+        "user_id": "u1",
+        "name": "Already Migrated",
+        "status": "active",
+        "channel_bindings": [
+            {"channel_type": "reddit", "enabled": True, "approval_required": False},
+        ],
+        "connection_bindings": [
+            {"connection_id": "reddit-custom", "platform": "reddit", "direction": "inbound"},
+        ],
+    })
+
+    await db_proxy["distribution_channels"].insert_one({
+        "channel_type": "linkedin",
+        "config": {},
+        "enabled": True,
+    })
+
+    return db_proxy
+
+
+@pytest.mark.asyncio
+async def test_migration_converts_legacy_bindings(seeded_db):
+    stats = await run_unify_connections_migration(seeded_db)
+
+    assert stats["skipped"] is False
+    assert stats["crews_processed"] == 3
+    # Crew 1: 2 bindings. Crew 3: already has connection_bindings (skipped).
+    assert stats["bindings_converted"] == 2
+    assert stats["crews_marked_approval_required"] == 1
+    assert stats["distribution_channels_orphaned"] == 1
+
+    crew1 = await seeded_db["crews"].find_one({"crew_id": "crew-1"})
+    assert len(crew1["connection_bindings"]) == 2
+    platforms = {b["platform"] for b in crew1["connection_bindings"]}
+    assert platforms == {"telegram", "discord"}
+    for b in crew1["connection_bindings"]:
+        assert b["direction"] == "both"
+    assert crew1["approval_required"] is True
+
+    crew2 = await seeded_db["crews"].find_one({"crew_id": "crew-2"})
+    assert crew2["connection_bindings"] == []
+    assert crew2["triggers"] == []
+    assert crew2["approval_required"] is False
+
+    # Crew 3 must keep its pre-existing connection_bindings untouched.
+    crew3 = await seeded_db["crews"].find_one({"crew_id": "crew-3"})
+    assert len(crew3["connection_bindings"]) == 1
+    assert crew3["connection_bindings"][0]["connection_id"] == "reddit-custom"
+
+
+@pytest.mark.asyncio
+async def test_migration_is_idempotent(seeded_db):
+    first = await run_unify_connections_migration(seeded_db)
+    assert first["skipped"] is False
+
+    # Tamper with a crew to prove second run doesn't re-touch it.
+    await seeded_db["crews"].update_one(
+        {"crew_id": "crew-1"},
+        {"$set": {"connection_bindings": [{"connection_id": "x", "platform": "telegram", "direction": "outbound"}]}},
+    )
+
+    second = await run_unify_connections_migration(seeded_db)
+    assert second["skipped"] is True
+
+    crew1 = await seeded_db["crews"].find_one({"crew_id": "crew-1"})
+    # Still the tampered value — migration did not run again
+    assert crew1["connection_bindings"][0]["connection_id"] == "x"
+
+
+@pytest.mark.asyncio
+async def test_dry_run_does_not_write(seeded_db, monkeypatch):
+    monkeypatch.setenv("MIGRATE_DRY_RUN", "1")
+    stats = await run_unify_connections_migration(seeded_db)
+
+    assert stats["dry_run"] is True
+    assert stats["bindings_converted"] == 2  # still reports what it *would* do
+
+    # Marker NOT written
+    marker = await seeded_db[MARKER_COLLECTION].find_one({"name": MIGRATION_NAME})
+    assert marker is None
+
+    # Crew 1 NOT mutated
+    crew1 = await seeded_db["crews"].find_one({"crew_id": "crew-1"})
+    assert "connection_bindings" not in crew1 or crew1.get("connection_bindings") == []
+
+
+@pytest.mark.asyncio
+async def test_migration_survives_missing_distribution_collection(db_proxy):
+    # No seeding → no distribution_channels rows
+    await db_proxy["crews"].insert_one({
+        "crew_id": "solo",
+        "user_id": "u1",
+        "name": "Solo",
+        "status": "active",
+    })
+    stats = await run_unify_connections_migration(db_proxy)
+    assert stats["skipped"] is False
+    assert stats["crews_processed"] == 1

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,8 +16,6 @@ import ConnectionsPage from "@/routes/connections";
 import ModelsPage from "@/routes/models";
 import SettingsPage from "@/routes/settings";
 import ApprovalsPage from "@/routes/approvals";
-import SchedulePage from "@/routes/schedule";
-import DistributionPage from "@/routes/distribution";
 import BlueprintsPage from "@/routes/blueprints";
 import WizardPage from "@/routes/wizard";
 import { UpdateNotifier } from "@/components/update-notifier";
@@ -118,8 +116,6 @@ export default function App() {
                 <Route path="/workspace/:id" element={<WorkspacePage />} />
                 <Route path="/connections" element={<ConnectionsPage />} />
                 <Route path="/approvals" element={<ApprovalsPage />} />
-                <Route path="/schedule" element={<SchedulePage />} />
-                <Route path="/distribution" element={<DistributionPage />} />
                 <Route path="/analytics" element={<AnalyticsPage />} />
                 <Route path="/settings" element={<SettingsPage />} />
               </Route>

--- a/frontend/src/components/crews/crew-builder.tsx
+++ b/frontend/src/components/crews/crew-builder.tsx
@@ -1,8 +1,18 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { cn } from "@/lib/utils";
-import { crewsApi, type CrewAgent, type LibraryAgent, type ChannelBinding } from "@/lib/api/crews-client";
+import {
+  crewsApi,
+  type CrewAgent,
+  type LibraryAgent,
+  type ChannelBinding,
+  type ConnectionBinding,
+  type CrewTrigger,
+} from "@/lib/api/crews-client";
+import {
+  connectionsApi,
+  type ConnectionSummary,
+} from "@/lib/api/connections-client";
 import { getModels, type ModelConfig } from "@/lib/api/models-client";
-import { getOAuthStatus } from "@/lib/api/oauth-client";
 import {
   BlueprintSelector,
   type BlueprintSelection,
@@ -31,24 +41,39 @@ import {
   Eye,
   Cable,
   MessageSquare,
-  Send,
   Cpu,
+  Bell,
+  Zap,
+  Calendar,
+  ArrowDownToLine,
+  ArrowUpFromLine,
 } from "lucide-react";
 
 type ExecutionMode = "sequential" | "parallel" | "pipeline" | "autonomous";
-type WizardStep = 1 | 2 | 3 | 4 | 5;
+type WizardStep = 1 | 2 | 3 | 4 | 5 | 6 | 7;
 
-// ---------------------------------------------------------------------------
-// Available connection types with metadata
-// ---------------------------------------------------------------------------
-const CONNECTION_TYPES = [
-  { id: "telegram", name: "Telegram", icon: "paper-plane", description: "Chat bot for Telegram groups and DMs", color: "bg-sky-500" },
-  { id: "discord", name: "Discord", icon: "gamepad", description: "Bot for Discord servers and channels", color: "bg-indigo-500" },
-  { id: "linkedin", name: "LinkedIn", icon: "briefcase", description: "Post content and engage on LinkedIn", color: "bg-blue-600" },
-  { id: "twitter", name: "Twitter / X", icon: "bird", description: "Post and engage on Twitter/X", color: "bg-neutral-800 dark:bg-neutral-600" },
-  { id: "instagram", name: "Instagram", icon: "camera", description: "Share content on Instagram", color: "bg-pink-500" },
-  { id: "facebook", name: "Facebook", icon: "thumbs-up", description: "Manage Facebook page content", color: "bg-blue-500" },
-] as const;
+type Direction = "inbound" | "outbound" | "both";
+
+interface ReactiveTriggerDraft {
+  id: string; // local-only, for list keying
+  connection_id: string;
+  keywords: string[];
+  hashtags: string[];
+  mentions: string[];
+}
+
+interface ScheduledTriggerDraft {
+  id: string;
+  mode: "cron" | "run_at";
+  cron: string;
+  run_at: string;
+  connection_ids: string[];
+  content_brief: string;
+}
+
+function _newId() {
+  return Math.random().toString(36).slice(2, 10);
+}
 
 interface AgentForm {
   name: string;
@@ -375,8 +400,10 @@ const STEP_TITLES: Record<WizardStep, { title: string; subtitle: string }> = {
   1: { title: "Crew Details", subtitle: "Name your crew and describe its purpose" },
   2: { title: "Execution Mode", subtitle: "Choose how agents collaborate" },
   3: { title: "Agent Team", subtitle: "Build your agent pipeline" },
-  4: { title: "Connections", subtitle: "Choose which channels this crew handles" },
-  5: { title: "Review & Create", subtitle: "Review your crew configuration" },
+  4: { title: "Connections & Directions", subtitle: "Pick the tools this crew uses and what direction each goes" },
+  5: { title: "Trigger", subtitle: "How should this crew fire — reactive, scheduled, or manual only?" },
+  6: { title: "Approval", subtitle: "Review outbound before it's sent?" },
+  7: { title: "Review & Create", subtitle: "Review your crew configuration" },
 };
 
 // ---------------------------------------------------------------------------
@@ -394,6 +421,9 @@ interface CrewBuilderProps {
     execution_config?: { mode: ExecutionMode; max_agent_invocations?: number; budget_limit_usd?: number };
     agents?: CrewAgent[];
     channel_bindings?: ChannelBinding[];
+    connection_bindings?: ConnectionBinding[];
+    triggers?: CrewTrigger[];
+    approval_required?: boolean;
   };
 }
 
@@ -422,6 +452,43 @@ export function CrewBuilder({ open, onClose, onCreated, editCrew }: CrewBuilderP
   const [channelBindings, setChannelBindings] = useState<ChannelBinding[]>(
     editCrew?.channel_bindings ?? []
   );
+
+  // Phase 3: connection_bindings, triggers, approval_required
+  const [availableConnections, setAvailableConnections] = useState<ConnectionSummary[]>([]);
+  const [connectionBindings, setConnectionBindings] = useState<ConnectionBinding[]>(
+    editCrew?.connection_bindings ?? []
+  );
+  const [reactiveTriggers, setReactiveTriggers] = useState<ReactiveTriggerDraft[]>(
+    (editCrew?.triggers ?? [])
+      .filter((t): t is Extract<CrewTrigger, { type: "reactive" }> => t.type === "reactive")
+      .map((t) => ({
+        id: _newId(),
+        connection_id: t.connection_id,
+        keywords: t.keywords ?? [],
+        hashtags: t.hashtags ?? [],
+        mentions: t.mentions ?? [],
+      }))
+  );
+  const [scheduledTriggers, setScheduledTriggers] = useState<ScheduledTriggerDraft[]>(
+    (editCrew?.triggers ?? [])
+      .filter((t): t is Extract<CrewTrigger, { type: "scheduled" }> => t.type === "scheduled")
+      .map((t) => ({
+        id: _newId(),
+        mode: t.cron ? "cron" : "run_at",
+        cron: t.cron ?? "",
+        run_at: t.run_at ?? "",
+        connection_ids: t.connection_ids ?? [],
+        content_brief: t.content_brief ?? "",
+      }))
+  );
+  const [approvalRequired, setApprovalRequired] = useState<boolean>(
+    editCrew?.approval_required ?? false
+  );
+  const [capabilityModal, setCapabilityModal] = useState<{
+    connection: ConnectionSummary;
+    direction: Direction;
+  } | null>(null);
+
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [libraryOpen, setLibraryOpen] = useState(false);
@@ -431,18 +498,8 @@ export function CrewBuilder({ open, onClose, onCreated, editCrew }: CrewBuilderP
   const [selectedModelId, setSelectedModelId] = useState<string | null>(
     editCrew?.agents?.[0]?.model_id ?? null
   );
-  const [oauthConnected, setOauthConnected] = useState<Record<string, boolean>>({});
-
-  // Check OAuth connection status for OAuth-based channels
-  const OAUTH_CHANNELS = ["linkedin", "instagram", "facebook"] as const;
-  useEffect(() => {
-    if (!open) return;
-    for (const provider of OAUTH_CHANNELS) {
-      getOAuthStatus(provider)
-        .then((s) => setOauthConnected((prev) => ({ ...prev, [provider]: s.connected })))
-        .catch(() => setOauthConnected((prev) => ({ ...prev, [provider]: false })));
-    }
-  }, [open]);
+  // Legacy OAuth-status polling is no longer needed — the unified
+  // /api/v1/connections aggregator returns connection state directly.
 
   // Fetch available models when dialog opens
   useEffect(() => {
@@ -454,6 +511,18 @@ export function CrewBuilder({ open, onClose, onCreated, editCrew }: CrewBuilderP
         .catch(() => setModels([]));
     }
   }, [open]);
+
+  // Fetch unified connections on open (Phase 3)
+  const refreshConnections = useCallback(() => {
+    connectionsApi
+      .list()
+      .then(setAvailableConnections)
+      .catch(() => setAvailableConnections([]));
+  }, []);
+
+  useEffect(() => {
+    if (open) refreshConnections();
+  }, [open, refreshConnections]);
 
   // Reset on open
   useEffect(() => {
@@ -467,6 +536,10 @@ export function CrewBuilder({ open, onClose, onCreated, editCrew }: CrewBuilderP
         setMaxInvocations(10);
         setBudgetLimit(1.0);
         setChannelBindings([]);
+        setConnectionBindings([]);
+        setReactiveTriggers([]);
+        setScheduledTriggers([]);
+        setApprovalRequired(false);
         setSelectedBlueprint(null);
         setSelectedModelId(null);
         setError(null);
@@ -498,15 +571,30 @@ export function CrewBuilder({ open, onClose, onCreated, editCrew }: CrewBuilderP
       case 1: return !!name.trim();
       case 2: return true; // always valid, mode has a default
       case 3: return isAutonomous || agents.every((a) => a.name.trim() && a.instructions.trim());
-      case 4: return true; // connections are optional
-      case 5: return !!canSubmit;
+      case 4: return true; // connections are optional — manual-only is supported
+      case 5: {
+        // Reactive: each draft needs ≥1 keyword/hashtag/mention.
+        for (const t of reactiveTriggers) {
+          if (!t.connection_id) return false;
+          if (t.keywords.length + t.hashtags.length + t.mentions.length === 0) return false;
+        }
+        // Scheduled: exactly one of cron/run_at.
+        for (const t of scheduledTriggers) {
+          if (t.mode === "cron" && !t.cron.trim()) return false;
+          if (t.mode === "run_at" && !t.run_at.trim()) return false;
+        }
+        return true;
+      }
+      case 6: return true; // approval toggle always valid
+      case 7: return !!canSubmit;
       default: return false;
     }
   };
 
-  // Steps: 1-Details, 2-Mode, 3-Agents (skip if autonomous), 4-Connections, 5-Review
-  const totalSteps = isAutonomous ? 4 : 5;
-  const maxStep = (isAutonomous ? 4 : 5) as WizardStep;
+  // Steps: 1-Details, 2-Mode, 3-Agents (skip if autonomous), 4-Connections,
+  // 5-Trigger, 6-Approval, 7-Review. Autonomous collapses 7→6 visual steps.
+  const totalSteps = isAutonomous ? 6 : 7;
+  const maxStep = 7 as WizardStep;
 
   function nextStep() {
     if (step === 2 && isAutonomous) {
@@ -524,23 +612,122 @@ export function CrewBuilder({ open, onClose, onCreated, editCrew }: CrewBuilderP
     }
   }
 
-  // Toggle a channel binding
-  function toggleChannel(channelType: string) {
-    setChannelBindings((prev) => {
-      const existing = prev.find((b) => b.channel_type === channelType);
-      if (existing) {
-        return prev.filter((b) => b.channel_type !== channelType);
-      }
-      return [...prev, { channel_type: channelType, enabled: true, approval_required: false }];
+  // --- Phase 3 connection binding helpers ---
+
+  function hasBinding(connId: string) {
+    return connectionBindings.some((b) => b.connection_id === connId);
+  }
+
+  function getBindingDirection(connId: string): Direction | null {
+    return connectionBindings.find((b) => b.connection_id === connId)?.direction ?? null;
+  }
+
+  function addBinding(conn: ConnectionSummary, direction: Direction) {
+    setConnectionBindings((prev) => {
+      const filtered = prev.filter((b) => b.connection_id !== conn.id);
+      return [
+        ...filtered,
+        { connection_id: conn.id, platform: conn.platform, direction },
+      ];
     });
   }
 
-  function toggleChannelApproval(channelType: string) {
-    setChannelBindings((prev) =>
-      prev.map((b) =>
-        b.channel_type === channelType ? { ...b, approval_required: !b.approval_required } : b
-      )
+  function removeBinding(connId: string) {
+    setConnectionBindings((prev) => prev.filter((b) => b.connection_id !== connId));
+    // Also drop any reactive triggers tied to this connection.
+    setReactiveTriggers((prev) => prev.filter((t) => t.connection_id !== connId));
+  }
+
+  function handleDirectionPick(conn: ConnectionSummary, direction: Direction) {
+    // Block directions the platform doesn't physically support.
+    if (direction === "inbound" && !conn.inbound_supported) return;
+    if (direction === "outbound" && !conn.outbound_supported) return;
+
+    // If the user picked a direction that's disabled at the connection-level,
+    // open the inline modal to offer enabling it.
+    const capability = direction === "inbound"
+      ? conn.inbound_enabled
+      : direction === "outbound"
+        ? conn.outbound_enabled
+        : (conn.inbound_enabled && conn.outbound_enabled);
+    if (!capability) {
+      setCapabilityModal({ connection: conn, direction });
+      return;
+    }
+    addBinding(conn, direction);
+  }
+
+  async function enableCapabilityAndContinue() {
+    if (!capabilityModal) return;
+    const { connection, direction } = capabilityModal;
+    const update: { inbound_enabled?: boolean; outbound_enabled?: boolean } = {};
+    if (direction === "inbound") update.inbound_enabled = true;
+    else if (direction === "outbound") update.outbound_enabled = true;
+    else {
+      update.inbound_enabled = true;
+      update.outbound_enabled = true;
+    }
+    try {
+      await connectionsApi.updateCapabilities(connection.id, update);
+      refreshConnections();
+      addBinding(connection, direction);
+    } catch (e) {
+      console.error("Failed to enable capability", e);
+    } finally {
+      setCapabilityModal(null);
+    }
+  }
+
+  // --- Reactive trigger helpers ---
+
+  function addReactiveTrigger(connectionId: string) {
+    setReactiveTriggers((prev) => [
+      ...prev,
+      { id: _newId(), connection_id: connectionId, keywords: [], hashtags: [], mentions: [] },
+    ]);
+  }
+
+  function removeReactiveTrigger(id: string) {
+    setReactiveTriggers((prev) => prev.filter((t) => t.id !== id));
+  }
+
+  function addRuleToReactive(
+    id: string,
+    field: "keywords" | "hashtags" | "mentions",
+    value: string,
+  ) {
+    const v = value.trim();
+    if (!v) return;
+    setReactiveTriggers((prev) =>
+      prev.map((t) => (t.id === id ? { ...t, [field]: Array.from(new Set([...t[field], v])) } : t))
     );
+  }
+
+  function removeRuleFromReactive(
+    id: string,
+    field: "keywords" | "hashtags" | "mentions",
+    value: string,
+  ) {
+    setReactiveTriggers((prev) =>
+      prev.map((t) => (t.id === id ? { ...t, [field]: t[field].filter((x) => x !== value) } : t))
+    );
+  }
+
+  // --- Scheduled trigger helpers ---
+
+  function addScheduledTrigger() {
+    setScheduledTriggers((prev) => [
+      ...prev,
+      { id: _newId(), mode: "cron", cron: "0 9 * * *", run_at: "", connection_ids: [], content_brief: "" },
+    ]);
+  }
+
+  function updateScheduledTrigger(id: string, patch: Partial<ScheduledTriggerDraft>) {
+    setScheduledTriggers((prev) => prev.map((t) => (t.id === id ? { ...t, ...patch } : t)));
+  }
+
+  function removeScheduledTrigger(id: string) {
+    setScheduledTriggers((prev) => prev.filter((t) => t.id !== id));
   }
 
   const updateAgent = (index: number, field: keyof AgentForm, value: string) => {
@@ -600,6 +787,42 @@ export function CrewBuilder({ open, onClose, onCreated, editCrew }: CrewBuilderP
         payload.channel_bindings = channelBindings;
       }
 
+      // Phase 3 additions
+      if (connectionBindings.length > 0) {
+        payload.connection_bindings = connectionBindings;
+      }
+      const triggers: CrewTrigger[] = [];
+      for (const t of reactiveTriggers) {
+        triggers.push({
+          type: "reactive",
+          connection_id: t.connection_id,
+          keywords: t.keywords,
+          hashtags: t.hashtags,
+          mentions: t.mentions,
+        });
+      }
+      for (const t of scheduledTriggers) {
+        triggers.push(
+          t.mode === "cron"
+            ? {
+                type: "scheduled",
+                connection_ids: t.connection_ids,
+                cron: t.cron,
+                content_brief: t.content_brief || undefined,
+              }
+            : {
+                type: "scheduled",
+                connection_ids: t.connection_ids,
+                run_at: t.run_at,
+                content_brief: t.content_brief || undefined,
+              }
+        );
+      }
+      if (triggers.length > 0) {
+        payload.triggers = triggers;
+      }
+      payload.approval_required = approvalRequired;
+
       if (isEdit && editCrew) {
         await crewsApi.update(editCrew.crew_id, payload);
       } else {
@@ -624,8 +847,8 @@ export function CrewBuilder({ open, onClose, onCreated, editCrew }: CrewBuilderP
 
   if (!open) return null;
 
-  // For step indicator display: map to visual step number
-  // Autonomous skips step 3 (agents), so steps 4,5 become visual 3,4
+  // For step indicator display: map to visual step number.
+  // Autonomous skips step 3 (agents), so steps 4..7 each shift down by 1 visually.
   const visualStep = isAutonomous && step >= 4 ? step - 1 : step;
 
   return (
@@ -1019,125 +1242,342 @@ export function CrewBuilder({ open, onClose, onCreated, editCrew }: CrewBuilderP
             </div>
           )}
 
-          {/* ─── Step 4: Connections ─── */}
+          {/* ─── Step 4: Connections & Directions ─── */}
           {step === 4 && (
             <div className="space-y-4">
-              <div className="bg-neutral-50 dark:bg-neutral-800/50 rounded-xl border border-neutral-200 dark:border-neutral-700 p-5 space-y-4">
+              <div className="bg-neutral-50 dark:bg-neutral-800/50 rounded-xl border border-neutral-200 dark:border-neutral-700 p-5 space-y-3">
                 <h3 className="text-sm font-medium text-neutral-900 dark:text-white flex items-center gap-2">
                   <Cable className="w-4 h-4 text-primary-500" />
-                  Channel Connections
+                  Pick connections & direction
                 </h3>
-                <p className="text-xs text-neutral-500 dark:text-neutral-400 -mt-2">
-                  Select which social channels this crew should handle. The crew will process
-                  inbound messages and can publish content to these platforms.
+                <p className="text-xs text-neutral-500 dark:text-neutral-400">
+                  Choose which tools this crew uses. For each, pick a direction: <b>Inbound</b> (listen for messages), <b>Outbound</b> (publish), or <b>Both</b>. Outbound-only platforms (Blog / Email / Slack webhook) are publish-only.
                 </p>
 
-                <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-                  {CONNECTION_TYPES.map((conn) => {
-                    const isSelected = channelBindings.some((b) => b.channel_type === conn.id);
-                    const binding = channelBindings.find((b) => b.channel_type === conn.id);
-                    const isOAuth = OAUTH_CHANNELS.includes(conn.id as typeof OAUTH_CHANNELS[number]);
-                    const isConnected = isOAuth ? oauthConnected[conn.id] : true;
-                    return (
-                      <div
-                        key={conn.id}
-                        className={cn(
-                          "relative rounded-xl border-2 transition-all overflow-hidden",
-                          isSelected
-                            ? "border-primary-500 bg-primary-50/50 dark:bg-primary-500/5"
-                            : "border-neutral-200 dark:border-neutral-700 hover:border-neutral-300 dark:hover:border-neutral-600"
-                        )}
-                      >
-                        <button
-                          type="button"
-                          onClick={() => toggleChannel(conn.id)}
-                          className="w-full p-4 text-left"
-                        >
-                          <div className="flex items-center gap-3 mb-2">
-                            <div className={cn("w-8 h-8 rounded-lg flex items-center justify-center text-white", conn.color)}>
-                              <MessageSquare className="w-4 h-4" />
-                            </div>
-                            <div className="flex-1 min-w-0">
-                              <p className="text-sm font-medium text-neutral-900 dark:text-white">
-                                {conn.name}
-                              </p>
-                              {isOAuth && !isConnected && (
-                                <p className="text-[10px] text-amber-600 dark:text-amber-400 flex items-center gap-1">
-                                  <AlertCircle className="w-3 h-3" /> Not connected
-                                </p>
-                              )}
-                              {isOAuth && isConnected && (
-                                <p className="text-[10px] text-green-600 dark:text-green-400">Connected</p>
-                              )}
-                            </div>
-                            {isSelected && (
-                              <div className="w-5 h-5 rounded-full bg-primary-500 flex items-center justify-center flex-shrink-0">
-                                <Check className="w-3 h-3 text-white" />
-                              </div>
-                            )}
-                          </div>
-                          <p className="text-[11px] text-neutral-500 dark:text-neutral-400 line-clamp-2">
-                            {conn.description}
-                          </p>
-                        </button>
-
-                        {/* Approval toggle (shown when selected) */}
-                        {isSelected && (
-                          <div className="px-4 pb-3 pt-0">
-                            <label className="flex items-center gap-2 text-xs text-neutral-600 dark:text-neutral-400 cursor-pointer">
-                              <input
-                                type="checkbox"
-                                checked={binding?.approval_required ?? false}
-                                onChange={() => toggleChannelApproval(conn.id)}
-                                className="rounded border-neutral-300 dark:border-neutral-600 text-primary-500 focus:ring-primary-500/50 w-3.5 h-3.5"
-                              />
-                              Require approval before sending
-                            </label>
-                          </div>
-                        )}
-                      </div>
-                    );
-                  })}
-                </div>
-
-                {channelBindings.length === 0 && (
+                {availableConnections.length === 0 ? (
                   <p className="text-xs text-neutral-400 dark:text-neutral-500 italic">
-                    No channels selected. You can add connections later from the crew settings.
+                    No connections set up yet. Add one from <a href="/connections" className="underline text-primary-500">Connections</a> and come back.
+                  </p>
+                ) : (
+                  <div className="space-y-2">
+                    {availableConnections.map((conn) => {
+                      const current = getBindingDirection(conn.id);
+                      const selected = hasBinding(conn.id);
+                      return (
+                        <div
+                          key={conn.id}
+                          className={cn(
+                            "rounded-xl border-2 p-3 transition-colors",
+                            selected
+                              ? "border-primary-500 bg-primary-50/50 dark:bg-primary-500/5"
+                              : "border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800/50"
+                          )}
+                        >
+                          <div className="flex items-center justify-between gap-3 flex-wrap">
+                            <div className="flex items-center gap-2 min-w-0">
+                              <div className="w-8 h-8 rounded-lg flex items-center justify-center bg-neutral-100 dark:bg-neutral-700">
+                                <MessageSquare className="w-4 h-4 text-neutral-600 dark:text-neutral-300" />
+                              </div>
+                              <div className="min-w-0">
+                                <p className="text-sm font-medium text-neutral-900 dark:text-white truncate">
+                                  {conn.display_name ?? conn.platform}
+                                </p>
+                                <p className="text-[10px] text-neutral-500 dark:text-neutral-400">
+                                  {conn.platform}
+                                  {!conn.connected && <span className="ml-1 text-amber-500">• disconnected</span>}
+                                </p>
+                              </div>
+                            </div>
+                            <div className="flex items-center gap-1">
+                              <DirectionChip
+                                label="Inbound"
+                                icon={ArrowDownToLine}
+                                active={current === "inbound"}
+                                disabled={!conn.inbound_supported}
+                                onClick={() => handleDirectionPick(conn, "inbound")}
+                              />
+                              <DirectionChip
+                                label="Outbound"
+                                icon={ArrowUpFromLine}
+                                active={current === "outbound"}
+                                disabled={!conn.outbound_supported}
+                                onClick={() => handleDirectionPick(conn, "outbound")}
+                              />
+                              <DirectionChip
+                                label="Both"
+                                icon={ArrowRightLeft}
+                                active={current === "both"}
+                                disabled={!conn.inbound_supported || !conn.outbound_supported}
+                                onClick={() => handleDirectionPick(conn, "both")}
+                              />
+                              {selected && (
+                                <button
+                                  type="button"
+                                  onClick={() => removeBinding(conn.id)}
+                                  className="ml-1 p-1 rounded text-neutral-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20"
+                                  title="Remove binding"
+                                >
+                                  <X className="w-3.5 h-3.5" />
+                                </button>
+                              )}
+                            </div>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+
+                {connectionBindings.length === 0 && (
+                  <p className="text-xs text-neutral-400 dark:text-neutral-500 italic">
+                    No connections selected. This crew will run manually only (the Run button on the crew card).
                   </p>
                 )}
               </div>
 
-              {channelBindings.length > 0 && (
-                <div className="bg-neutral-50 dark:bg-neutral-800/50 rounded-xl border border-neutral-200 dark:border-neutral-700 p-4">
-                  <div className="flex items-center gap-2 mb-2">
-                    <Send className="w-3.5 h-3.5 text-primary-500" />
-                    <span className="text-xs font-medium text-neutral-700 dark:text-neutral-300">
-                      {channelBindings.length} channel{channelBindings.length !== 1 ? "s" : ""} selected
-                    </span>
-                  </div>
-                  <div className="flex flex-wrap gap-2">
-                    {channelBindings.map((b) => {
-                      const conn = CONNECTION_TYPES.find((c) => c.id === b.channel_type);
-                      return (
-                        <span
-                          key={b.channel_type}
-                          className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium bg-primary-100 dark:bg-primary-500/20 text-primary-700 dark:text-primary-300 border border-primary-200 dark:border-primary-800"
-                        >
-                          {conn?.name ?? b.channel_type}
-                          {b.approval_required && (
-                            <Shield className="w-3 h-3 text-amber-500" />
-                          )}
-                        </span>
-                      );
-                    })}
+              {/* Enable-capability inline modal */}
+              {capabilityModal && (
+                <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50 backdrop-blur-sm">
+                  <div className="bg-white dark:bg-neutral-900 rounded-xl border border-neutral-200 dark:border-neutral-700 p-5 max-w-md mx-4 shadow-xl">
+                    <div className="flex items-center gap-2 mb-3">
+                      <AlertCircle className="w-5 h-5 text-amber-500" />
+                      <h4 className="text-sm font-semibold text-neutral-900 dark:text-white">
+                        Capability disabled
+                      </h4>
+                    </div>
+                    <p className="text-sm text-neutral-600 dark:text-neutral-400 mb-4">
+                      <b className="capitalize">{capabilityModal.direction}</b> is currently disabled on{" "}
+                      <b>{capabilityModal.connection.display_name ?? capabilityModal.connection.platform}</b>.
+                      Enable it now so this crew can use it?
+                    </p>
+                    <div className="flex items-center justify-end gap-2">
+                      <button
+                        type="button"
+                        onClick={() => setCapabilityModal(null)}
+                        className="px-3 py-1.5 rounded-lg text-sm font-medium text-neutral-700 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-800"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        type="button"
+                        onClick={enableCapabilityAndContinue}
+                        className="px-3 py-1.5 rounded-lg text-sm font-medium bg-primary-500 text-white hover:bg-primary-600"
+                      >
+                        Enable & continue
+                      </button>
+                    </div>
                   </div>
                 </div>
               )}
             </div>
           )}
 
-          {/* ─── Step 5: Review ─── */}
+          {/* ─── Step 5: Trigger ─── */}
           {step === 5 && (
+            <div className="space-y-4">
+              <div className="bg-neutral-50 dark:bg-neutral-800/50 rounded-xl border border-neutral-200 dark:border-neutral-700 p-5 space-y-4">
+                <h3 className="text-sm font-medium text-neutral-900 dark:text-white flex items-center gap-2">
+                  <Zap className="w-4 h-4 text-primary-500" />
+                  Reactive triggers
+                </h3>
+                <p className="text-xs text-neutral-500 dark:text-neutral-400 -mt-2">
+                  Fire this crew when an inbound message matches any keyword, hashtag, or @mention.
+                </p>
+                {reactiveTriggers.length === 0 && connectionBindings.filter((b) => b.direction === "inbound" || b.direction === "both").length === 0 && (
+                  <p className="text-xs text-neutral-400 dark:text-neutral-500 italic">
+                    Bind at least one inbound connection on the previous step to enable reactive triggers.
+                  </p>
+                )}
+                <div className="space-y-3">
+                  {reactiveTriggers.map((trigger) => {
+                    const conn = availableConnections.find((c) => c.id === trigger.connection_id);
+                    return (
+                      <div key={trigger.id} className="rounded-lg border border-neutral-200 dark:border-neutral-700 p-3 bg-white dark:bg-neutral-800 space-y-2">
+                        <div className="flex items-center justify-between">
+                          <div className="flex items-center gap-2">
+                            <ArrowDownToLine className="w-3.5 h-3.5 text-primary-500" />
+                            <span className="text-sm font-medium text-neutral-900 dark:text-white">
+                              {conn?.display_name ?? conn?.platform ?? trigger.connection_id}
+                            </span>
+                          </div>
+                          <button
+                            type="button"
+                            onClick={() => removeReactiveTrigger(trigger.id)}
+                            className="text-neutral-400 hover:text-red-500"
+                          >
+                            <Trash2 className="w-3.5 h-3.5" />
+                          </button>
+                        </div>
+                        <RuleChips
+                          label="Keywords"
+                          values={trigger.keywords}
+                          onAdd={(v) => addRuleToReactive(trigger.id, "keywords", v)}
+                          onRemove={(v) => removeRuleFromReactive(trigger.id, "keywords", v)}
+                        />
+                        <RuleChips
+                          label="Hashtags"
+                          values={trigger.hashtags}
+                          placeholderPrefix="#"
+                          onAdd={(v) => addRuleToReactive(trigger.id, "hashtags", v)}
+                          onRemove={(v) => removeRuleFromReactive(trigger.id, "hashtags", v)}
+                        />
+                        <RuleChips
+                          label="Mentions"
+                          values={trigger.mentions}
+                          placeholderPrefix="@"
+                          onAdd={(v) => addRuleToReactive(trigger.id, "mentions", v)}
+                          onRemove={(v) => removeRuleFromReactive(trigger.id, "mentions", v)}
+                        />
+                        {trigger.keywords.length + trigger.hashtags.length + trigger.mentions.length === 0 && (
+                          <p className="text-[11px] text-red-500">
+                            Add at least one keyword, hashtag, or mention.
+                          </p>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {connectionBindings
+                    .filter((b) => b.direction === "inbound" || b.direction === "both")
+                    .map((b) => {
+                      const conn = availableConnections.find((c) => c.id === b.connection_id);
+                      return (
+                        <button
+                          key={b.connection_id}
+                          type="button"
+                          onClick={() => addReactiveTrigger(b.connection_id)}
+                          className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full border border-dashed border-neutral-300 dark:border-neutral-600 text-xs text-neutral-600 dark:text-neutral-300 hover:border-primary-500 hover:text-primary-500"
+                        >
+                          <Plus className="w-3 h-3" />
+                          {conn?.display_name ?? conn?.platform ?? b.connection_id}
+                        </button>
+                      );
+                    })}
+                </div>
+              </div>
+
+              <div className="bg-neutral-50 dark:bg-neutral-800/50 rounded-xl border border-neutral-200 dark:border-neutral-700 p-5 space-y-3">
+                <div className="flex items-center justify-between">
+                  <h3 className="text-sm font-medium text-neutral-900 dark:text-white flex items-center gap-2">
+                    <Calendar className="w-4 h-4 text-primary-500" />
+                    Scheduled triggers
+                  </h3>
+                  <button
+                    type="button"
+                    onClick={addScheduledTrigger}
+                    className="inline-flex items-center gap-1 text-xs text-primary-500 hover:text-primary-600"
+                  >
+                    <Plus className="w-3 h-3" />
+                    Add schedule
+                  </button>
+                </div>
+                <p className="text-xs text-neutral-500 dark:text-neutral-400 -mt-1">
+                  Fire on a cron schedule (recurring) or a specific datetime (one-shot).
+                </p>
+                {scheduledTriggers.length === 0 && (
+                  <p className="text-xs text-neutral-400 dark:text-neutral-500 italic">
+                    No schedules set. Add one if you want this crew to fire automatically on a timer.
+                  </p>
+                )}
+                <div className="space-y-3">
+                  {scheduledTriggers.map((trigger) => (
+                    <div key={trigger.id} className="rounded-lg border border-neutral-200 dark:border-neutral-700 p-3 bg-white dark:bg-neutral-800 space-y-2">
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2 text-xs">
+                          <label className="inline-flex items-center gap-1 cursor-pointer">
+                            <input
+                              type="radio"
+                              name={`mode-${trigger.id}`}
+                              checked={trigger.mode === "cron"}
+                              onChange={() => updateScheduledTrigger(trigger.id, { mode: "cron" })}
+                            />
+                            Recurring (cron)
+                          </label>
+                          <label className="inline-flex items-center gap-1 cursor-pointer ml-2">
+                            <input
+                              type="radio"
+                              name={`mode-${trigger.id}`}
+                              checked={trigger.mode === "run_at"}
+                              onChange={() => updateScheduledTrigger(trigger.id, { mode: "run_at" })}
+                            />
+                            One-shot
+                          </label>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => removeScheduledTrigger(trigger.id)}
+                          className="text-neutral-400 hover:text-red-500"
+                        >
+                          <Trash2 className="w-3.5 h-3.5" />
+                        </button>
+                      </div>
+                      {trigger.mode === "cron" ? (
+                        <input
+                          type="text"
+                          value={trigger.cron}
+                          onChange={(e) => updateScheduledTrigger(trigger.id, { cron: e.target.value })}
+                          placeholder="0 9 * * *"
+                          className="w-full px-2.5 py-1.5 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-white text-xs font-mono"
+                        />
+                      ) : (
+                        <input
+                          type="datetime-local"
+                          value={trigger.run_at}
+                          onChange={(e) => updateScheduledTrigger(trigger.id, { run_at: e.target.value })}
+                          className="w-full px-2.5 py-1.5 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-white text-xs"
+                        />
+                      )}
+                      <textarea
+                        value={trigger.content_brief}
+                        onChange={(e) => updateScheduledTrigger(trigger.id, { content_brief: e.target.value })}
+                        placeholder="What should this crew produce? (optional)"
+                        rows={2}
+                        className="w-full px-2.5 py-1.5 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-white text-xs resize-none"
+                      />
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {reactiveTriggers.length === 0 && scheduledTriggers.length === 0 && (
+                <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-xl p-3 text-xs text-amber-800 dark:text-amber-300">
+                  No triggers configured — this crew will only fire when you click <b>Run</b> on its card.
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* ─── Step 6: Approval ─── */}
+          {step === 6 && (
+            <div className="space-y-4">
+              <div className="bg-neutral-50 dark:bg-neutral-800/50 rounded-xl border border-neutral-200 dark:border-neutral-700 p-5 space-y-3">
+                <h3 className="text-sm font-medium text-neutral-900 dark:text-white flex items-center gap-2">
+                  <Bell className="w-4 h-4 text-primary-500" />
+                  Approval
+                </h3>
+                <label className="flex items-start gap-3 cursor-pointer p-3 rounded-lg bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700">
+                  <input
+                    type="checkbox"
+                    checked={approvalRequired}
+                    onChange={(e) => setApprovalRequired(e.target.checked)}
+                    className="mt-0.5 rounded border-neutral-300 dark:border-neutral-600 text-primary-500 focus:ring-primary-500/50 w-4 h-4"
+                  />
+                  <div>
+                    <p className="text-sm font-medium text-neutral-900 dark:text-white">
+                      Review outbound before sending
+                    </p>
+                    <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-0.5">
+                      When on, this crew's output is queued in the <a href="/approvals" className="underline text-primary-500">Approvals</a> page instead of publishing immediately. You edit / approve / reject there before it goes out.
+                    </p>
+                  </div>
+                </label>
+              </div>
+            </div>
+          )}
+
+          {/* ─── Step 7: Review ─── */}
+          {step === 7 && (
             <div className="space-y-4">
               <div className="bg-neutral-50 dark:bg-neutral-800/50 rounded-xl border border-neutral-200 dark:border-neutral-700 p-5 space-y-3">
                 <h3 className="text-sm font-medium text-neutral-900 dark:text-white flex items-center gap-2">
@@ -1248,34 +1688,91 @@ export function CrewBuilder({ open, onClose, onCreated, editCrew }: CrewBuilderP
                 </div>
               )}
 
-              {/* Connections summary */}
-              {channelBindings.length > 0 && (
+              {/* Connections & Directions summary */}
+              {connectionBindings.length > 0 && (
                 <div className="bg-neutral-50 dark:bg-neutral-800/50 rounded-xl border border-neutral-200 dark:border-neutral-700 p-5 space-y-3">
                   <h3 className="text-sm font-medium text-neutral-900 dark:text-white flex items-center gap-2">
                     <Cable className="w-4 h-4 text-primary-500" />
-                    Connections ({channelBindings.length})
+                    Connections & Directions ({connectionBindings.length})
                   </h3>
                   <div className="flex flex-wrap gap-2">
-                    {channelBindings.map((b) => {
-                      const conn = CONNECTION_TYPES.find((c) => c.id === b.channel_type);
+                    {connectionBindings.map((b) => {
+                      const conn = availableConnections.find((c) => c.id === b.connection_id);
+                      const dirLabel = b.direction === "both" ? "Both" : b.direction === "inbound" ? "Inbound" : "Outbound";
+                      const DirIcon = b.direction === "both" ? ArrowRightLeft : b.direction === "inbound" ? ArrowDownToLine : ArrowUpFromLine;
                       return (
                         <span
-                          key={b.channel_type}
+                          key={b.connection_id}
                           className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 text-neutral-700 dark:text-neutral-300"
                         >
-                          <div className={cn("w-4 h-4 rounded flex items-center justify-center text-white", conn?.color ?? "bg-neutral-500")}>
-                            <MessageSquare className="w-2.5 h-2.5" />
-                          </div>
-                          {conn?.name ?? b.channel_type}
-                          {b.approval_required && (
-                            <span className="text-[10px] text-amber-500 font-medium">(approval)</span>
-                          )}
+                          {conn?.display_name ?? conn?.platform ?? b.platform}
+                          <span className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded bg-primary-100 dark:bg-primary-500/20 text-primary-700 dark:text-primary-300">
+                            <DirIcon className="w-2.5 h-2.5" />
+                            {dirLabel}
+                          </span>
                         </span>
                       );
                     })}
                   </div>
                 </div>
               )}
+
+              {/* Triggers summary */}
+              <div className="bg-neutral-50 dark:bg-neutral-800/50 rounded-xl border border-neutral-200 dark:border-neutral-700 p-5 space-y-3">
+                <h3 className="text-sm font-medium text-neutral-900 dark:text-white flex items-center gap-2">
+                  <Zap className="w-4 h-4 text-primary-500" />
+                  Triggers
+                </h3>
+                {reactiveTriggers.length === 0 && scheduledTriggers.length === 0 ? (
+                  <p className="text-xs text-neutral-500 dark:text-neutral-400 italic">
+                    Manual only — fires when you click Run on the crew card.
+                  </p>
+                ) : (
+                  <div className="space-y-2 text-xs">
+                    {reactiveTriggers.map((t) => {
+                      const conn = availableConnections.find((c) => c.id === t.connection_id);
+                      const rules = [...t.keywords, ...t.hashtags, ...t.mentions];
+                      return (
+                        <div key={t.id} className="flex items-start gap-2 p-2 rounded-lg bg-white dark:bg-neutral-800 border border-neutral-100 dark:border-neutral-700">
+                          <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-orange-100 dark:bg-orange-500/20 text-orange-700 dark:text-orange-400 text-[10px] font-medium">
+                            <Zap className="w-2.5 h-2.5" /> Reactive
+                          </span>
+                          <span className="text-neutral-700 dark:text-neutral-300">
+                            on <b>{conn?.display_name ?? t.connection_id}</b> matching <span className="text-neutral-500 dark:text-neutral-400">{rules.join(", ") || "(none)"}</span>
+                          </span>
+                        </div>
+                      );
+                    })}
+                    {scheduledTriggers.map((t) => (
+                      <div key={t.id} className="flex items-start gap-2 p-2 rounded-lg bg-white dark:bg-neutral-800 border border-neutral-100 dark:border-neutral-700">
+                        <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-blue-100 dark:bg-blue-500/20 text-blue-700 dark:text-blue-400 text-[10px] font-medium">
+                          <Calendar className="w-2.5 h-2.5" /> Scheduled
+                        </span>
+                        <span className="text-neutral-700 dark:text-neutral-300 font-mono">
+                          {t.mode === "cron" ? t.cron : `at ${t.run_at}`}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {/* Approval summary */}
+              <div className={cn(
+                "rounded-xl border p-4 text-xs",
+                approvalRequired
+                  ? "bg-amber-50 dark:bg-amber-900/20 border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-300"
+                  : "bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800 text-green-800 dark:text-green-300"
+              )}>
+                <div className="flex items-center gap-2">
+                  {approvalRequired ? <Shield className="w-4 h-4" /> : <Check className="w-4 h-4" />}
+                  <span className="font-medium">
+                    {approvalRequired
+                      ? "Review outbound before sending — output queued in Approvals."
+                      : "Auto-publish — crew output goes out immediately."}
+                  </span>
+                </div>
+              </div>
             </div>
           )}
         </div>
@@ -1328,6 +1825,99 @@ export function CrewBuilder({ open, onClose, onCreated, editCrew }: CrewBuilderP
             )}
           </div>
         </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Small UI helpers used inside the wizard
+// ---------------------------------------------------------------------------
+
+function DirectionChip({
+  label,
+  icon: Icon,
+  active,
+  disabled,
+  onClick,
+}: {
+  label: string;
+  icon: React.ElementType;
+  active: boolean;
+  disabled: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        "inline-flex items-center gap-1 px-2 py-1 rounded-md border text-[11px] font-medium transition-colors",
+        active
+          ? "border-primary-500 bg-primary-500 text-white"
+          : "border-neutral-200 dark:border-neutral-700 text-neutral-600 dark:text-neutral-300 hover:border-primary-400",
+        disabled && "opacity-40 cursor-not-allowed hover:border-neutral-200 dark:hover:border-neutral-700"
+      )}
+      title={disabled ? `${label} not supported on this platform` : undefined}
+    >
+      <Icon className="w-3 h-3" />
+      {label}
+    </button>
+  );
+}
+
+function RuleChips({
+  label,
+  values,
+  placeholderPrefix,
+  onAdd,
+  onRemove,
+}: {
+  label: string;
+  values: string[];
+  placeholderPrefix?: string;
+  onAdd: (value: string) => void;
+  onRemove: (value: string) => void;
+}) {
+  const [draft, setDraft] = useState("");
+  const submit = () => {
+    const v = draft.trim();
+    if (!v) return;
+    onAdd(v);
+    setDraft("");
+  };
+  return (
+    <div className="space-y-1">
+      <label className="text-[11px] font-medium text-neutral-500 dark:text-neutral-400">
+        {label}
+      </label>
+      <div className="flex flex-wrap items-center gap-1.5">
+        {values.map((v) => (
+          <span
+            key={v}
+            className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-primary-50 dark:bg-primary-500/10 text-primary-700 dark:text-primary-300 text-[11px] border border-primary-200 dark:border-primary-800"
+          >
+            {v}
+            <button type="button" onClick={() => onRemove(v)} className="hover:text-red-500">
+              <X className="w-2.5 h-2.5" />
+            </button>
+          </span>
+        ))}
+        <input
+          type="text"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              submit();
+            }
+          }}
+          onBlur={submit}
+          placeholder={`+ ${placeholderPrefix ?? ""}${label.toLowerCase().slice(0, -1)}`}
+          className="flex-1 min-w-[120px] px-2 py-0.5 text-[11px] rounded border border-transparent hover:border-neutral-200 dark:hover:border-neutral-700 focus:border-primary-500 bg-transparent outline-none"
+        />
       </div>
     </div>
   );

--- a/frontend/src/components/crews/crew-builder.tsx
+++ b/frontend/src/components/crews/crew-builder.tsx
@@ -1385,7 +1385,7 @@ export function CrewBuilder({ open, onClose, onCreated, editCrew }: CrewBuilderP
                 </p>
                 {reactiveTriggers.length === 0 && connectionBindings.filter((b) => b.direction === "inbound" || b.direction === "both").length === 0 && (
                   <p className="text-xs text-neutral-400 dark:text-neutral-500 italic">
-                    Bind at least one inbound connection on the previous step to enable reactive triggers.
+                    To add a reactive trigger, go back to <b>Step 4</b> and pick a connection with direction <b>Inbound</b> or <b>Both</b>. Triggers are configured per inbound-bound connection.
                   </p>
                 )}
                 <div className="space-y-3">

--- a/frontend/src/components/navigation/desktop-sidebar.tsx
+++ b/frontend/src/components/navigation/desktop-sidebar.tsx
@@ -9,8 +9,6 @@ import {
   FlaskConical,
   Cable,
   ClipboardCheck,
-  Clock,
-  Send,
   Settings,
   ChevronLeft,
   ChevronRight,
@@ -40,8 +38,6 @@ const navItems: NavItem[] = [
   { label: "Workspace", path: "/workspace", icon: FlaskConical },
   { label: "Connections", path: "/connections", icon: Cable },
   { label: "Approvals", path: "/approvals", icon: ClipboardCheck },
-  { label: "Schedule", path: "/schedule", icon: Clock },
-  { label: "Distribution", path: "/distribution", icon: Send },
   { label: "Settings", path: "/settings", icon: Settings },
 ];
 

--- a/frontend/src/lib/api/connections-client.ts
+++ b/frontend/src/lib/api/connections-client.ts
@@ -1,0 +1,112 @@
+import { api } from "@/lib/transport";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ConnectionPlatform =
+  | "telegram"
+  | "discord"
+  | "reddit"
+  | "twitter"
+  | "linkedin"
+  | "instagram"
+  | "facebook"
+  | "blog"
+  | "email"
+  | "slack_webhook";
+
+export type ConnectionStore =
+  | "oauth_connections"
+  | "reddit_accounts"
+  | "twitter_accounts"
+  | "channel_registrations"
+  | "distribution_channels";
+
+export interface ConnectionSummary {
+  id: string;
+  platform: ConnectionPlatform;
+  store: ConnectionStore;
+  display_name?: string | null;
+  connected: boolean;
+  inbound_enabled: boolean;
+  outbound_enabled: boolean;
+  inbound_supported: boolean;
+  outbound_supported: boolean;
+  config_summary: Record<string, unknown>;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface ConnectionListResponse {
+  success: boolean;
+  connections: ConnectionSummary[];
+  total_count: number;
+}
+
+export interface CapabilityUpdate {
+  inbound_enabled?: boolean;
+  outbound_enabled?: boolean;
+}
+
+export type OutboundPlatform = "blog" | "email" | "slack_webhook";
+
+export interface OutboundConnectionCreate {
+  platform: OutboundPlatform;
+  name: string;
+  config: Record<string, unknown>;
+  enabled?: boolean;
+}
+
+export interface OutboundConnectionUpdate {
+  name?: string;
+  config?: Record<string, unknown>;
+  enabled?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// API client
+// ---------------------------------------------------------------------------
+
+export const connectionsApi = {
+  list: async (): Promise<ConnectionSummary[]> => {
+    const { data } = await api.get<ConnectionListResponse>("/connections");
+    return data.connections ?? [];
+  },
+
+  get: async (id: string): Promise<ConnectionSummary> => {
+    const { data } = await api.get<ConnectionSummary>(`/connections/${encodeURIComponent(id)}`);
+    return data;
+  },
+
+  updateCapabilities: async (
+    id: string,
+    update: CapabilityUpdate,
+  ): Promise<ConnectionSummary> => {
+    const { data } = await api.patch<ConnectionSummary>(
+      `/connections/${encodeURIComponent(id)}/capabilities`,
+      update,
+    );
+    return data;
+  },
+
+  createOutbound: async (payload: OutboundConnectionCreate): Promise<ConnectionSummary> => {
+    const { data } = await api.post<ConnectionSummary>("/connections/outbound", payload);
+    return data;
+  },
+
+  updateOutbound: async (
+    id: string,
+    update: OutboundConnectionUpdate,
+  ): Promise<ConnectionSummary> => {
+    const { data } = await api.put<ConnectionSummary>(
+      `/connections/outbound/${encodeURIComponent(id)}`,
+      update,
+    );
+    return data;
+  },
+
+  deleteOutbound: async (id: string): Promise<void> => {
+    await api.delete(`/connections/outbound/${encodeURIComponent(id)}`);
+  },
+};

--- a/frontend/src/lib/api/crews-client.ts
+++ b/frontend/src/lib/api/crews-client.ts
@@ -71,6 +71,8 @@ export interface CrewRun {
   input_data?: Record<string, unknown>;
   output_data?: Record<string, unknown>;
   error?: string;
+  trigger_type?: "reactive" | "scheduled" | "manual";
+  trigger_source?: string;
 }
 
 export interface CrewRunStep {

--- a/frontend/src/lib/api/crews-client.ts
+++ b/frontend/src/lib/api/crews-client.ts
@@ -36,6 +36,29 @@ export interface ChannelBinding {
   approval_required: boolean;
 }
 
+// Phase 3 additions — safe to read as optional since PR 1 may not be merged yet.
+export interface ConnectionBinding {
+  connection_id: string;
+  platform: string;
+  direction: "inbound" | "outbound" | "both";
+}
+
+export type CrewTrigger =
+  | {
+      type: "reactive";
+      connection_id: string;
+      keywords?: string[];
+      hashtags?: string[];
+      mentions?: string[];
+    }
+  | {
+      type: "scheduled";
+      connection_ids?: string[];
+      cron?: string;
+      run_at?: string;
+      content_brief?: string;
+    };
+
 export interface Crew {
   id?: string;
   crew_id: string;
@@ -44,6 +67,9 @@ export interface Crew {
   execution_config?: CrewExecutionConfig;
   agents?: CrewAgent[];
   channel_bindings?: ChannelBinding[];
+  connection_bindings?: ConnectionBinding[];
+  triggers?: CrewTrigger[];
+  approval_required?: boolean;
   phases?: unknown[];
   schedule?: CrewSchedule;
   status: "active" | "paused" | "archived" | "idle";
@@ -71,6 +97,8 @@ export interface CrewRun {
   input_data?: Record<string, unknown>;
   output_data?: Record<string, unknown>;
   error?: string;
+  trigger_type?: "reactive" | "scheduled" | "manual";
+  trigger_source?: string;
 }
 
 export interface CrewRunStep {

--- a/frontend/src/routes/connections.tsx
+++ b/frontend/src/routes/connections.tsx
@@ -21,6 +21,9 @@ import {
   LogIn,
   User,
   Copy,
+  FileText,
+  Mail,
+  Hash,
 } from "lucide-react";
 import {
   configureOAuthClient,
@@ -38,10 +41,25 @@ import {
   deleteTrigger,
   type Trigger,
 } from "@/lib/api/triggers-client";
+import {
+  connectionsApi,
+  type ConnectionSummary,
+  type OutboundPlatform,
+} from "@/lib/api/connections-client";
 
 // ─── Types ──────────────────────────────────────────────────────
 
-type ConnectionId = "telegram" | "discord" | "linkedin" | "twitter" | "instagram" | "facebook" | "reddit";
+type ConnectionId =
+  | "telegram"
+  | "discord"
+  | "linkedin"
+  | "twitter"
+  | "instagram"
+  | "facebook"
+  | "reddit"
+  | "blog"
+  | "email"
+  | "slack_webhook";
 
 interface ConnectionConfig {
   id: ConnectionId;
@@ -63,6 +81,8 @@ interface ConnectionConfig {
   supportsOutbound: boolean;
   defaultInbound: boolean;
   defaultOutbound: boolean;
+  /** True for blog/email/slack_webhook — stored in backend via /connections/outbound. */
+  outboundOnly?: boolean;
 }
 
 interface SavedConnection {
@@ -273,6 +293,67 @@ const CONNECTIONS: ConnectionConfig[] = [
       { key: "keywords", label: "Keywords (comma-separated)", placeholder: "local LLM, ollama, gguf" },
     ],
   },
+  {
+    id: "blog",
+    name: "Blog",
+    description: "Publish to Ghost, WordPress, or any custom REST endpoint.",
+    icon: FileText,
+    iconBg: "bg-amber-100 dark:bg-amber-500/20",
+    iconColor: "text-amber-600 dark:text-amber-400",
+    docsUrl: "https://ghost.org/docs/content-api/",
+    oauthProvider: null,
+    supportsInbound: false,
+    supportsOutbound: true,
+    defaultInbound: false,
+    defaultOutbound: true,
+    outboundOnly: true,
+    fields: [
+      { key: "name", label: "Connection Name", placeholder: "My Blog" },
+      { key: "cms_type", label: "CMS Type (ghost | wordpress | custom)", placeholder: "ghost" },
+      { key: "api_url", label: "API URL", placeholder: "https://my-blog.com/ghost/api/v3/admin/posts" },
+      { key: "api_key", label: "API Key (optional)", placeholder: "Admin API key", secret: true },
+    ],
+  },
+  {
+    id: "email",
+    name: "Email",
+    description: "Send AI-generated content by email (SendGrid, SES, or SMTP).",
+    icon: Mail,
+    iconBg: "bg-rose-100 dark:bg-rose-500/20",
+    iconColor: "text-rose-600 dark:text-rose-400",
+    docsUrl: "https://docs.sendgrid.com/api-reference/mail-send/mail-send",
+    oauthProvider: null,
+    supportsInbound: false,
+    supportsOutbound: true,
+    defaultInbound: false,
+    defaultOutbound: true,
+    outboundOnly: true,
+    fields: [
+      { key: "name", label: "Connection Name", placeholder: "Newsletter sender" },
+      { key: "provider", label: "Provider (sendgrid | ses | smtp)", placeholder: "sendgrid" },
+      { key: "api_key", label: "API Key", placeholder: "SG.xxxx...", secret: true },
+      { key: "from_email", label: "From Address", placeholder: "hello@example.com" },
+    ],
+  },
+  {
+    id: "slack_webhook",
+    name: "Slack Webhook",
+    description: "Post to a Slack channel via an incoming webhook URL.",
+    icon: Hash,
+    iconBg: "bg-violet-100 dark:bg-violet-500/20",
+    iconColor: "text-violet-600 dark:text-violet-400",
+    docsUrl: "https://api.slack.com/messaging/webhooks",
+    oauthProvider: null,
+    supportsInbound: false,
+    supportsOutbound: true,
+    defaultInbound: false,
+    defaultOutbound: true,
+    outboundOnly: true,
+    fields: [
+      { key: "name", label: "Connection Name", placeholder: "Team ops" },
+      { key: "webhook_url", label: "Webhook URL", placeholder: "https://hooks.slack.com/services/T.../B.../xxx", secret: true },
+    ],
+  },
 ];
 
 // ─── Helpers ────────────────────────────────────────────────────
@@ -387,9 +468,87 @@ export default function ConnectionsPage() {
     setShowSecrets({});
   };
 
-  // Token-paste save (Telegram/Discord/Reddit)
+  // Load existing outbound-only connections from the aggregator on mount so
+  // blog/email/slack_webhook cards reflect real backend state (not localStorage).
+  useEffect(() => {
+    let cancelled = false;
+    connectionsApi
+      .list()
+      .then((rows: ConnectionSummary[]) => {
+        if (cancelled) return;
+        const outboundRows = rows.filter(
+          (r) => r.platform === "blog" || r.platform === "email" || r.platform === "slack_webhook",
+        );
+        if (outboundRows.length === 0) return;
+        setConnections((prev) => {
+          const filtered = prev.filter(
+            (c) => c.id !== "blog" && c.id !== "email" && c.id !== "slack_webhook",
+          );
+          for (const row of outboundRows) {
+            filtered.push({
+              id: row.platform as ConnectionId,
+              config: { _backend_id: row.id, name: row.display_name ?? "" },
+              inbound: row.inbound_enabled,
+              outbound: row.outbound_enabled,
+              status: row.connected ? "connected" : "disconnected",
+              connectedAt: row.created_at ?? undefined,
+              profileName: row.display_name ?? undefined,
+            });
+          }
+          saveConnections(filtered);
+          return filtered;
+        });
+      })
+      .catch(() => {
+        // Backend may not yet know about /connections — non-fatal for localStorage-based cards.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Token-paste save (Telegram/Discord/Reddit/Blog/Email/Slack webhook)
   const handleSave = async (connId: ConnectionId) => {
     setTesting(connId);
+
+    const conf = CONNECTIONS.find((c) => c.id === connId);
+
+    // Outbound-only connections (blog / email / slack_webhook) go to the unified backend.
+    if (conf?.outboundOnly) {
+      try {
+        const name = (formData.name || conf.name).trim();
+        const cfg: Record<string, unknown> = {};
+        for (const field of conf.fields) {
+          if (field.key === "name") continue;
+          const value = (formData[field.key] || "").trim();
+          if (value) cfg[field.key] = value;
+        }
+        const created = await connectionsApi.createOutbound({
+          platform: conf.id as OutboundPlatform,
+          name,
+          config: cfg,
+        });
+
+        const updated = connections.filter((c) => c.id !== connId);
+        updated.push({
+          id: connId,
+          config: { _backend_id: created.id, name },
+          inbound: false,
+          outbound: true,
+          status: "connected",
+          connectedAt: created.created_at ?? new Date().toISOString(),
+          profileName: name,
+        });
+        setConnections(updated);
+        saveConnections(updated);
+      } catch (e) {
+        console.error("Outbound connection save failed", e);
+      }
+      setTesting(null);
+      setEditing(null);
+      setFormData({});
+      return;
+    }
 
     // Reddit has a dedicated backend endpoint — save there too so the poller picks it up.
     if (connId === "reddit") {
@@ -486,6 +645,19 @@ export default function ConnectionsPage() {
   };
 
   const handleDisconnect = async (conn: ConnectionConfig) => {
+    // Outbound-only connections live in the backend — delete there.
+    if (conn.outboundOnly) {
+      const saved = getConnection(conn.id);
+      const backendId = saved?.config._backend_id;
+      if (backendId) {
+        try {
+          await connectionsApi.deleteOutbound(backendId);
+        } catch {
+          // proceed with local cleanup anyway
+        }
+      }
+    }
+
     // If OAuth provider, also disconnect on backend
     if (conn.oauthProvider) {
       try {

--- a/frontend/src/routes/connections.tsx
+++ b/frontend/src/routes/connections.tsx
@@ -575,6 +575,27 @@ export default function ConnectionsPage() {
       } catch (e) {
         console.error("Reddit save/test failed", e);
       }
+    } else if (connId === "telegram" || connId === "discord") {
+      // Phase 3: persist Telegram/Discord to backend channel_registrations
+      // so the /api/v1/connections aggregator (crew-builder Step 4) surfaces them.
+      // Without this, Solo's Connections page was localStorage-only and Step 4
+      // saw an empty list.
+      try {
+        const { api } = await import("@/lib/transport");
+        const config: Record<string, string> = {};
+        for (const [k, v] of Object.entries(formData)) {
+          const trimmed = v.trim();
+          if (trimmed) config[k] = trimmed;
+        }
+        if (Object.keys(config).length > 0) {
+          await api.post("/channels/registrations", {
+            channel_type: connId,
+            config,
+          });
+        }
+      } catch (e) {
+        console.error(`${connId} backend save failed (localStorage still updated)`, e);
+      }
     } else {
       await new Promise((r) => setTimeout(r, 1500));
     }
@@ -668,6 +689,23 @@ export default function ConnectionsPage() {
         }));
       } catch {
         // proceed with local cleanup anyway
+      }
+    }
+
+    // Phase 3: Telegram/Discord — drop the backend registration so the
+    // aggregator stops surfacing it.
+    if (conn.id === "telegram" || conn.id === "discord") {
+      try {
+        const { api } = await import("@/lib/transport");
+        const { data } = await api.get<{ data?: { registrations?: Array<{ id?: string; channel_type?: string }> } }>("/channels/registrations");
+        const regs = data?.data?.registrations ?? [];
+        for (const reg of regs) {
+          if (reg.channel_type === conn.id && reg.id) {
+            await api.delete(`/channels/registrations/${reg.id}`).catch(() => {});
+          }
+        }
+      } catch (e) {
+        console.error(`Failed to drop ${conn.id} from backend`, e);
       }
     }
 

--- a/frontend/src/routes/crews.tsx
+++ b/frontend/src/routes/crews.tsx
@@ -93,6 +93,32 @@ function StatusBadge({ status }: { status: string }) {
   );
 }
 
+function TriggerTypeBadge({ triggerType }: { triggerType?: string }) {
+  // Phase 3: indicates why this run fired. Defaults to "manual" so runs from
+  // before the trigger metadata existed still render something sensible.
+  const t = triggerType ?? "manual";
+  const map: Record<string, { label: string; cls: string }> = {
+    manual: {
+      label: "Manual",
+      cls: "bg-neutral-100 dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400",
+    },
+    reactive: {
+      label: "Reactive",
+      cls: "bg-orange-50 dark:bg-orange-500/10 text-orange-600 dark:text-orange-400",
+    },
+    scheduled: {
+      label: "Scheduled",
+      cls: "bg-blue-50 dark:bg-blue-500/10 text-blue-600 dark:text-blue-400",
+    },
+  };
+  const info = map[t] ?? map.manual;
+  return (
+    <span className={cn("inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium", info.cls)}>
+      {info.label}
+    </span>
+  );
+}
+
 const MODE_BADGES: Record<string, { label: string; cls: string; icon: React.ElementType }> = {
   sequential: {
     label: "Sequential",
@@ -134,6 +160,7 @@ export default function CrewsPage() {
   const [searchQuery, setSearchQuery] = useState("");
   const [statusFilter, setStatusFilter] = useState<string>("all");
   const [modeFilter, setModeFilter] = useState<string>("all");
+  const [phase3Filter, setPhase3Filter] = useState<string>("all");
 
   const loadData = useCallback(async () => {
     try {
@@ -192,6 +219,27 @@ export default function CrewsPage() {
       (crew.execution_config?.mode || "sequential") !== modeFilter
     ) {
       return false;
+    }
+    if (phase3Filter !== "all") {
+      const bindings = crew.connection_bindings ?? [];
+      const triggers = crew.triggers ?? [];
+      switch (phase3Filter) {
+        case "inbound":
+          if (!bindings.some((b) => b.direction === "inbound" || b.direction === "both")) return false;
+          break;
+        case "outbound":
+          if (!bindings.some((b) => b.direction === "outbound" || b.direction === "both")) return false;
+          break;
+        case "reactive":
+          if (!triggers.some((t) => t.type === "reactive")) return false;
+          break;
+        case "scheduled":
+          if (!triggers.some((t) => t.type === "scheduled")) return false;
+          break;
+        case "approval":
+          if (!crew.approval_required) return false;
+          break;
+      }
     }
     return true;
   });
@@ -330,6 +378,18 @@ export default function CrewsPage() {
                 <option value="parallel">Parallel</option>
                 <option value="pipeline">Pipeline</option>
                 <option value="autonomous">Autonomous</option>
+              </select>
+              <select
+                value={phase3Filter}
+                onChange={(e) => setPhase3Filter(e.target.value)}
+                className="px-2 py-1.5 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-white text-xs focus:ring-2 focus:ring-primary-500/30 outline-none"
+              >
+                <option value="all">All bindings</option>
+                <option value="inbound">Inbound</option>
+                <option value="outbound">Outbound</option>
+                <option value="reactive">Reactive trigger</option>
+                <option value="scheduled">Scheduled trigger</option>
+                <option value="approval">Approval required</option>
               </select>
             </div>
           )}
@@ -520,6 +580,7 @@ function RunsList({ runs }: { runs: CrewRun[] }) {
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
               <StatusBadge status={run.status} />
+              <TriggerTypeBadge triggerType={run.trigger_type} />
               <div>
                 <span className="text-sm font-medium text-neutral-900 dark:text-white">
                   {run.crew_name || run.crew_id.slice(0, 8)}

--- a/frontend/tests/e2e/connections/connections.spec.ts
+++ b/frontend/tests/e2e/connections/connections.spec.ts
@@ -23,8 +23,8 @@ test.beforeEach(async ({ page }) => {
 // ==========================================================================
 
 test.describe("CRUD via UI", () => {
-  // DC-CONN-01: View all 7 connection cards
-  test("DC-CONN-01: view all 7 connection cards", async ({ page }) => {
+  // DC-CONN-01: View all 10 connection cards (7 socials + Blog + Email + Slack webhook)
+  test("DC-CONN-01: view all 10 connection cards", async ({ page }) => {
     await expect(page.locator("h1", { hasText: "Connections" })).toBeVisible();
 
     await expect(page.locator("h3", { hasText: "Telegram Bot" })).toBeVisible();
@@ -34,9 +34,13 @@ test.describe("CRUD via UI", () => {
     await expect(page.locator("h3", { hasText: "Twitter / X" })).toBeVisible();
     await expect(page.locator("h3", { hasText: "Instagram" })).toBeVisible();
     await expect(page.locator("h3", { hasText: "Facebook" })).toBeVisible();
+    // Phase 3: outbound-only additions.
+    await expect(page.locator("h3", { hasText: "Blog" })).toBeVisible();
+    await expect(page.locator("h3", { hasText: "Email" })).toBeVisible();
+    await expect(page.locator("h3", { hasText: "Slack Webhook" })).toBeVisible();
 
     const count = await connections.connectionCards.count();
-    expect(count).toBe(7);
+    expect(count).toBe(10);
   });
 
   // DC-CONN-02: Expand Telegram connection form
@@ -48,9 +52,11 @@ test.describe("CRUD via UI", () => {
     // Bot Token field should be visible
     await expect(page.locator("input[placeholder*='123456']")).toBeVisible();
 
-    // Direction toggles should be visible
-    await expect(page.locator("text=Inbound")).toBeVisible();
-    await expect(page.locator("text=Outbound")).toBeVisible();
+    // Direction toggles should be visible inside the Telegram card.
+    // Scoped to the card to avoid strict-mode collisions with other cards'
+    // Inbound/Outbound labels (e.g. Blog / Email / Slack webhook).
+    await expect(telegramCard.locator("text=Inbound").first()).toBeVisible();
+    await expect(telegramCard.locator("text=Outbound").first()).toBeVisible();
   });
 
   // DC-CONN-03: Expand Discord connection form
@@ -96,8 +102,10 @@ test.describe("CRUD via UI", () => {
     await expect(page.locator("input[placeholder*='Access Token']").first()).toBeVisible();
     await expect(page.locator("input[placeholder*='Access Token Secret']")).toBeVisible();
 
-    // Twitter/X supports outbound only — no Inbound toggle
-    await expect(page.locator("text=Outbound")).toBeVisible();
+    // Twitter/X supports outbound only — no Inbound toggle.
+    // Scoped to the Twitter card so Blog / Email / Slack Outbound labels
+    // don't trigger strict-mode violations.
+    await expect(twitterCard.locator("text=Outbound").first()).toBeVisible();
   });
 
   // DC-CONN-13: Save Twitter/X credentials
@@ -165,11 +173,11 @@ test.describe("Positive Workflows", () => {
     await expect(page.locator("button", { hasText: "Sign in with LinkedIn" })).toBeVisible();
   });
 
-  // DC-CONN-09: External docs links are present
+  // DC-CONN-09: External docs links are present (10 total after Phase 3)
   test("DC-CONN-09: external docs links are present", async ({ page }) => {
     const docsLinks = page.locator("a[title='Setup guide']");
     const count = await docsLinks.count();
-    expect(count).toBe(7);
+    expect(count).toBe(10);
 
     const links = await docsLinks.all();
     for (const link of links) {

--- a/frontend/tests/e2e/crews/crews.spec.ts
+++ b/frontend/tests/e2e/crews/crews.spec.ts
@@ -100,10 +100,10 @@ test.describe("Wizard Flow", () => {
   test("DC-CREW-WIZ-01: wizard shows step indicator", async () => {
     await crews.openBuilder();
 
-    // Should have 4 step indicator circles
+    // Post-Phase-3 the wizard is 7 steps (6 for autonomous).
     const indicators = crews.stepIndicators;
     const count = await indicators.count();
-    expect(count).toBeGreaterThanOrEqual(3); // 3 for autonomous, 4 for others
+    expect(count).toBeGreaterThanOrEqual(6);
   });
 
   // DC-CREW-WIZ-02: Step 1 shows crew name and description
@@ -149,20 +149,30 @@ test.describe("Wizard Flow", () => {
     await crews.nextButton.click();
     await page.waitForTimeout(300);
 
-    // Step 4: Connections
-    await expect(page.locator("text=Channel Connections").first()).toBeVisible();
+    // Step 4: Connections & Directions (Phase 3)
+    await expect(page.locator("text=/Pick connections/i").first()).toBeVisible();
     await crews.nextButton.click();
     await page.waitForTimeout(300);
 
-    // Step 5: Review
-    await expect(page.locator("text=Review Configuration").first()).toBeVisible();
+    // Step 5: Trigger (Phase 3)
+    await expect(page.locator("text=/Reactive triggers/i").first()).toBeVisible();
+    await crews.nextButton.click();
+    await page.waitForTimeout(300);
+
+    // Step 6: Approval (Phase 3)
+    await expect(page.locator("text=/Review outbound before sending/i").first()).toBeVisible();
+    await crews.nextButton.click();
+    await page.waitForTimeout(300);
+
+    // Step 7: Review
+    await expect(page.locator("text=/Review Configuration/i").first()).toBeVisible();
   });
 
-  // DC-CREW-WIZ-05: Connections step shows channel cards
-  test("DC-CREW-WIZ-05: connections step shows channel cards", async ({ page }) => {
+  // DC-CREW-WIZ-05: Connections & Directions step shows connection rows
+  test("DC-CREW-WIZ-05: connections step shows connection rows", async ({ page }) => {
     await crews.openBuilder();
 
-    // Navigate to step 4 (Connections)
+    // Navigate to step 4 (Connections & Directions)
     await crews.crewNameInput.fill("Connections Test");
     await crews.nextButton.click(); // → Step 2
     await page.waitForTimeout(200);
@@ -174,25 +184,27 @@ test.describe("Wizard Flow", () => {
     const agentInstructions = crews.agentInstructionTextareas.first();
     await agentName.fill("Bot Agent");
     await agentInstructions.fill("Handle messages");
-    await crews.nextButton.click(); // → Step 4 (Connections)
+    await crews.nextButton.click(); // → Step 4 (Connections & Directions)
     await page.waitForTimeout(300);
 
-    // Should show Channel Connections heading
-    await expect(page.locator("text=Channel Connections").first()).toBeVisible();
+    // Phase 3: heading is now "Pick connections & direction".
+    await expect(page.locator("text=/Pick connections/i").first()).toBeVisible();
 
-    // Should have connection cards (Telegram, Discord, LinkedIn, Twitter, Instagram, Facebook)
-    const connectionCards = page.locator(".grid button").filter({
-      has: page.locator("p.text-sm.font-medium"),
-    });
-    const count = await connectionCards.count();
-    expect(count).toBeGreaterThanOrEqual(6);
+    // Connections now come from GET /api/v1/connections. On a clean test
+    // env the list may be empty — in that case the "no connections" hint
+    // shows. Either way, the step should render without error.
+    const emptyHint = page.locator("text=/No connections set up yet/i");
+    const directionChips = page.locator("button", { hasText: /^(Inbound|Outbound|Both)$/ });
+    const hasEmpty = await emptyHint.isVisible().catch(() => false);
+    const chipCount = await directionChips.count();
 
-    // Click Telegram to select it
-    await page.locator("text=Telegram").first().click();
-    await page.waitForTimeout(200);
+    if (!hasEmpty) {
+      // At least one connection row → at least 3 direction chips per row.
+      expect(chipCount).toBeGreaterThanOrEqual(3);
+    }
 
-    // Should show selected count
-    await expect(page.locator("text=1 channel selected")).toBeVisible();
+    // The legacy "1 channel selected" assertion no longer applies — that
+    // summary line came from the removed hardcoded channel grid.
   });
 
   // DC-CREW-WIZ-06: Back button navigates backwards

--- a/frontend/tests/e2e/fixtures/page-objects/crews.page.ts
+++ b/frontend/tests/e2e/fixtures/page-objects/crews.page.ts
@@ -10,11 +10,14 @@ import { type Page, type Locator, expect } from "@playwright/test";
  * - Tabs: Crews | Runs
  * - Status filter and mode filter selects (crews tab only)
  * - Crew cards with Run buttons
- * - CrewBuilder wizard (4-step):
+ * - CrewBuilder wizard (7-step after Phase 3 PR 3b):
  *   Step 1: Crew Details (name, description)
  *   Step 2: Execution Mode
- *   Step 3: Agent Team
- *   Step 4: Review & Create
+ *   Step 3: Agent Team (skipped for autonomous)
+ *   Step 4: Connections & Directions
+ *   Step 5: Trigger
+ *   Step 6: Approval
+ *   Step 7: Review & Create
  */
 export class CrewsPage {
   readonly page: Page;
@@ -116,7 +119,7 @@ export class CrewsPage {
     return this.builderDialog.getByRole("button", { name: /back/i });
   }
 
-  /** Create Crew submit button (step 4). */
+  /** Create Crew submit button (step 7). */
   get submitButton(): Locator {
     return this.builderDialog.getByRole("button", { name: /create crew|save changes/i });
   }
@@ -181,6 +184,10 @@ export class CrewsPage {
 
   /**
    * Open the wizard and create a crew through all steps.
+   *
+   * Post-Phase-3 wizard is 7 steps. Agent fields must be filled on step 3
+   * before Next is enabled (non-autonomous modes). All other steps have
+   * sensible defaults, so we can click through them quickly.
    */
   async createCrew(data: {
     name: string;
@@ -196,19 +203,32 @@ export class CrewsPage {
       await this.crewDescriptionInput.fill(data.description);
     }
 
-    // Next → Step 2 (Execution Mode)
+    // → Step 2 (Execution Mode)
     await this.nextButton.click();
     await this.page.waitForTimeout(300);
 
-    // Next → Step 3 (Agents)
+    // → Step 3 (Agents) — fill minimal agent so Next unlocks.
+    await this.nextButton.click();
+    await this.page.waitForTimeout(300);
+    const agentName = this.agentNameInputs.first();
+    if (await agentName.isVisible().catch(() => false)) {
+      await agentName.fill("Test Agent");
+      await this.agentInstructionTextareas.first().fill("Run the task.");
+    }
+
+    // → Step 4 (Connections & Directions)
     await this.nextButton.click();
     await this.page.waitForTimeout(300);
 
-    // Next → Step 4 (Connections)
+    // → Step 5 (Trigger)
     await this.nextButton.click();
     await this.page.waitForTimeout(300);
 
-    // Next → Step 5 (Review)
+    // → Step 6 (Approval)
+    await this.nextButton.click();
+    await this.page.waitForTimeout(300);
+
+    // → Step 7 (Review)
     await this.nextButton.click();
     await this.page.waitForTimeout(300);
 

--- a/frontend/tests/e2e/navigation/navigation.spec.ts
+++ b/frontend/tests/e2e/navigation/navigation.spec.ts
@@ -19,13 +19,13 @@ test("DC-NAV-01: sidebar shows all navigation items", async () => {
   await expect(nav.sidebar).toBeVisible();
 
   const labels = await nav.getNavLabels();
-  const expectedItems = ["Chat", "Model Hub", "Personas", "Agents", "Crews", "Blueprints", "Workspace", "Connections", "Approvals", "Schedule", "Distribution", "Settings"];
+  const expectedItems = ["Chat", "Model Hub", "Personas", "Agents", "Crews", "Blueprints", "Workspace", "Connections", "Approvals", "Settings"];
 
   for (const item of expectedItems) {
     expect(labels).toContain(item);
   }
 
-  expect(labels.length).toBe(12);
+  expect(labels.length).toBe(10);
 });
 
 // DC-NAV-02: Navigate to each page and verify heading
@@ -40,8 +40,6 @@ test("DC-NAV-02: navigate to each page and verify heading", async ({ page }) => 
     { label: "Workspace", heading: "Workspace" },
     { label: "Connections", heading: "Connections" },
     { label: "Approvals", heading: "Approval Queue" },
-    { label: "Schedule", heading: "Scheduled Jobs" },
-    { label: "Distribution", heading: "Distribution" },
     { label: "Settings", heading: "Settings" },
   ];
 
@@ -103,12 +101,12 @@ test("DC-NAV-04: sidebar collapse/expand toggle works", async ({ page }) => {
   expect(expandedBox!.width).toBeGreaterThan(100);
 
   const expandedLabels = await nav.getNavLabels();
-  expect(expandedLabels.length).toBe(12);
+  expect(expandedLabels.length).toBe(10);
 });
 
 // DC-NAV-05: Page transitions are smooth (no flash)
 test("DC-NAV-05: page transitions are smooth", async ({ page }) => {
-  const routes = ["Personas", "Agents", "Crews", "Blueprints", "Workspace", "Connections", "Approvals", "Schedule", "Distribution", "Settings", "Chat"];
+  const routes = ["Personas", "Agents", "Crews", "Blueprints", "Workspace", "Connections", "Approvals", "Settings", "Chat"];
 
   for (const route of routes) {
     await nav.navigateTo(route);


### PR DESCRIPTION
## Summary

Full Phase 3 IA refactor in one release. Consolidates what was originally planned as 5 stacked PRs (#21 → #25) into a single merge so review + release happen in one step.

## Mental model (the "north star")

The app is a **team**. Agents = team members, Crews = teams. Teams **do work** using **connections** (their tools). Connections are user-level — Solo is single-user, so you authenticate once per platform. A crew picks which connections it uses, which **direction** per connection (Inbound / Outbound / Both), and a **trigger** (Reactive, Scheduled, or Manual via the Run button).

Before this PR, three surfaces (Connections, Distribution, Schedule) each held their own auth or scheduling state. A user who connected Reddit once had to re-configure it to publish; a user who set a schedule didn't see it in their crew. This PR collapses everything.

## What changed

### Backend

**Data model** (additive — existing crews keep working)
- `Crew.connection_bindings[]`: `{connection_id, platform, direction: "inbound"|"outbound"|"both"}`
- `Crew.triggers[]`: discriminated union — reactive `{keywords, hashtags, mentions}` or scheduled `{cron | run_at, content_brief}`
- `Crew.approval_required: bool`
- `CrewRun.trigger_type` + `trigger_source` — so each run records *why* it fired
- `inbound_enabled` / `outbound_enabled` flags on Reddit + Twitter records
- Idempotent startup migration (`services/migrations/unify_connections_migration.py`) backfills `connection_bindings` from legacy `channel_bindings` with `direction="both"`, promotes per-binding `approval_required` to the top-level flag. `MIGRATE_DRY_RUN=1` for preview.

**Connections aggregator**
- `GET /api/v1/connections` merges `oauth_connections`, `reddit_accounts`, `twitter_accounts`, `channel_registrations`, and `distribution_channels` into one list with prefixed IDs (`oauth:linkedin`, `reddit:<id>`, `outbound:<uuid>` etc.)
- `PATCH /api/v1/connections/{id}/capabilities` toggles `inbound_enabled` / `outbound_enabled`. Rejects enabling a direction the platform doesn't physically support.
- `POST/PUT/DELETE /api/v1/connections/outbound` for three new outbound-only types: **Blog**, **Email**, **Slack webhook** (backed by existing `distribution_channels` collection).

**Runtime wiring** (gated on `UNIFIED_CREWS`, default ON)
- `services/feature_flags.py` — the flag. Set `UNIFIED_CREWS=0` to fall back to legacy paths.
- `services/inbound_router.py` — matches inbound messages against every crew's `triggers[type=reactive]` filtered by `connection_id` + keyword/hashtag/mention substrings. Multi-match → local LLM disambiguator (graceful fallback to first match). Dispatches via `crew_service.start_run(trigger_type="reactive")`.
- `services/scheduled_runner.py` — APScheduler-backed. On startup scans active crews, registers one job per `triggers[type=scheduled]` (cron or one-shot date). Live-refresh on crew create/update/delete.
- `channel_service.handle_message` routes through `inbound_router` first; falls through to legacy `trigger_service` only on no match.
- `crew_orchestrator._publish_to_bound_channels` gains `_publish_via_connection_bindings` — direction-aware outbound, honours top-level `crew.approval_required`.

### Frontend

**Connections page** — 10 cards (7 socials + Blog + Email + Slack webhook) with existing OAuth + token-paste flows preserved.

**Crew builder** (7-step wizard; autonomous mode collapses to 6 by skipping Agent Team):
1. Crew Details
2. Execution Mode
3. Agent Team
4. **Connections & Directions** — real aggregator list with three direction chips per connection (Inbound / Outbound / Both), chips disabled when the platform doesn't support that direction. Picking a direction whose capability is off opens an inline "Enable now?" modal → calls `updateCapabilities` → completes the binding.
5. **Trigger** — Reactive (per inbound-bound connection: chip-input for keywords / hashtags / mentions) + Scheduled (cron OR one-shot datetime picker + optional content brief). No triggers = crew is manual-only.
6. **Approval** — single toggle "Review outbound before sending."
7. **Review & Create** — summary with Connections & Directions, Triggers, Approval sections.

**Crews page** — Runs tab shows a `TriggerTypeBadge` (Manual / Reactive / Scheduled) per row; Crews tab adds a filter dropdown (Inbound / Outbound / Reactive / Scheduled / Approval-required).

**Sidebar** — Distribution + Schedule entries removed. Sidebar drops 12 → 10 items. Page files stay on disk for one release cycle as dead code (FUTURE cleanup task in TODO.md deletes them after soak).

## What's not in this PR (intentional)

- Actually deleting `routes/distribution.tsx`, `routes/schedule.tsx`, `backend/routers/distribution.py`, the standalone scheduler backend — FUTURE cleanup after one release cycle of dead-code soak.
- Connection-level fallback crew for unmatched inbound messages (skipped per decision #6 in TODO.md).
- Per-crew priority ordering for keyword-match ties (skipped — LLM disambiguation handles v1).

## Test plan

- [x] `pytest backend/tests/` → **755 passed** (+51 new across aggregator, migration, inbound_router, scheduled_runner, schema validators)
- [x] `cd frontend && npm run build` → clean
- [x] Full Playwright E2E suite: **162 passed** after Phase 3 test updates (13 chat failures are pre-existing, environment-dependent — unrelated to Phase 3)
- [ ] Manual smoke:
  - Sidebar shows 10 items, no Schedule or Distribution.
  - `/connections`: all 10 cards (7 socials + Blog + Email + Slack webhook).
  - New Crew → walk all 7 steps. Pick a connection, change directions; verify the "enable capability" modal appears and completes. Add a reactive keyword trigger + a scheduled cron; toggle approval on.
  - Post a matching inbound message → Runs tab shows a **Reactive** badge; wait one minute → **Scheduled** badge appears.
  - If approval was on, the row lands in `/approvals` instead of sending.

## Supersedes

Closes #21, #22, #23, #24, #25 — merged together here for a single release diff.

## Migration notes for the operator

- Startup migration runs once per SQLite DB file. Log line: `Migration unify_connections_v1 applied: {...}`. Check `migrations_applied` collection after first boot.
- `UNIFIED_CREWS` default is **true**. Set `UNIFIED_CREWS=0` in `.env` if you need to revert to legacy routing paths (emergency rollback without redeploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)