### PR TITLE
chore: release v1.0.0-8

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "contextuai-solo",
   "description": "ContextuAI Solo — Personal AI Desktop App",
   "private": true,
-  "version": "1.0.0-7",
+  "version": "1.0.0-8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contextuai-solo"
-version = "1.0.0-7"
+version = "1.0.0-8"
 description = "ContextuAI Solo - Your AI Business Assistant"
 authors = ["ContextuAI"]
 edition = "2021"

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "ContextuAI Solo",
-  "version": "1.0.0-7",
+  "version": "1.0.0-8",
   "identifier": "com.contextuai.solo",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- Version bump to `v1.0.0-8` across `frontend/package.json`, `src-tauri/Cargo.toml`, and `tauri.conf.json`.

## Test plan
- [ ] CI green on required checks
- [ ] After merge, release workflow produces installers

🤖 Generated with [Claude Code](https://claude.com/claude-code)