### PR TITLE
docs: sync GPU offload for local models (v1.0.0-15)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ The backend was ported from MongoDB. A compatibility layer preserves the Motor A
 - **Crew system**: Multi-agent teams with persistent memory (`crew_memory_service.py`)
 
 ### Local AI Models (`backend/routers/local_models.py`)
-GGUF models downloaded from HuggingFace, stored in `~/.contextuai-solo/models/`. Inference via llama-cpp-python on CPU.
+GGUF models downloaded from HuggingFace, stored in `~/.contextuai-solo/models/`. Inference via llama-cpp-python, with automatic GPU offload (Apple Metal / NVIDIA CUDA / Vulkan) when the installed build supports it, falling back to CPU. Offload is gated by `llama_cpp.llama_supports_gpu_offload()` and tunable via the `LOCAL_MODEL_GPU_LAYERS` env var (`auto` (default) / `0` to force CPU / `<N>` layers); the loaded model stays resident in RAM across messages and only reloads on a model swap.
 - 41 curated GGUF models (Gemma 4, Qwen 3/3.5, DeepSeek R1, Llama 3, Mistral, Phi-4, etc.) from 0.5B to 70B
 - Download: `POST /api/v1/local-models/{model_id}/download` (SSE progress)
 - Sync to DB: `POST /api/v1/local-models/sync` (registers downloaded models in the `models` collection)

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Solo is built for people who run a business with a small team — or no team at 
 
 Solo runs 100% on your desktop. No accounts. No cloud sync. No telemetry.
 
-- **AI models run locally** on your CPU — download once, use forever, no internet required
+- **AI models run locally** — on your GPU when available (Apple Metal / NVIDIA CUDA / Vulkan), CPU otherwise — download once, use forever, no internet required
 - **All data stored locally** in SQLite — conversations, agents, crews, everything
 - **No sign-up, no login** — you're the admin, always
 - **Bring Your Own Key** — optionally connect Anthropic, OpenAI, Google, or AWS Bedrock when you need cloud-scale power
@@ -202,9 +202,9 @@ Solo is a native desktop app that runs ~500 MB installed. If you bring your own 
 | **RAM** | 4 GB | 8–32 GB depending on model — see the table in the Local Models section below |
 | **Disk** | ~500 MB for the app | +1–40 GB per downloaded model (keep several; swap between them) |
 | **Network** | Required for cloud provider calls | One-time model download from HuggingFace; fully offline after |
-| **GPU** | Not used | Not used (CPU-only inference in the current build) |
+| **GPU** | Not used | Used automatically when available — Apple Metal (Apple Silicon), NVIDIA CUDA, or Vulkan; falls back to CPU |
 
-**On local inference speed:** llama-cpp-python runs entirely on CPU. On a modern laptop, expect roughly 5–20 tokens/sec on 7–14B models, 1–3 tokens/sec on 70B models. If you need faster 70B output, route to a cloud provider via BYOK instead.
+**On local inference speed:** llama-cpp-python offloads to your GPU automatically when the installed build supports it (Apple Metal, NVIDIA CUDA, Vulkan) — several times faster than CPU on the same model — and falls back to CPU otherwise. On CPU, expect roughly 5–20 tokens/sec on 7–14B models and 1–3 tokens/sec on 70B models; on Apple Silicon or a discrete GPU, substantially more. Set `LOCAL_MODEL_GPU_LAYERS=0` to force CPU, or route 70B output to a cloud provider via BYOK.
 
 ---
 


### PR DESCRIPTION
## Summary
Docs drifted from the v1.0.0-15 GPU offload feature (#49). Local GGUF inference now uses the GPU (Apple Metal / NVIDIA CUDA / Vulkan) when available, but the docs still claimed CPU-only.

- **README**: data-locality bullet, hardware table GPU row, and the local-inference-speed note updated; documents `LOCAL_MODEL_GPU_LAYERS`.
- **CLAUDE.md**: Local AI Models section now describes GPU offload + the env var, and notes the model stays resident in RAM across messages.

## Test plan
- [x] No "CPU-only" / "runs entirely on CPU" claims remain in README/CLAUDE.md
- [x] Doc-only change — no code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)