### PR TITLE
ci(release): make tag creation idempotent to survive duplicate triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,23 @@ jobs:
           RELEASE_TAG: ${{ needs.compute.outputs.release_tag }}
           TARGET_SHA: ${{ github.sha }}
         run: |
-          echo "Creating tag $RELEASE_TAG at $TARGET_SHA"
+          echo "Ensuring tag $RELEASE_TAG at $TARGET_SHA"
+
+          # Idempotent: a redundant workflow_dispatch racing the chore-on-main
+          # auto-release (or a re-run) must NOT hard-fail with HTTP 422
+          # "Reference already exists". Only error if the tag exists but points
+          # at a different commit — that's a real conflict worth stopping for.
+          existing_sha=$(gh api "repos/${{ github.repository }}/git/ref/tags/$RELEASE_TAG" \
+            --jq '.object.sha' 2>/dev/null || echo "")
+          if [[ -n "$existing_sha" ]]; then
+            if [[ "$existing_sha" == "$TARGET_SHA" ]]; then
+              echo "Tag $RELEASE_TAG already exists at $TARGET_SHA — nothing to do."
+              exit 0
+            fi
+            echo "::error::Tag $RELEASE_TAG already exists at $existing_sha, not $TARGET_SHA. Refusing to move a published tag."
+            exit 1
+          fi
+
           gh api "repos/${{ github.repository }}/git/refs" \
             -f "ref=refs/tags/$RELEASE_TAG" \
             -f "sha=$TARGET_SHA" \


### PR DESCRIPTION
## Summary
- The `Create Tag` step in `release.yml` called the refs API unconditionally and hard-failed with **HTTP 422 "Reference already exists"** whenever a second run raced it on the same tag.
- This bit us on **v1.0.0-15**: a redundant `workflow_dispatch` fired on top of the `chore: release` on-`main` auto-release; both targeted the same tag, and the dispatch run errored at tag creation. (The auto-run still published correctly — the failure was cosmetic but confusing.)
- Fix: check for the ref first. No-op if it already points at the target SHA; error only if it points at a **different** commit (a genuine conflict). Tag-push and dispatch paths both stay safe.

Note: the matching `/prod-release` skill doc was also corrected (locally; `.claude/` is gitignored) to stop instructing a manual `workflow_dispatch` after merge — the squash-merge of the bump PR is the sole trigger, so the duplicate run won't be created in the first place. This workflow change is belt-and-suspenders for any accidental double-trigger.

## Test plan
- [x] `release.yml` parses as valid YAML
- [x] Verified against the v1.0.0-15 incident: idempotent path returns success instead of 422 when the tag already exists at the same SHA
- [ ] Next release exercises the on-main auto-trigger end to end (single run, green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)