### PR TITLE
fix: LinkedIn OAuth scope + Tauri v2 detection (v1.0.0-9)

### DIFF
--- a/backend/routers/desktop_oauth.py
+++ b/backend/routers/desktop_oauth.py
@@ -37,7 +37,7 @@ OAUTH_PROVIDERS = {
         "authorize_url": "https://www.linkedin.com/oauth/v2/authorization",
         "token_url": "https://www.linkedin.com/oauth/v2/accessToken",
         "userinfo_url": "https://api.linkedin.com/v2/userinfo",
-        "scopes": ["openid", "profile", "w_member_social", "w_organization_social"],
+        "scopes": ["openid", "profile", "w_member_social"],
         "docs_url": "https://learn.microsoft.com/en-us/linkedin/marketing/getting-started",
     },
     "instagram": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "contextuai-solo",
   "description": "ContextuAI Solo — Personal AI Desktop App",
   "private": true,
-  "version": "1.0.0-8",
+  "version": "1.0.0-9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contextuai-solo"
-version = "1.0.0-8"
+version = "1.0.0-9"
 description = "ContextuAI Solo - Your AI Business Assistant"
 authors = ["ContextuAI"]
 edition = "2021"

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "ContextuAI Solo",
-  "version": "1.0.0-8",
+  "version": "1.0.0-9",
   "identifier": "com.contextuai.solo",
   "build": {
     "frontendDist": "../dist",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,7 +37,7 @@ function RequireWizard({ children }: { children: React.ReactNode }) {
   return <>{children}</>;
 }
 
-const isTauri = typeof window !== "undefined" && "__TAURI__" in window;
+const isTauri = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 
 /** Updates the HTML splash screen status text. */
 function updateSplash(text: string) {

--- a/frontend/src/components/update-notifier.tsx
+++ b/frontend/src/components/update-notifier.tsx
@@ -17,7 +17,7 @@ export function UpdateNotifier() {
 
   // Check for updates once on mount
   useEffect(() => {
-    if (!("__TAURI__" in window)) return;
+    if (!("__TAURI_INTERNALS__" in window)) return;
 
     let cancelled = false;
     (async () => {

--- a/frontend/src/lib/transport.ts
+++ b/frontend/src/lib/transport.ts
@@ -1,4 +1,4 @@
-const isTauri = typeof window !== "undefined" && "__TAURI__" in window;
+const isTauri = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 // Desktop Solo backend runs on port 18741; override via VITE_API_URL env var
 const DEV_API_URL = import.meta.env.VITE_API_URL || "http://127.0.0.1:18741/api/v1";
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,7 +4,7 @@ import App from "./App";
 import "./styles/globals.css";
 
 // In Tauri, intercept external link clicks and open them in the system browser
-if ("__TAURI__" in window) {
+if ("__TAURI_INTERNALS__" in window) {
   document.addEventListener(
     "click",
     (e) => {

--- a/frontend/src/routes/connections.tsx
+++ b/frontend/src/routes/connections.tsx
@@ -647,7 +647,7 @@ export default function ConnectionsPage() {
       const { auth_url } = await getOAuthAuthorizeUrl(conn.oauthProvider);
 
       // Step 3: Open browser for user to authorize
-      if ("__TAURI__" in window) {
+      if ("__TAURI_INTERNALS__" in window) {
         const { open } = await import("@tauri-apps/plugin-shell");
         await open(auth_url);
       } else {


### PR DESCRIPTION
## Summary
- **Tauri v2 detection** — switch all 5 isTauri checks from `__TAURI__` (v1 global, never injected in v2) to `__TAURI_INTERNALS__`. Fixes silent failure of OAuth Connect on macOS, IPC transport, auto-updater, and external link handling.
- **LinkedIn OAuth scope** — drop unused `w_organization_social` from the scope list. The actual publish path uses `/v2/ugcPosts` which accepts `urn:li:organization:{id}` as author under `w_member_social` when the user is a Page admin. The scope was added speculatively in fac5aa0 with no caller; LinkedIn rejects the entire OAuth handshake on apps without Community Management API verified, blocking connection.
- **chore: release v1.0.0-9** — version bumped in `package.json`, `tauri.conf.json`, `Cargo.toml`.

## Test plan
- [ ] Windows: `npm run tauri dev` → click LinkedIn Connect → browser opens, sign in, callback completes, card flips to Connected, Test button appears.
- [ ] macOS: install the v1.0.0-9 DMG manually (auto-update is broken in v1.0.0-8 due to the same `__TAURI__` bug — requires one-time manual install). Repeat the LinkedIn Connect flow.
- [ ] Crew builder: LinkedIn channel shows Connected (not Disconnected) after OAuth completes.
- [ ] Existing publishing path unchanged: org posting via `urn:li:organization:{id}` still works through `/v2/ugcPosts` under `w_member_social`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)