### PR TITLE
ci(release): create tag via gh REST API to bypass workflow-permissions cap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,14 @@ jobs:
           echo "Computed: release_tag='$release_tag' should_release=$should_release"
 
   # ── Tag: only for dispatch + chore-on-main paths. Tag-push events skip. ──
+  #
+  # Uses the GitHub REST API (`gh api`) instead of `git push origin <tag>` —
+  # the latter fails on this repo because default_workflow_permissions is set
+  # to "read" at the org/repo level, and the workflow-level
+  # `permissions: contents: write` elevation isn't enough to satisfy the
+  # git smart-HTTP push endpoint (the extraheader is set but the push is
+  # rejected, manifesting as a confusing `could not read Username` error).
+  # `gh api` uses GH_TOKEN directly against the refs API and works fine.
   tag:
     name: Create Tag
     needs: [compute]
@@ -127,13 +135,18 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - name: Create and push tag
+      - name: Create tag via REST API
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ needs.compute.outputs.release_tag }}
+          TARGET_SHA: ${{ github.sha }}
         run: |
-          git tag "$RELEASE_TAG"
-          git push origin "$RELEASE_TAG"
+          echo "Creating tag $RELEASE_TAG at $TARGET_SHA"
+          gh api "repos/${{ github.repository }}/git/refs" \
+            -f "ref=refs/tags/$RELEASE_TAG" \
+            -f "sha=$TARGET_SHA" \
+            --silent
+          echo "Tag created."
 
   build:
     name: Build (${{ matrix.platform.name }})


### PR DESCRIPTION
## Why

The repo has `default_workflow_permissions = "read"` at the org/repo level. Workflow-level `permissions: contents: write` elevates `GITHUB_TOKEN` for most operations, **but `git push origin <tag>` over smart-HTTP still fails** — the extraheader is set by `actions/checkout@v4`, the push attempts auth, the server rejects it, and git falls back to credential prompting which dies non-interactively with the confusing error:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

Confirmed root cause by comparing two runs of identical YAML:
| Run | Result | Notes |
|---|---|---|
| May 3 (`v1.0.0-10` dispatch) | ✅ success | smart-HTTP push worked |
| Today (`v1.0.0-12` dispatch) | ❌ failure | smart-HTTP push rejected |

The workflow YAML is unchanged between those dates. What changed was the org/repo Actions workflow-permissions default tightening to `read`.

## Fix

Drop `actions/checkout` from the tag job and call `gh api repos/.../git/refs` directly with `GH_TOKEN`. The REST endpoint honors the workflow-level `contents: write` elevation correctly (unlike the smart-HTTP push endpoint), so the tag gets created without ever touching git.

## Diff shape

```diff
   tag:
     ...
     steps:
-      - uses: actions/checkout@v4
-      - name: Create and push tag
+      - name: Create tag via REST API
         env:
+          GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: \${{ needs.compute.outputs.release_tag }}
+          TARGET_SHA: \${{ github.sha }}
         run: |
-          git tag "\$RELEASE_TAG"
-          git push origin "\$RELEASE_TAG"
+          gh api "repos/\${{ github.repository }}/git/refs" \
+            -f "ref=refs/tags/\$RELEASE_TAG" \
+            -f "sha=\$TARGET_SHA" \
+            --silent
```

## Test plan

- [ ] PR Checks pass
- [ ] Next \`chore: release v…\` PR squash-merge tags the commit without manual intervention
- [ ] (No effect on tag-push or workflow_dispatch paths — only the `tag` job changed)

## Note

This unblocks the end-to-end auto-release flow without needing any PAT (`RELEASE_DISPATCH_TOKEN` remains unnecessary, per PR #41). Combined, the two PRs fully restore unattended releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)