### PR TITLE
ci: stop shipping stale cached bundles in releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,14 @@ jobs:
         working-directory: frontend
         run: npm ci
 
+      # Remove any stale bundler outputs restored from the Rust cache.
+      # Without this, beta-era artifacts (e.g. `*_1.0.0_*` from when the MSI
+      # bundler stripped non-numeric prereleases) ride along in target/ and
+      # get picked up by the collect steps below.
+      - name: Clean stale bundle outputs from Rust cache
+        shell: bash
+        run: rm -rf frontend/src-tauri/target/*/release/bundle/
+
       - name: Build Tauri app
         working-directory: frontend
         env:
@@ -137,19 +145,21 @@ jobs:
         shell: bash
         run: |
           mkdir -p release-assets
+          VERSION="${RELEASE_TAG#v}"
           BUNDLE_DIR="frontend/src-tauri/target/${{ matrix.platform.rust-target }}/release/bundle"
-          cp "$BUNDLE_DIR"/msi/*.msi release-assets/ 2>/dev/null || true
-          cp "$BUNDLE_DIR"/msi/*.msi.sig release-assets/ 2>/dev/null || true
-          cp "$BUNDLE_DIR"/nsis/*setup.exe release-assets/ 2>/dev/null || true
-          cp "$BUNDLE_DIR"/nsis/*setup.exe.sig release-assets/ 2>/dev/null || true
+          cp "$BUNDLE_DIR"/msi/*_${VERSION}_*.msi release-assets/ 2>/dev/null || true
+          cp "$BUNDLE_DIR"/msi/*_${VERSION}_*.msi.sig release-assets/ 2>/dev/null || true
+          cp "$BUNDLE_DIR"/nsis/*_${VERSION}_*setup.exe release-assets/ 2>/dev/null || true
+          cp "$BUNDLE_DIR"/nsis/*_${VERSION}_*setup.exe.sig release-assets/ 2>/dev/null || true
           ls -la release-assets/
 
       - name: Collect macOS installer
         if: matrix.platform.os == 'macos-latest'
         run: |
           mkdir -p release-assets
+          VERSION="${RELEASE_TAG#v}"
           BUNDLE_DIR="frontend/src-tauri/target/${{ matrix.platform.rust-target }}/release/bundle"
-          cp "$BUNDLE_DIR"/dmg/*.dmg release-assets/ 2>/dev/null || true
+          cp "$BUNDLE_DIR"/dmg/*_${VERSION}_*.dmg release-assets/ 2>/dev/null || true
           cp "$BUNDLE_DIR"/macos/*.app.tar.gz release-assets/ 2>/dev/null || true
           cp "$BUNDLE_DIR"/macos/*.app.tar.gz.sig release-assets/ 2>/dev/null || true
           ls -la release-assets/
@@ -158,11 +168,12 @@ jobs:
         if: matrix.platform.os == 'ubuntu-22.04'
         run: |
           mkdir -p release-assets
+          VERSION="${RELEASE_TAG#v}"
           BUNDLE_DIR="frontend/src-tauri/target/${{ matrix.platform.rust-target }}/release/bundle"
-          cp "$BUNDLE_DIR"/deb/*.deb release-assets/ 2>/dev/null || true
-          cp "$BUNDLE_DIR"/rpm/*.rpm release-assets/ 2>/dev/null || true
-          cp "$BUNDLE_DIR"/appimage/*.AppImage release-assets/ 2>/dev/null || true
-          cp "$BUNDLE_DIR"/appimage/*.AppImage.sig release-assets/ 2>/dev/null || true
+          cp "$BUNDLE_DIR"/deb/*_${VERSION}_*.deb release-assets/ 2>/dev/null || true
+          cp "$BUNDLE_DIR"/rpm/*-${VERSION}-*.rpm release-assets/ 2>/dev/null || true
+          cp "$BUNDLE_DIR"/appimage/*_${VERSION}_*.AppImage release-assets/ 2>/dev/null || true
+          cp "$BUNDLE_DIR"/appimage/*_${VERSION}_*.AppImage.sig release-assets/ 2>/dev/null || true
           ls -la release-assets/
 
       - name: Upload build artifacts


### PR DESCRIPTION
## Summary
Releases since `v1.0.0-7` have been shipping duplicate install assets — correctly-named `*_1.0.0-8_*` alongside ghost `*_1.0.0_*` files left over from the `v1.0.0-beta.X` era. Root cause is the Rust build cache retaining old bundler outputs.

### Why it happens
- Cache key in `release.yml` is `rust-${os}-${hash(Cargo.lock)}`.
- `Cargo.lock` hasn't been touched since PR #15 (auto-updater), so the key has been stable across every release since.
- `actions/cache@v4` only **saves** on key miss — the cache has been frozen at whatever `target/.../release/bundle/` contained the first time the current key was populated (the beta era, when Tauri's MSI bundler stripped non-numeric prereleases into `*_1.0.0_*` filenames).
- Each release restores those ghosts, builds its own fresh bundles into the same tree, and the collect-step globs (`cp *.msi` etc.) sweep up both sets.
- Evidence: `v1.0.0-beta.6` release has only `_1.0.0_*` files; `1.0.0.-7` and `v1.0.0-8` both ship `_1.0.0_*` + `_1.0.0-{N}_*` pairs; no `_1.0.0-7_*` appear in `v1.0.0-8` (confirming the cache is frozen, not accumulating per-release).

### Fix (two layers)
1. **Clean the bundle dir** after cache restore, before `tauri build` — kills the root cause.
2. **Narrow the collect-step globs** to match the current `$VERSION` — defense-in-depth so any future stray file can't leak into a release.

### Not covered
- `v1.0.0-8`'s release page still has the duplicate assets. Needs manual deletion from the GitHub Release UI.
- Separate issue: `latest.json` references `.app.tar.gz` (macOS) and `.AppImage` (Linux) URLs that the workflow doesn't actually build — breaks in-app auto-update on those platforms. Not addressed here.

## Test plan
- [ ] CI green on required checks
- [ ] Next release via `/prod-release` publishes only correctly-versioned assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)