### PR TITLE
chore: release v1.0.0-14

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "contextuai-solo",
   "description": "ContextuAI Solo — Personal AI Desktop App",
   "private": true,
-  "version": "1.0.0-13",
+  "version": "1.0.0-14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contextuai-solo"
-version = "1.0.0-13"
+version = "1.0.0-14"
 description = "ContextuAI Solo - Your AI Business Assistant"
 authors = ["ContextuAI"]
 edition = "2021"

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "ContextuAI Solo",
-  "version": "1.0.0-13",
+  "version": "1.0.0-14",
   "identifier": "com.contextuai.solo",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Release v1.0.0-14

Version bump only — bumps `frontend/package.json`, `frontend/src-tauri/tauri.conf.json`, and `frontend/src-tauri/Cargo.toml` from `1.0.0-13` → `1.0.0-14`.

### What ships in this release
- **fix(rag): bundle embedding model so packaged KB ingestion works** (#46) — the all-MiniLM-L6-v2 ONNX model is now bundled into the PyInstaller sidecar, so RAG / Personal Docs ingestion works in distributed installers (verified via a local installable build).

### Release mechanics
On squash-merge to `main`, the **Release** workflow matches the `chore: release vX.Y.Z-N` subject, auto-tags `v1.0.0-14`, builds Windows/macOS/Linux installers, and publishes the GitHub Release (prerelease).

🤖 Generated with [Claude Code](https://claude.com/claude-code)