### PR TITLE
chore: release v1.0.0-16

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "contextuai-solo",
   "description": "ContextuAI Solo — Personal AI Desktop App",
   "private": true,
-  "version": "1.0.0-15",
+  "version": "1.0.0-16",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contextuai-solo"
-version = "1.0.0-15"
+version = "1.0.0-16"
 description = "ContextuAI Solo - Your AI Business Assistant"
 authors = ["ContextuAI"]
 edition = "2021"

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "ContextuAI Solo",
-  "version": "1.0.0-15",
+  "version": "1.0.0-16",
   "identifier": "com.contextuai.solo",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Release **v1.0.0-16**.

Bumps the three version files (package.json, tauri.conf.json, Cargo.toml) in sync. Squash-merging this to `main` triggers the Release workflow (tag → build all platforms → publish + latest.json).

### What ships in this release
- Crew run flow fixes: run-task dialog, per-agent state persistence, agent_id assignment on edit, crew memory persistence.
- Ollama as a first-class provider (Test/Save connection) + crew & chat routing; localhost default.
- Preloaded sample crews (writer → reviewer → finalizer) and a finalizer nudge in the builder.
- Cookbook link on the Crews page and builder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)