### PR TITLE
chore: release v1.0.0-15

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "contextuai-solo",
   "description": "ContextuAI Solo — Personal AI Desktop App",
   "private": true,
-  "version": "1.0.0-14",
+  "version": "1.0.0-15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contextuai-solo"
-version = "1.0.0-14"
+version = "1.0.0-15"
 description = "ContextuAI Solo - Your AI Business Assistant"
 authors = ["ContextuAI"]
 edition = "2021"

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "ContextuAI Solo",
-  "version": "1.0.0-14",
+  "version": "1.0.0-15",
   "identifier": "com.contextuai.solo",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- Version bump to `1.0.0-15` across the three synced files (package.json, tauri.conf.json, Cargo.toml).
- Ships the GPU offload change from #49 (local GGUF inference now uses Metal/CUDA/Vulkan when available).

## Test plan
- [x] `npm run build` passes
- [ ] After merge: trigger `release.yml` via workflow_dispatch with `version=v1.0.0-15`, verify GitHub Release + `latest.json` publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)