### PR TITLE
chore: release v1.0.0-13

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "contextuai-solo",
   "description": "ContextuAI Solo — Personal AI Desktop App",
   "private": true,
-  "version": "1.0.0-12",
+  "version": "1.0.0-13",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "contextuai-solo"
-version = "1.0.0-11"
+version = "1.0.0-13"
 dependencies = [
  "env_logger",
  "log",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contextuai-solo"
-version = "1.0.0-12"
+version = "1.0.0-13"
 description = "ContextuAI Solo - Your AI Business Assistant"
 authors = ["ContextuAI"]
 edition = "2021"

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "ContextuAI Solo",
-  "version": "1.0.0-12",
+  "version": "1.0.0-13",
   "identifier": "com.contextuai.solo",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- Bumps the four version files to `1.0.0-13` in lockstep (`frontend/package.json`, `frontend/src-tauri/tauri.conf.json`, `frontend/src-tauri/Cargo.toml`, `frontend/src-tauri/Cargo.lock`).
- v1.0.0-12 built all three platform installers successfully on [run 26340064233](https://github.com/contextuai/contextuai-solo/actions/runs/26340064233) but the **Publish Release** job was skipped because the implicit `if` clause cascaded the skipped `Create Tag` state down the dependency graph. PR #43 fixed that.
- v1.0.0-13 is the first release on the fixed pipeline — code identical to v1.0.0-12 except for `release.yml` (not shipped in the binary).

## Pre-merge checklist
- [x] All four version files match `1.0.0-13`
- [x] `cd frontend && npm run build` passes locally
- [x] Subject matches the workflow's strict release-detection regex: `chore: release v1.0.0-13`
- [ ] PR Checks pass (Build & Type Check + Playwright E2E)

## Post-merge expectation

The main-push triggers `.github/workflows/release.yml`:
1. `compute` → `should_release=true`, `release_tag=v1.0.0-13`
2. `tag` → creates `v1.0.0-13` via gh REST API (PR #42's idempotency note: this path is fine for new tags; existing-tag dispatch case still needs a follow-up)
3. `build` matrix → Windows/macOS/Linux installers
4. `release` → now actually runs (PR #43 fix) and publishes to GitHub Releases with `latest.json` updater manifest

There will likely be a secondary tag-push workflow run that wastes ~25 min rebuilding and re-publishing the same files. That's a known follow-up — to be solved by adding `concurrency:` or by short-circuiting `compute` when the release already exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)