### PR TITLE
chore: release v1.0.0-12

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "contextuai-solo",
   "description": "ContextuAI Solo — Personal AI Desktop App",
   "private": true,
-  "version": "1.0.0-11",
+  "version": "1.0.0-12",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contextuai-solo"
-version = "1.0.0-11"
+version = "1.0.0-12"
 description = "ContextuAI Solo - Your AI Business Assistant"
 authors = ["ContextuAI"]
 edition = "2021"

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "ContextuAI Solo",
-  "version": "1.0.0-11",
+  "version": "1.0.0-12",
   "identifier": "com.contextuai.solo",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Release v1.0.0-12

Version bump across the three lockstep files:

- `frontend/package.json` → `1.0.0-12`
- `frontend/src-tauri/tauri.conf.json` → `1.0.0-12`
- `frontend/src-tauri/Cargo.toml` → `1.0.0-12`

## What's included since v1.0.0-11

- **feat: Phase 6 UX cleanup** (#39) — Connectors rename, Workspace tabs, dialog scrolling, sidebar height fix, mode-toggle scroll-out fix, chat-first Coder project detail (Team behind a header dialog), per-platform markdown conversion before publishing.

## Release flow

Squash-merging this PR produces the subject `chore: release v1.0.0-12 (#NN)`, which matches `auto-release.yml`'s regex. That workflow verifies the three version files agree, then dispatches `release.yml` to tag `v1.0.0-12` and build Windows / macOS / Linux installers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)