### PR TITLE
fix(crews): run-task dialog, Ollama provider, sample crews, finalizer nudge

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Solo auto-detects your hardware and recommends the right model:
 | 32 GB | Qwen 3 32B, DeepSeek R1 32B, Gemma 3 27B, Qwen 2.5 Coder 32B |
 | 48+ GB | Llama 3.1 70B, DeepSeek R1 70B |
 
-8 model families: **Qwen 3.5** / **Qwen 3** / **Qwen 2.5** / **DeepSeek R1** / **Gemma 3** / **Llama 3** / **Mistral** / **Phi-4** — covering general chat, reasoning, coding, creative writing, multilingual, and vision.
+9 model families: **Qwen 3.5** / **Qwen 3** / **Qwen 2.5** / **DeepSeek R1** / **Gemma 3** / **Gemma 4** / **Llama 3** / **Mistral** / **Phi-4** — covering general chat, reasoning, coding, creative writing, multilingual, and vision.
 
 ### Built-in Coding Server
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 # TODO — ContextuAI Solo Moonshot
 
 > Master task list. Prioritized by phases. Check off as completed.
-> **Created:** 2026-03-19 | **Last synced with code:** 2026-05-17
+> **Created:** 2026-03-19 | **Last synced with code:** 2026-06-29
 
 ---
 
@@ -296,7 +296,7 @@ Phases 0–4 and Phase 5 (Coder multi-agent) are shipped and verified against th
 
 ## QUICK REFERENCE
 
-**Total models in catalog:** 41 (8 families: Qwen 2.5, Qwen 3, Qwen 3.5, Gemma 3, Gemma 4, Llama, Mistral, Phi, DeepSeek)
+**Total models in catalog:** 41 (9 families: Qwen 2.5, Qwen 3, Qwen 3.5, Gemma 3, Gemma 4, Llama, Mistral, Phi, DeepSeek)
 **Total agents:** 113 markdown files across 14 categories (engineering 12 + coder-companion 5 excluded from Solo's main library → 96 visible in Solo; the 5 coder-companion agents surface in Coder mode)
 **Current release tag:** v1.0.0-11 (cut 2026-05-15)
 **Moonshot pick model:** Qwen 3.5 35B-A3B (MoE) — 35B brain, 3B speed, thinking + vision + 256K context

--- a/backend/app.py
+++ b/backend/app.py
@@ -516,6 +516,15 @@ async def startup_event():
         # Seed crew templates library
         await _seed_crew_templates(proxy)
 
+        # Seed example crews (ready-to-run samples) for the desktop user
+        try:
+            from services.sample_crew_seeder import seed_sample_crews
+            n_samples = await seed_sample_crews(proxy)
+            if n_samples:
+                logger.info("Seeded %d sample crew(s)", n_samples)
+        except Exception:
+            logger.exception("Failed to seed sample crews")
+
         # Seed model configs for any already-downloaded local GGUF models
         await _seed_local_models(proxy)
 

--- a/backend/models/cloud_provider_models.py
+++ b/backend/models/cloud_provider_models.py
@@ -25,14 +25,17 @@ class CloudProviderType(str, Enum):
     OPENAI = "openai"
     GOOGLE = "google"
     BEDROCK = "bedrock"
+    OLLAMA = "ollama"
 
 
 # Sensitive keys per provider type — these are masked in responses.
+# Ollama is local and key-less, so it has no sensitive fields.
 SENSITIVE_KEYS = {
     CloudProviderType.ANTHROPIC.value: {"api_key"},
     CloudProviderType.OPENAI.value: {"api_key"},
     CloudProviderType.GOOGLE.value: {"api_key"},
     CloudProviderType.BEDROCK.value: {"aws_secret_access_key"},
+    CloudProviderType.OLLAMA.value: set(),
 }
 
 MASK = "***"

--- a/backend/repositories/crew_memory_repository.py
+++ b/backend/repositories/crew_memory_repository.py
@@ -51,7 +51,11 @@ class CrewMemoryRepository(BaseRepository):
             "updated_at": now,
         }
         result = await self.collection.insert_one(doc)
-        doc["id"] = str(doc.pop("_id"))
+        # The SQLite compat layer copies the document on insert and does not
+        # write `_id` back into `doc`, so read it from the result instead of
+        # popping a key that isn't there (which raised KeyError: '_id').
+        doc["id"] = str(result.inserted_id)
+        doc.pop("_id", None)
         return doc
 
     # ------------------------------------------------------------------

--- a/backend/repositories/crew_repository.py
+++ b/backend/repositories/crew_repository.py
@@ -133,6 +133,14 @@ class CrewRepository(BaseRepository):
     async def update_crew(self, crew_id: str, data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Update a crew by crew_id."""
         data["updated_at"] = datetime.utcnow().isoformat()
+        # Assign agent_ids to any agents added via update (e.g. a new step
+        # added in the Edit dialog). create_crew does this on insert, but
+        # update must too — otherwise a new agent has agent_id=None, which
+        # breaks run creation (CrewRunResponse requires a string agent_id).
+        if isinstance(data.get("agents"), list):
+            for agent in data["agents"]:
+                if isinstance(agent, dict) and not agent.get("agent_id"):
+                    agent["agent_id"] = str(uuid.uuid4())
         result = await self.collection.find_one_and_update(
             {"crew_id": crew_id, "deleted_at": None},
             {"$set": data},
@@ -308,15 +316,31 @@ class CrewRunRepository(BaseRepository):
     async def update_agent_state(
         self, run_id: str, agent_id: str, state_update: Dict[str, Any]
     ) -> Optional[Dict[str, Any]]:
-        """Update a specific agent's state within a run."""
-        result = await self.collection.find_one_and_update(
-            {"run_id": run_id, "agents.agent_id": agent_id},
-            {"$set": {f"agents.$.{k}": v for k, v in state_update.items()}},
-            return_document=True,
-        )
-        if result:
-            result["id"] = str(result.pop("_id"))
-        return result
+        """Update a specific agent's state within a run.
+
+        Implemented as a read-modify-write over the whole ``agents`` array
+        rather than a positional ``agents.$`` update: the SQLite
+        motor-compat layer does not support MongoDB's positional array
+        operator (nor matching ``agents.agent_id`` against array elements),
+        so a positional update silently no-ops and every run's per-agent
+        state would stay "pending" forever.
+        """
+        run = await self.collection.find_one({"run_id": run_id})
+        if not run:
+            return None
+
+        agents = run.get("agents") or []
+        matched = False
+        for agent in agents:
+            if agent.get("agent_id") == agent_id:
+                agent.update(state_update)
+                matched = True
+                break
+
+        if not matched:
+            return None
+
+        return await self.update_run(run_id, {"agents": agents})
 
     async def append_agent_state(
         self, run_id: str, agent_state: Dict[str, Any]

--- a/backend/routers/ai_chat.py
+++ b/backend/routers/ai_chat.py
@@ -580,6 +580,19 @@ async def ai_chat(request: ChatRequest, http_request: Request = None):
         if model_config and OllamaService.is_ollama_model(model_config):
             logger.info(f"🏠 ROUTING: Ollama model detected ({model_config.get('name')}), using OllamaService")
 
+            # Honor the base_url saved in Settings -> AI Providers (falls back
+            # to the localhost default). Without this the singleton would use
+            # the env default and could fail to reach a custom Ollama host.
+            ollama_svc = ollama_service
+            try:
+                from services.cloud_provider_service import CloudProviderService
+                _creds = await CloudProviderService(db).get_credentials("ollama")
+                _base_url = (_creds or {}).get("base_url")
+                if _base_url:
+                    ollama_svc = OllamaService(base_url=_base_url)
+            except Exception as _e:
+                logger.warning(f"⚠️ Could not resolve saved Ollama base_url: {_e}")
+
             # Store user message
             user_message_id = await store_message(session_id, "user", request.prompt)
 
@@ -607,7 +620,7 @@ async def ai_chat(request: ChatRequest, http_request: Request = None):
                 async def ollama_event_generator() -> AsyncGenerator[str, None]:
                     collected_response = []
                     try:
-                        gen = await ollama_service.call_model(
+                        gen = await ollama_svc.call_model(
                             prompt=effective_prompt,
                             model_id=model_id,
                             persona_context=persona_context,
@@ -649,7 +662,7 @@ async def ai_chat(request: ChatRequest, http_request: Request = None):
 
                 return StreamingResponse(ollama_event_generator(), media_type="text/plain")
             else:
-                result = await ollama_service.call_model(
+                result = await ollama_svc.call_model(
                     prompt=effective_prompt,
                     model_id=model_id,
                     persona_context=persona_context,

--- a/backend/services/cloud_provider_service.py
+++ b/backend/services/cloud_provider_service.py
@@ -210,6 +210,8 @@ class CloudProviderService:
                 ok, error = await _probe_google(cfg)
             elif provider_type == CloudProviderType.BEDROCK.value:
                 ok, error = await _probe_bedrock(cfg)
+            elif provider_type == CloudProviderType.OLLAMA.value:
+                ok, error = await _probe_ollama(cfg)
             else:
                 ok, error = False, f"Unsupported provider type: {provider_type!r}"
         except Exception as exc:  # safety net
@@ -301,6 +303,27 @@ async def _probe_google(cfg: Dict[str, Any]):
         return False, _short_error(exc)
 
 
+async def _probe_ollama(cfg: Dict[str, Any]):
+    """Probe a local Ollama server by listing its pulled models.
+
+    Ollama is key-less; the only config is an optional ``base_url`` (defaults
+    to ``http://localhost:11434``). A 2xx from ``/api/tags`` means the server
+    is reachable.
+    """
+    base_url = (cfg.get("base_url") or "http://localhost:11434").rstrip("/")
+    try:
+        async with httpx.AsyncClient(timeout=PROBE_TIMEOUT_SECONDS) as client:
+            resp = await client.get(f"{base_url}/api/tags")
+        if 200 <= resp.status_code < 300:
+            return True, None
+        return False, _extract_error_message(resp, default=f"HTTP {resp.status_code}")
+    except httpx.HTTPError as exc:
+        return False, (
+            f"Could not reach Ollama at {base_url} — is `ollama serve` running? "
+            f"({_short_error(exc)})"
+        )
+
+
 async def _probe_bedrock(cfg: Dict[str, Any]):
     import asyncio
 
@@ -344,6 +367,7 @@ def _default_display_name(provider_type: str) -> str:
         "openai": "OpenAI",
         "google": "Google AI",
         "bedrock": "AWS Bedrock",
+        "ollama": "Ollama (Local)",
     }.get(provider_type, provider_type.title())
 
 

--- a/backend/services/crew_orchestrator.py
+++ b/backend/services/crew_orchestrator.py
@@ -181,8 +181,22 @@ class CrewOrchestrator:
         """
         agents = crew.get("agents", [])
         run_id = run["run_id"]
-        user_input = run.get("input", "")
+        user_input = (run.get("input") or "").strip()
         input_data = run.get("input_data", {})
+
+        # Defensive: a run with no explicit task (e.g. a manual "Run Crew"
+        # press before the task dialog existed) would otherwise hand each
+        # agent an empty prompt, and a persona-only system prompt makes the
+        # model just describe its own role instead of producing work. Derive
+        # an objective from the crew's purpose and steer toward a deliverable.
+        if not user_input:
+            desc = (crew.get("description") or "").strip()
+            objective = f"{desc}\n\n" if desc else ""
+            user_input = (
+                f"{objective}Produce the actual deliverable for this crew's purpose. "
+                "Output the finished work product itself — do not describe your role, "
+                "skills, or what you would do."
+            )
 
         if mode == ExecutionMode.AUTONOMOUS.value:
             return await self._execute_autonomous(
@@ -624,6 +638,10 @@ class CrewOrchestrator:
             # Local model selected — do NOT fall through to Bedrock on failure
             return await self._invoke_via_local(agent_cfg, prompt, model_id)
 
+        if model_id and model_id.lower().startswith("ollama"):
+            # Ollama model selected — do NOT fall through to Claude/Bedrock.
+            return await self._invoke_via_ollama(agent_cfg, prompt, model_id)
+
         if CLAUDE_SDK_AVAILABLE:
             try:
                 return await self._invoke_via_claude_sdk(agent_cfg, prompt)
@@ -664,6 +682,57 @@ class CrewOrchestrator:
             "tokens_used": tokens_used,
             "cost": 0.0,
         }
+
+    async def _invoke_via_ollama(
+        self, agent_cfg: Dict[str, Any], prompt: str, model_id: str
+    ) -> Dict[str, Any]:
+        """Invoke an agent via a local Ollama server (no API key, no fallback).
+
+        Resolves the server URL from the saved ``ollama`` cloud-provider row
+        (Settings -> AI Providers), defaulting to ``http://localhost:11434``.
+        """
+        from services.ollama_direct_service import OllamaDirectService
+
+        agent_name = agent_cfg.get("name", "Agent")
+        system_prompt = await self._resolve_instructions(agent_cfg)
+
+        # Resolve the configured Ollama base_url (if the provider was saved).
+        base_url = None
+        try:
+            from database import get_database
+            from services.cloud_provider_service import CloudProviderService
+
+            db = await get_database()
+            creds = await CloudProviderService(db).get_credentials("ollama")
+            if creds:
+                base_url = creds.get("base_url")
+        except Exception:
+            logger.debug("Could not resolve saved Ollama base_url; using default")
+
+        messages: List[Dict[str, str]] = []
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+        messages.append({"role": "user", "content": prompt})
+
+        logger.info(f"Running crew agent '{agent_name}' via Ollama: {model_id}")
+
+        parts: List[str] = []
+        usage: Dict[str, Any] = {}
+        svc = OllamaDirectService()
+        async for evt in svc.stream_chat(
+            messages, model_id=model_id, base_url=base_url, max_tokens=4096
+        ):
+            if evt.get("type") == "delta":
+                parts.append(evt.get("content", ""))
+            elif evt.get("type") == "done":
+                usage = evt.get("usage", {})
+
+        output = "".join(parts)
+        tokens_used = usage.get("total_tokens", 0)
+        logger.info(
+            f"Crew agent '{agent_name}' completed via Ollama (tokens={tokens_used})"
+        )
+        return {"output": output, "tokens_used": tokens_used, "cost": 0.0}
 
     async def _resolve_instructions(self, agent_cfg: Dict[str, Any]) -> str:
         """Resolve agent instructions, falling back to library agent if instructions are too short."""

--- a/backend/services/ollama_service.py
+++ b/backend/services/ollama_service.py
@@ -14,14 +14,17 @@ from ollama import AsyncClient
 
 logger = logging.getLogger(__name__)
 
-OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://ollama:11434")
+# Desktop runs Ollama on localhost; Docker deployments override via env.
+OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
 
 
 class OllamaService:
     """Service for invoking local models via the Ollama Python SDK."""
 
-    def __init__(self):
-        self.base_url = OLLAMA_BASE_URL
+    def __init__(self, base_url: Optional[str] = None):
+        # Per-instance override (e.g. the URL saved in Settings -> AI Providers)
+        # wins over the env default so the configured connection is honored.
+        self.base_url = base_url or OLLAMA_BASE_URL
         self._client: Optional[AsyncClient] = None
         logger.info(f"OllamaService initialized with base URL: {self.base_url}")
 

--- a/backend/services/sample_crew_seeder.py
+++ b/backend/services/sample_crew_seeder.py
@@ -1,0 +1,165 @@
+"""
+Sample Crew Seeder — preloads a couple of ready-to-run example crews so new
+users can see how Crews work (and the writer -> reviewer -> finalizer pattern)
+without building one from scratch.
+
+Unlike ``crew_template_seeder`` (which fills the unused ``crew_templates``
+collection), this seeds real, runnable crews into the ``crews`` collection for
+the desktop user, so they appear directly on the Crews page.
+
+Idempotency
+-----------
+Seeding runs once ever, gated by a flag doc in ``app_meta``. This means a user
+who deletes a sample crew won't have it silently reappear on the next launch.
+"""
+
+import logging
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+DESKTOP_USER_ID = "desktop-user"
+SEED_FLAG_ID = "sample_crews_seeded_v1"
+
+# A finalizer turns the reviewer's critique into the finished deliverable.
+# Kept in sync with the frontend crew-builder FINALIZER_INSTRUCTIONS.
+FINALIZER_INSTRUCTIONS = (
+    "You are the Finalizer for this crew. You receive the previous draft and "
+    "the reviewer's feedback. Apply the feedback and produce the FINAL, "
+    "ready-to-publish deliverable.\n\n"
+    "Output ONLY the finished result exactly as it should be delivered — no "
+    "preamble, scorecard, headings, or commentary. Do not write 'Here is' or "
+    "'Final version:'. Return just the deliverable itself."
+)
+
+# Each sample is a list of steps. A step either references a library agent by
+# id (its system_prompt becomes the instructions) or is the custom finalizer.
+SAMPLE_CREWS: List[Dict[str, Any]] = [
+    {
+        "name": "LinkedIn Content Pipeline (Sample)",
+        "description": (
+            "A 3-step content team: a Social Media Manager drafts a LinkedIn "
+            "post, a Brand Voice Guardian reviews it, and a Finalizer applies "
+            "the feedback to produce a publish-ready post."
+        ),
+        "mode": "sequential",
+        "tags": ["sample", "content", "linkedin"],
+        "steps": [
+            {"library_agent_id": "marketing_sales-social-media-manager", "role": "writer"},
+            {"library_agent_id": "social_engagement-brand-voice-guardian", "role": "reviewer"},
+            {"finalizer": True},
+        ],
+    },
+    {
+        "name": "Blog → Social Repurposer (Sample)",
+        "description": (
+            "Turns a piece of source content into a polished social post: a "
+            "Content Repurposer adapts it, a Brand Voice Guardian reviews, and "
+            "a Finalizer outputs the ready-to-post version."
+        ),
+        "mode": "sequential",
+        "tags": ["sample", "content", "repurpose"],
+        "steps": [
+            {"library_agent_id": "social_engagement-content-repurposer", "role": "writer"},
+            {"library_agent_id": "social_engagement-brand-voice-guardian", "role": "reviewer"},
+            {"finalizer": True},
+        ],
+    },
+]
+
+
+async def _already_seeded(db) -> bool:
+    try:
+        doc = await db["app_meta"].find_one({"_id": SEED_FLAG_ID})
+        return doc is not None
+    except Exception:
+        return False
+
+
+async def _mark_seeded(db) -> None:
+    try:
+        await db["app_meta"].insert_one(
+            {"_id": SEED_FLAG_ID, "seeded_at": datetime.utcnow().isoformat()}
+        )
+    except Exception:
+        logger.debug("Could not write sample-crew seed flag", exc_info=True)
+
+
+async def _build_agent(
+    step: Dict[str, Any], order: int, agent_repo
+) -> Optional[Dict[str, Any]]:
+    """Resolve one step into a crew agent config, or None if unresolvable."""
+    if step.get("finalizer"):
+        return {
+            "name": "Finalizer",
+            "role": "editor",
+            "instructions": FINALIZER_INSTRUCTIONS,
+            "order": order,
+        }
+
+    lib_id = step.get("library_agent_id")
+    lib_agent = await agent_repo.get_by_id(lib_id)
+    if not lib_agent or not lib_agent.get("system_prompt"):
+        logger.warning(
+            "Sample crew seeder: library agent '%s' not found — skipping sample", lib_id
+        )
+        return None
+
+    return {
+        "name": lib_agent.get("name") or lib_id,
+        "role": step.get("role", "custom"),
+        "instructions": lib_agent["system_prompt"],
+        "library_agent_id": lib_id,
+        "order": order,
+    }
+
+
+async def seed_sample_crews(db) -> int:
+    """Seed the example crews once. Returns the number created."""
+    try:
+        from repositories.crew_repository import CrewRepository
+        from repositories.workspace_agent_repository import WorkspaceAgentRepository
+
+        if await _already_seeded(db):
+            return 0
+
+        crew_repo = CrewRepository(db)
+        agent_repo = WorkspaceAgentRepository(db)
+
+        created = 0
+        for sample in SAMPLE_CREWS:
+            # Skip if a crew with this name already exists for the user.
+            existing = await crew_repo.get_by_name(DESKTOP_USER_ID, sample["name"])
+            if existing:
+                continue
+
+            agents: List[Dict[str, Any]] = []
+            ok = True
+            for i, step in enumerate(sample["steps"]):
+                agent = await _build_agent(step, i, agent_repo)
+                if agent is None:
+                    ok = False
+                    break
+                agents.append(agent)
+            if not ok:
+                continue
+
+            crew_data = {
+                "name": sample["name"],
+                "description": sample["description"],
+                "agents": agents,
+                "execution_config": {"mode": sample["mode"], "timeout_seconds": 600},
+                "memory_enabled": True,
+                "tags": sample.get("tags", []),
+                "kind": "crew",
+            }
+            await crew_repo.create_crew(DESKTOP_USER_ID, crew_data)
+            created += 1
+            logger.info("Seeded sample crew: %s", sample["name"])
+
+        await _mark_seeded(db)
+        return created
+    except Exception:
+        logger.exception("Failed to seed sample crews (non-fatal)")
+        return 0

--- a/backend/tests/test_crew_run_agent_state.py
+++ b/backend/tests/test_crew_run_agent_state.py
@@ -1,0 +1,81 @@
+"""Regression tests for CrewRunRepository.update_agent_state.
+
+The SQLite motor-compat layer does not support MongoDB's positional array
+operator (``agents.$.field``) nor matching ``agents.agent_id`` against array
+elements. The original positional implementation therefore silently no-opped
+and every crew run kept its per-agent state stuck at "pending" with no output,
+even after the run completed. These tests lock in the read-modify-write
+implementation that actually persists per-agent state.
+"""
+
+import pytest
+
+from repositories.crew_repository import CrewRunRepository
+
+
+def _run_data(agent_ids):
+    return {
+        "input": "do the thing",
+        "input_data": None,
+        "agents": [
+            {
+                "agent_id": aid,
+                "name": f"Agent {i}",
+                "role": "custom",
+                "status": "pending",
+                "output": None,
+                "tokens_used": 0,
+                "cost_usd": 0.0,
+            }
+            for i, aid in enumerate(agent_ids)
+        ],
+        "trigger_type": "manual",
+        "trigger_source": "manual",
+    }
+
+
+@pytest.mark.asyncio
+async def test_update_agent_state_persists_status_and_output(db_proxy):
+    repo = CrewRunRepository(db_proxy)
+    run = await repo.create_run("crew-1", "desktop-user", _run_data(["a1", "a2"]))
+    run_id = run["run_id"]
+
+    updated = await repo.update_agent_state(
+        run_id, "a2", {"status": "completed", "output": "hello world", "tokens_used": 42}
+    )
+    assert updated is not None
+
+    fresh = await repo.get_by_run_id(run_id)
+    by_id = {a["agent_id"]: a for a in fresh["agents"]}
+    # The targeted agent is updated...
+    assert by_id["a2"]["status"] == "completed"
+    assert by_id["a2"]["output"] == "hello world"
+    assert by_id["a2"]["tokens_used"] == 42
+    # ...and the other agent is left untouched (no array clobbering).
+    assert by_id["a1"]["status"] == "pending"
+    assert by_id["a1"]["output"] is None
+
+
+@pytest.mark.asyncio
+async def test_update_agent_state_returns_none_for_unknown_agent(db_proxy):
+    repo = CrewRunRepository(db_proxy)
+    run = await repo.create_run("crew-1", "desktop-user", _run_data(["a1"]))
+    result = await repo.update_agent_state(run["run_id"], "missing", {"status": "completed"})
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_update_agent_state_keeps_agents_a_list(db_proxy):
+    """Guards against the positional-operator bug that replaced the agents
+    list with a dict shaped like ``{"$": {...}}``."""
+    repo = CrewRunRepository(db_proxy)
+    run = await repo.create_run("crew-1", "desktop-user", _run_data(["a1", "a2"]))
+    run_id = run["run_id"]
+
+    await repo.update_agent_state(run_id, "a1", {"status": "running"})
+    await repo.update_agent_state(run_id, "a2", {"status": "completed"})
+
+    fresh = await repo.get_by_run_id(run_id)
+    assert isinstance(fresh["agents"], list)
+    assert len(fresh["agents"]) == 2
+    assert {a["agent_id"] for a in fresh["agents"]} == {"a1", "a2"}

--- a/backend/tests/test_sample_crew_seeder.py
+++ b/backend/tests/test_sample_crew_seeder.py
@@ -1,0 +1,74 @@
+"""Tests for the sample crew seeder.
+
+Verifies it seeds ready-to-run example crews (writer -> reviewer -> finalizer),
+resolves library-agent system prompts into instructions, and is idempotent so
+samples don't reappear after a user deletes them.
+"""
+
+import pytest
+
+from services.sample_crew_seeder import (
+    seed_sample_crews,
+    FINALIZER_INSTRUCTIONS,
+    DESKTOP_USER_ID,
+)
+from repositories.crew_repository import CrewRepository
+
+# The library-agent ids the samples reference.
+_LIB_IDS = [
+    "marketing_sales-social-media-manager",
+    "social_engagement-brand-voice-guardian",
+    "social_engagement-content-repurposer",
+]
+
+
+async def _seed_library_agents(db):
+    for aid in _LIB_IDS:
+        await db["workspace_agents"].insert_one({
+            "agent_id": aid,
+            "name": aid.split("-", 1)[-1].replace("-", " ").title(),
+            "system_prompt": f"You are {aid}. " + ("x" * 80),
+            "is_active": True,
+        })
+
+
+@pytest.mark.asyncio
+async def test_seeds_sample_crews_with_finalizer(db_proxy):
+    await _seed_library_agents(db_proxy)
+
+    created = await seed_sample_crews(db_proxy)
+    assert created == 2
+
+    crews, _ = await CrewRepository(db_proxy).get_user_crews(DESKTOP_USER_ID, limit=50)
+    names = {c["name"] for c in crews}
+    assert "LinkedIn Content Pipeline (Sample)" in names
+
+    pipeline = next(c for c in crews if c["name"] == "LinkedIn Content Pipeline (Sample)")
+    agents = pipeline["agents"]
+    assert len(agents) == 3
+    # Every agent got an id and real instructions.
+    assert all(a.get("agent_id") for a in agents)
+    assert all(len(a.get("instructions") or "") > 0 for a in agents)
+    # Last step is the finalizer (the deliverable producer).
+    assert agents[-1]["name"] == "Finalizer"
+    assert agents[-1]["role"] == "editor"
+    assert agents[-1]["instructions"] == FINALIZER_INSTRUCTIONS
+    assert agents[-1].get("library_agent_id") is None
+
+
+@pytest.mark.asyncio
+async def test_seeding_is_idempotent(db_proxy):
+    await _seed_library_agents(db_proxy)
+    first = await seed_sample_crews(db_proxy)
+    assert first == 2
+    # Second run is gated by the seed flag — nothing new.
+    second = await seed_sample_crews(db_proxy)
+    assert second == 0
+
+
+@pytest.mark.asyncio
+async def test_skips_sample_when_library_agent_missing(db_proxy):
+    # No library agents inserted → samples can't resolve → none created,
+    # but the run still completes without raising.
+    created = await seed_sample_crews(db_proxy)
+    assert created == 0

--- a/docs/user-guide/05-crews.md
+++ b/docs/user-guide/05-crews.md
@@ -101,7 +101,8 @@ Review your full configuration:
 ## Running a Crew
 
 1. Click the **Run** button on a crew card, or open the crew detail page and click **Run Crew**.
-2. A progress modal appears showing real-time status.
+2. A task-input dialog appears — titled "Run {crew name}". Enter a description in the **Task for this run** field (required, auto-focused). Be specific about the deliverable, intended audience, and any constraints. Click **Run Crew** to proceed, or **Cancel** to abort. Submitting with an empty task is blocked with inline validation.
+3. A progress modal appears showing real-time status.
 
 ### Run Progress
 
@@ -141,3 +142,4 @@ Each crew card shows:
 - **Enable approval for social channels** until you trust the output quality — you don't want to auto-post something embarrassing.
 - **Keep autonomous crews small** — set a low invocation limit (5–10) and budget ($1–$5) while you're learning how they behave.
 - **Check the Runs tab** regularly to monitor costs and catch failures early.
+- **Run crews at zero cost with Ollama** — if you have an Ollama provider configured under Settings → AI Providers, select any of its models as the crew's AI model. Crew agents run fully offline and free against your local Ollama server.

--- a/docs/user-guide/05-crews.md
+++ b/docs/user-guide/05-crews.md
@@ -13,6 +13,11 @@ Crews are multi-agent teams that work together to accomplish complex tasks. You 
 3. Configure your crew's details, execution mode, agents, and connections.
 4. Run the crew and monitor its progress in real-time.
 
+> **New here?** Solo ships with a couple of ready-to-run **sample crews**
+> (tagged `sample`) — e.g. *LinkedIn Content Pipeline* — that demonstrate the
+> recommended **writer → reviewer → finalizer** pattern. Open one, click
+> **Run Crew**, enter a task, and inspect how each step feeds the next.
+
 ## Crew List
 
 The main page shows:
@@ -62,6 +67,13 @@ Build your agent team:
 - Click **Browse Library** to pick from the 96 pre-built agents.
 - Reorder agents to control the execution sequence (for Sequential mode).
 - Each agent needs a **name** and **instructions** at minimum.
+
+> **The last step is your deliverable.** In Sequential and Pipeline crews, the
+> crew's result is the **last step's output**. If your crew ends on a reviewer,
+> the result is a *critique* — not a finished piece. The builder detects this
+> and shows an **"Add a finalizer step?"** suggestion: one click adds a
+> **Finalizer** that applies the review and outputs the publish-ready result.
+> The recommended shape for content crews is **writer → reviewer → finalizer**.
 
 #### Browsing the Agent Library
 

--- a/docs/user-guide/09-settings.md
+++ b/docs/user-guide/09-settings.md
@@ -23,7 +23,7 @@ Configure the AI models available throughout the app. See the [Model Hub guide](
 | OpenAI | Yes | GPT-4o, GPT-4o mini, O1 |
 | Google Gemini | Yes | Gemini 2.0 Flash/Pro |
 | AWS Bedrock | Yes | Claude 3 via AWS |
-| Ollama | No | Local models via Ollama server |
+| Ollama | No | Local models via Ollama server. Expand the card, enter your server URL, and click **Test Connection** — Solo probes the running Ollama server and displays a connected/saved indicator once verified, the same as cloud providers. |
 
 For each cloud provider:
 1. Expand the card.

--- a/frontend/src/components/crews/crew-builder.tsx
+++ b/frontend/src/components/crews/crew-builder.tsx
@@ -52,6 +52,7 @@ import {
   ArrowDownToLine,
   ArrowUpFromLine,
   Wrench,
+  Wand2,
 } from "lucide-react";
 
 type ExecutionMode = "sequential" | "parallel" | "pipeline" | "autonomous";
@@ -177,10 +178,62 @@ const ROLE_OPTIONS = [
   "researcher",
   "analyst",
   "writer",
+  "editor",
   "reviewer",
   "coordinator",
   "coder",
 ];
+
+// A finalizer turns a reviewer's critique into the finished, publish-ready
+// deliverable. In sequential/pipeline crews the LAST step's output IS the
+// crew's result, so a crew that ends on a reviewer hands back a critique
+// instead of a usable artifact.
+const FINALIZER_INSTRUCTIONS =
+  "You are the Finalizer for this crew. You receive the previous draft and " +
+  "the reviewer's feedback. Apply the feedback and produce the FINAL, " +
+  "ready-to-use deliverable.\n\n" +
+  "Output ONLY the finished result exactly as it should be delivered — no " +
+  "preamble, scorecard, headings, or commentary. Do not write 'Here is' or " +
+  "'Final version:'. Return just the deliverable itself.";
+
+const REVIEWER_HINTS = [
+  "review",
+  "guardian",
+  "critic",
+  "critique",
+  "qa",
+  "quality",
+  "approv",
+  "audit",
+  "evaluat",
+  "feedback",
+];
+const FINALIZER_HINTS = [
+  "finaliz",
+  "publish",
+  "polish",
+  "assembl",
+  "compile",
+  "final draft",
+  "final version",
+  "deliverable",
+];
+
+function _agentHaystack(a: AgentForm): string {
+  return `${a.role} ${a.name} ${a.instructions}`.toLowerCase();
+}
+
+function looksLikeFinalizer(a: AgentForm): boolean {
+  if (a.role === "editor" || a.name.trim().toLowerCase() === "finalizer") return true;
+  const hay = _agentHaystack(a);
+  return FINALIZER_HINTS.some((h) => hay.includes(h));
+}
+
+function looksLikeReviewer(a: AgentForm): boolean {
+  if (a.role === "reviewer") return true;
+  const hay = _agentHaystack(a);
+  return REVIEWER_HINTS.some((h) => hay.includes(h));
+}
 
 // ---------------------------------------------------------------------------
 // Library Panel (overlay inside crew builder)
@@ -330,6 +383,8 @@ export function CrewBuilder({ open, onClose, onCreated, kind = "crew", editCrew 
       coder_run_timeout_seconds: a.coder_run_timeout_seconds,
     })) ?? [emptyAgent()]
   );
+  // Lets the user dismiss the "add a finalizer" suggestion if intentional.
+  const [finalizerHintDismissed, setFinalizerHintDismissed] = useState(false);
   const [maxInvocations, setMaxInvocations] = useState(
     editCrew?.execution_config?.max_agent_invocations ?? 10
   );
@@ -465,6 +520,20 @@ export function CrewBuilder({ open, onClose, onCreated, kind = "crew", editCrew 
   };
 
   const isAutonomous = executionMode === "autonomous";
+
+  // Nudge: in a sequential/pipeline crew the last step's output is the
+  // deliverable. If the crew ends on a reviewer, the result is a critique, not
+  // a finished artifact — suggest adding a finalizer step.
+  const _lastAgent = agents[agents.length - 1];
+  const showFinalizerHint =
+    !isAutonomous &&
+    (executionMode === "sequential" || executionMode === "pipeline") &&
+    agents.length >= 2 &&
+    !!_lastAgent &&
+    !_lastAgent.coder_project_id &&
+    looksLikeReviewer(_lastAgent) &&
+    !looksLikeFinalizer(_lastAgent) &&
+    !finalizerHintDismissed;
 
   // A step is valid if it has a name AND (instructions OR coder_project_id).
   const isAgentValid = (a: AgentForm): boolean => {
@@ -646,6 +715,14 @@ export function CrewBuilder({ open, onClose, onCreated, kind = "crew", editCrew 
   };
 
   const addAgent = () => setAgents((prev) => [...prev, emptyAgent()]);
+
+  const addFinalizer = () => {
+    setAgents((prev) => [
+      ...prev,
+      { name: "Finalizer", role: "editor", instructions: FINALIZER_INSTRUCTIONS },
+    ]);
+    setFinalizerHintDismissed(true);
+  };
 
   const addCoderStep = (project: CoderProject) => {
     setAgents((prev) => [...prev, emptyCoderStep(project)]);
@@ -1105,6 +1182,42 @@ export function CrewBuilder({ open, onClose, onCreated, kind = "crew", editCrew 
                   </div>
                 ))}
               </div>
+
+              {/* Finalizer nudge — the last step's output is the deliverable */}
+              {showFinalizerHint && (
+                <div className="flex items-start gap-3 rounded-xl border border-amber-200 dark:border-amber-800/60 bg-amber-50 dark:bg-amber-500/10 p-4">
+                  <Sparkles className="w-5 h-5 text-amber-500 flex-shrink-0 mt-0.5" />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
+                      Add a finalizer step?
+                    </p>
+                    <p className="text-xs text-amber-700/90 dark:text-amber-300/80 mt-1">
+                      Your last step <strong>{_lastAgent?.name?.trim() || "the reviewer"}</strong> looks
+                      like a reviewer. In a {executionMode} crew, the{" "}
+                      <strong>last step's output is the deliverable</strong> — so this crew would hand
+                      back a critique, not a finished piece. Add a <strong>Finalizer</strong> that
+                      applies the review and outputs the publish-ready result.
+                    </p>
+                    <div className="flex items-center gap-2 mt-3">
+                      <button
+                        type="button"
+                        onClick={addFinalizer}
+                        className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-amber-500 text-white hover:bg-amber-600 transition-colors"
+                      >
+                        <Wand2 className="w-3.5 h-3.5" />
+                        Add Finalizer step
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setFinalizerHintDismissed(true)}
+                        className="px-3 py-1.5 rounded-lg text-xs font-medium text-amber-700 dark:text-amber-300 hover:bg-amber-100 dark:hover:bg-amber-500/20 transition-colors"
+                      >
+                        Dismiss
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              )}
 
               {/* Agent cards */}
               {agents.map((agent, index) => {

--- a/frontend/src/components/crews/crew-builder.tsx
+++ b/frontend/src/components/crews/crew-builder.tsx
@@ -886,32 +886,22 @@ export function CrewBuilder({ open, onClose, onCreated, kind = "crew", editCrew 
         />
 
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-neutral-200 dark:border-neutral-800">
-          <div className="flex items-center gap-3">
-            <div className="p-2 rounded-lg bg-primary-50 dark:bg-primary-500/10">
+        <div className="flex items-center justify-between gap-4 px-6 py-4 border-b border-neutral-200 dark:border-neutral-800">
+          <div className="flex items-center gap-3 min-w-0">
+            <div className="p-2 rounded-lg bg-primary-50 dark:bg-primary-500/10 flex-shrink-0">
               <Users className="w-5 h-5 text-primary-500" />
             </div>
-            <div>
-              <h2 className="text-lg font-semibold text-neutral-900 dark:text-white">
+            <div className="min-w-0">
+              <h2 className="text-lg font-semibold text-neutral-900 dark:text-white truncate">
                 {isEdit ? `Edit ${noun}` : `Create New ${noun}`}
               </h2>
-              <p className="text-xs text-neutral-500 dark:text-neutral-400">
+              <p className="text-xs text-neutral-500 dark:text-neutral-400 truncate">
                 {STEP_TITLES[step].subtitle}
               </p>
             </div>
           </div>
-          <div className="flex items-center gap-4">
+          <div className="flex items-center gap-4 flex-shrink-0">
             <StepIndicator currentStep={visualStep} totalSteps={totalSteps} />
-            <a
-              href="https://contextuai.com/cookbook"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hidden sm:flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium text-neutral-500 dark:text-neutral-400 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
-              title="Recipes & patterns for getting more out of Crews"
-            >
-              <BookOpen className="w-3.5 h-3.5" />
-              Cookbook
-            </a>
             <button
               onClick={onClose}
               className="p-2 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
@@ -2025,7 +2015,7 @@ export function CrewBuilder({ open, onClose, onCreated, kind = "crew", editCrew 
 
         {/* Footer */}
         <div className="flex items-center justify-between px-6 py-4 border-t border-neutral-200 dark:border-neutral-800">
-          <div>
+          <div className="flex items-center gap-3">
             {step > 1 && (
               <button
                 type="button"
@@ -2036,6 +2026,16 @@ export function CrewBuilder({ open, onClose, onCreated, kind = "crew", editCrew 
                 Back
               </button>
             )}
+            <a
+              href="https://contextuai.com/cookbook"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium text-neutral-500 dark:text-neutral-400 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+              title="Recipes & patterns for getting more out of Crews"
+            >
+              <BookOpen className="w-4 h-4" />
+              Cookbook
+            </a>
           </div>
           <div className="flex items-center gap-3">
             <button

--- a/frontend/src/components/crews/crew-builder.tsx
+++ b/frontend/src/components/crews/crew-builder.tsx
@@ -902,6 +902,16 @@ export function CrewBuilder({ open, onClose, onCreated, kind = "crew", editCrew 
           </div>
           <div className="flex items-center gap-4">
             <StepIndicator currentStep={visualStep} totalSteps={totalSteps} />
+            <a
+              href="https://contextuai.com/cookbook"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hidden sm:flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium text-neutral-500 dark:text-neutral-400 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+              title="Recipes & patterns for getting more out of Crews"
+            >
+              <BookOpen className="w-3.5 h-3.5" />
+              Cookbook
+            </a>
             <button
               onClick={onClose}
               className="p-2 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"

--- a/frontend/src/lib/api/cloud-providers-client.ts
+++ b/frontend/src/lib/api/cloud-providers-client.ts
@@ -4,7 +4,12 @@ import { api } from "@/lib/transport";
 // Types
 // ---------------------------------------------------------------------------
 
-export type CloudProviderType = "anthropic" | "openai" | "google" | "bedrock";
+export type CloudProviderType =
+  | "anthropic"
+  | "openai"
+  | "google"
+  | "bedrock"
+  | "ollama";
 
 export interface CloudProvider {
   provider_id: string;

--- a/frontend/src/lib/api/crews-client.ts
+++ b/frontend/src/lib/api/crews-client.ts
@@ -197,8 +197,15 @@ export const crewsApi = {
     return (raw.runs ?? (raw.data as Record<string, unknown>)?.runs ?? []) as CrewRun[];
   },
 
-  startRun: async (crewId: string, inputData?: Record<string, unknown>): Promise<CrewRun> => {
+  startRun: async (
+    crewId: string,
+    input?: string,
+    inputData?: Record<string, unknown>,
+  ): Promise<CrewRun> => {
+    // `input` is the task/objective for this run. Without it the crew has
+    // nothing concrete to do and agents fall back to describing themselves.
     const { data } = await api.post<{ data: CrewRun }>(`/crews/${crewId}/run`, {
+      input: input && input.trim() ? input.trim() : undefined,
       input_data: inputData ?? {},
     });
     return (data as { data: CrewRun }).data;

--- a/frontend/src/routes/crew-detail.tsx
+++ b/frontend/src/routes/crew-detail.tsx
@@ -70,6 +70,7 @@ export default function CrewDetailPage() {
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<"overview" | "runs" | "schedule">("overview");
   const [editorOpen, setEditorOpen] = useState(false);
+  const [runDialogOpen, setRunDialogOpen] = useState(false);
   const [activeRunView, setActiveRunView] = useState<{ crewId: string; runId: string } | null>(null);
 
   const loadData = useCallback(async () => {
@@ -99,15 +100,17 @@ export default function CrewDetailPage() {
     loadData();
   };
 
-  const handleStartRun = async () => {
+  // Open the task dialog. Running a crew without a concrete task makes
+  // agents describe their own role instead of producing real output, so we
+  // always collect an objective first.
+  const handleStartRun = () => setRunDialogOpen(true);
+
+  const handleRunSubmit = async (taskInput: string) => {
     if (!id) return;
-    try {
-      const run = await crewsApi.startRun(id);
-      setActiveRunView({ crewId: id, runId: run.run_id });
-      handleRefresh();
-    } catch (err) {
-      console.error("Failed to start run:", err);
-    }
+    const run = await crewsApi.startRun(id, taskInput);
+    setRunDialogOpen(false);
+    setActiveRunView({ crewId: id, runId: run.run_id });
+    handleRefresh();
   };
 
   const handleDelete = async () => {
@@ -315,6 +318,17 @@ export default function CrewDetailPage() {
             agents: crew.agents,
             channel_bindings: crew.channel_bindings,
           }}
+        />
+      )}
+
+      {/* Run Crew task dialog */}
+      {runDialogOpen && (
+        <RunCrewDialog
+          crewName={crew.name}
+          crewDescription={crew.description}
+          isAutonomous={isAutonomous}
+          onClose={() => setRunDialogOpen(false)}
+          onSubmit={handleRunSubmit}
         />
       )}
 
@@ -668,6 +682,127 @@ function ScheduleTab({ crew }: { crew: Crew }) {
               </span>
             </div>
           )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Run Crew task dialog
+// ---------------------------------------------------------------------------
+
+function RunCrewDialog({
+  crewName,
+  crewDescription,
+  isAutonomous,
+  onClose,
+  onSubmit,
+}: {
+  crewName: string;
+  crewDescription?: string | null;
+  isAutonomous: boolean;
+  onClose: () => void;
+  onSubmit: (taskInput: string) => Promise<void>;
+}) {
+  const [task, setTask] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async () => {
+    if (!task.trim()) {
+      setError("Describe the task so the crew has something to work on.");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onSubmit(task);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to start run");
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+      <div className="w-full max-w-lg bg-white dark:bg-neutral-900 rounded-2xl border border-neutral-200 dark:border-neutral-800 shadow-xl">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-neutral-200 dark:border-neutral-800">
+          <div className="flex items-center gap-2">
+            <div className="p-1.5 rounded-lg bg-primary-50 dark:bg-primary-500/10">
+              <Play className="w-4 h-4 text-primary-500" />
+            </div>
+            <h3 className="font-semibold text-neutral-900 dark:text-white">
+              Run {crewName}
+            </h3>
+          </div>
+          <button
+            onClick={onClose}
+            disabled={submitting}
+            className="p-1.5 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors disabled:opacity-50"
+          >
+            <XCircle className="w-5 h-5 text-neutral-400" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-5 py-4 space-y-3">
+          {crewDescription && (
+            <p className="text-xs text-neutral-500 dark:text-neutral-400">
+              {crewDescription}
+            </p>
+          )}
+          <div>
+            <label className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1.5">
+              Task for this run
+            </label>
+            <textarea
+              autoFocus
+              value={task}
+              onChange={(e) => {
+                setTask(e.target.value);
+                if (error) setError(null);
+              }}
+              rows={5}
+              placeholder={
+                isAutonomous
+                  ? "e.g. Research our top 3 competitors and produce a one-page positioning brief."
+                  : "e.g. Write 3 LinkedIn posts announcing our new AI agent platform for B2B SaaS founders. Professional but punchy."
+              }
+              className="w-full rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 px-3 py-2 text-sm text-neutral-900 dark:text-white placeholder:text-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500/40 resize-none"
+            />
+            <p className="text-xs text-neutral-400 dark:text-neutral-500 mt-1.5">
+              Be specific about the deliverable, audience, and any constraints. The
+              crew uses this as the objective for every agent in the pipeline.
+            </p>
+          </div>
+          {error && (
+            <p className="text-xs text-red-500 dark:text-red-400">{error}</p>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-2 px-5 py-4 border-t border-neutral-200 dark:border-neutral-800">
+          <button
+            onClick={onClose}
+            disabled={submitting}
+            className="px-4 py-2 rounded-lg text-sm font-medium text-neutral-600 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={submitting}
+            className="flex items-center gap-2 px-4 py-2 rounded-lg bg-primary-500 text-white hover:bg-primary-600 transition-colors text-sm font-medium disabled:opacity-60"
+          >
+            {submitting ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <Play className="w-4 h-4" />
+            )}
+            {submitting ? "Starting…" : "Run Crew"}
+          </button>
         </div>
       </div>
     </div>

--- a/frontend/src/routes/crews.tsx
+++ b/frontend/src/routes/crews.tsx
@@ -21,7 +21,11 @@ import {
   Search,
   Filter,
   FlaskConical,
+  BookOpen,
 } from "lucide-react";
+
+// Recipes, patterns, and walkthroughs for getting more out of Crews.
+const COOKBOOK_URL = "https://contextuai.com/cookbook";
 
 // Phase 4 PR 3: top-level tab kinds for the unified Crews page.
 type CrewsTab = "crews" | "projects" | "runs";
@@ -360,6 +364,16 @@ export default function CrewsPage() {
             </div>
           </div>
           <div className="flex items-center gap-3">
+            <a
+              href={COOKBOOK_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium text-neutral-600 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+              title="Recipes & patterns for getting more out of Crews"
+            >
+              <BookOpen className="w-4 h-4" />
+              Cookbook
+            </a>
             <button
               onClick={handleRefresh}
               className="p-2 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"

--- a/frontend/src/routes/settings.tsx
+++ b/frontend/src/routes/settings.tsx
@@ -397,9 +397,9 @@ function AIProvidersTab() {
 
           {/* Cloud + Ollama provider cards */}
           {PROVIDER_GUIDES.map((guide) => {
-            const saved = guide.id === "ollama"
-              ? undefined  // Ollama not tracked as CloudProvider in backend
-              : savedByType[guide.id as CloudProviderType];
+            // Ollama is now a first-class provider row too, so its saved /
+            // connected state is tracked the same way as the cloud providers.
+            const saved = savedByType[guide.id as CloudProviderType];
             return (
               <ProviderCard
                 key={guide.id}


### PR DESCRIPTION
## Summary

Fixes the crew flow (crews were producing generic self-descriptions instead of real output) and wires up Ollama as a first-class provider, plus onboarding niceties.

### Crew run flow
- **Run Crew now collects a task** via a dialog and sends it as `input`. Previously the button sent no task, so agents fell back to describing their own role. Empty runs now derive an objective from the crew purpose and steer toward a deliverable.
- **Per-agent state persists**: `update_agent_state` rewritten as read-modify-write (the SQLite compat layer has no positional `agents.$` operator), so steps no longer stay stuck on "pending".
- **`update_crew` assigns agent_ids** to newly-added steps (parity with `create_crew`) — previously adding a step via Edit broke run creation with a 400.
- **Crew memory persists**: read `result.inserted_id` instead of `doc.pop("_id")` (KeyError fix).

### Ollama
- Added `OLLAMA` to `CloudProviderType` + a `/api/tags` probe so **Test/Save work** in Settings → AI Providers (was HTTP 422).
- `OllamaService` defaults to `http://localhost:11434` (not the Docker hostname) and accepts a `base_url`; chat resolves the saved URL.
- Crew orchestrator routes `ollama:` models via `OllamaDirectService`.

### Onboarding
- **Seed sample crews** (writer → reviewer → finalizer) on first launch (idempotent), so users see how Crews work.
- **Finalizer nudge** in the builder: if a sequential/pipeline crew ends on a reviewer, suggest adding a one-click Finalizer (the last step's output is the deliverable).
- **Cookbook link** (https://contextuai.com/cookbook) on the Crews page and in the builder footer.

### Tests
- `test_crew_run_agent_state.py`, `test_sample_crew_seeder.py`. Backend crew/cloud/ollama suite green; frontend `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)