### PR TITLE
fix(ci): keep Publish Release running when tag job is skipped

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,6 +308,16 @@ jobs:
   release:
     name: Publish Release
     needs: [compute, build]
+    # The `tag` job is intentionally skipped on tag-push events (the tag
+    # already exists). Without an explicit `if:` here, GitHub Actions
+    # cascades that skipped state down the dependency graph and skips this
+    # job too — even though `build` reports success. Override with the
+    # success-of-build check that actually matters. See v1.0.0-12 run
+    # 26340064233 where all builds succeeded but no release was published.
+    if: |
+      always()
+      && needs.compute.outputs.should_release == 'true'
+      && needs.build.result == 'success'
     runs-on: ubuntu-latest
     env:
       RELEASE_TAG: ${{ needs.compute.outputs.release_tag }}


### PR DESCRIPTION
## Summary

- The `release` job in `.github/workflows/release.yml` had no `if:` clause, so when the upstream `tag` job was skipped (every tag-push trigger), GitHub Actions cascaded the skip to `release` even though `build` succeeded. Result: installers built, no release published.
- v1.0.0-12 hit exactly this — [run 26340064233](https://github.com/contextuai/contextuai-solo/actions/runs/26340064233) shows 258 MB / 168 MB / 436 MB of platform installers uploaded as artifacts but the GitHub Release page was never created.
- Adds an explicit `if: always() && should_release && build.result == 'success'` to break the implicit skip cascade.

## Why the chain cascades

```
tag-push event
 └─ compute    → should_release=true   (success)
 └─ tag        → if: ... && (dispatch || main-push)  → SKIPPED
 └─ build      → if: always() && (tag.success || tag.skipped) → success
 └─ release    → (no if:)              → SKIPPED ← skip cascades from `tag`
```

After the fix, `release` uses `always()` plus the conditions that actually matter, so a skipped `tag` no longer blocks publish.

## Test plan
- [ ] After merge, re-trigger Release via workflow_dispatch with `version=v1.0.0-12` to publish the v1.0.0-12 release (artifacts still exist on the original run until 2026-08-21, so we could also recover from those — but a fresh dispatch is cleaner).
- [ ] Confirm GitHub Releases page lists v1.0.0-12 with .msi/.exe/.dmg/.app.tar.gz/.deb/.rpm/.AppImage assets attached + `latest.json` updater manifest.
- [ ] On the next normal `/release` cut, confirm both the main-push run (the one that should publish) and the secondary tag-push run (currently the one that was skipping) behave correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)