### PR TITLE
ci: fix YAML parse error in auto-release.yml

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -28,7 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     # Fast path: only proceed if the commit looks like a release commit.
     # Strict regex validation happens inside the parse step.
-    if: startsWith(github.event.head_commit.message, 'chore: release v')
+    # NOTE: the expression contains a colon inside the literal string, so the
+    # whole value must be wrapped in double quotes — otherwise YAML sees the
+    # inner `:` as a mapping indicator and rejects the file.
+    if: "startsWith(github.event.head_commit.message, 'chore: release v')"
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Problem
`auto-release.yml` from #31 merged to main but the first run (on commit `fd21f93`) failed immediately with **"Invalid workflow file"** — zero jobs created. GitHub's annotation pointed at line 31.

Reproduced locally with `python -c 'import yaml; yaml.safe_load(open(".github/workflows/auto-release.yml"))'`:

```
yaml.scanner.ScannerError: mapping values are not allowed here
  in "auto-release.yml", line 31, column 60
```

## Root cause
Line 31:
```yaml
    if: startsWith(github.event.head_commit.message, 'chore: release v')
```

The `if:` value is an unquoted YAML scalar containing the colon inside `'chore: release v'`. YAML's strict parser (same as GitHub's) hits that inner colon at column 60 and interprets it as a mapping indicator, aborting the file.

## Fix
Wrap the whole `if:` value in double quotes — only line in the file where an expression contains a literal colon.

```yaml
if: "startsWith(github.event.head_commit.message, 'chore: release v')"
```

Verified with `yaml.safe_load` locally before pushing.

## Test plan
- [ ] CI green
- [ ] After merge, confirm `auto-release.yml` runs on the merge commit and **skips cleanly** via the `startsWith(...)` guard (merge message is `ci: fix YAML parse...`, not a release commit)
- [ ] Next `chore: release vX.Y.Z-N` merge actually dispatches `release.yml` (requires `RELEASE_DISPATCH_TOKEN` secret to be set first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)