### PR TITLE
ci(release): fix Create Tag 404 handling (no more manual tag push)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,8 +147,17 @@ jobs:
           # auto-release (or a re-run) must NOT hard-fail with HTTP 422
           # "Reference already exists". Only error if the tag exists but points
           # at a different commit — that's a real conflict worth stopping for.
-          existing_sha=$(gh api "repos/${{ github.repository }}/git/ref/tags/$RELEASE_TAG" \
-            --jq '.object.sha' 2>/dev/null || echo "")
+          #
+          # NOTE: `gh api` prints the error body to stdout on a 404, so the old
+          # `$(... || echo "")` captured that JSON body instead of clearing it —
+          # a non-existent tag then looked like it "already exists at a different
+          # SHA" and the job hard-failed (see v1.0.0-16). Capture the SHA only
+          # when the lookup actually succeeds (HTTP 200); a 404 → empty.
+          existing_sha=""
+          if ! existing_sha=$(gh api "repos/${{ github.repository }}/git/ref/tags/$RELEASE_TAG" \
+              --jq '.object.sha' 2>/dev/null); then
+            existing_sha=""
+          fi
           if [[ -n "$existing_sha" ]]; then
             if [[ "$existing_sha" == "$TARGET_SHA" ]]; then
               echo "Tag $RELEASE_TAG already exists at $TARGET_SHA — nothing to do."


### PR DESCRIPTION
## Problem
The auto-triggered release on `main` fires correctly, but the **Create Tag** job hard-fails: `gh api` prints the error body to stdout on a 404, and the old
```
existing_sha=$(gh api … --jq '.object.sha' 2>/dev/null || echo "")
```
captured that JSON body (the `|| echo ""` is *inside* `$()`). A non-existent tag then looked like it "already exists at a different SHA", so the job refused and `build`/`release` were skipped. v1.0.0-16 had to be published via a manual `git push origin v1.0.0-16` (tag-push path skips this job).

## Fix
Capture the SHA only when the lookup succeeds (HTTP 200); a 404 → empty string. Verified the bash logic for both cases (404 absent → creates tag; 200 present → idempotent no-op / conflict guard preserved).

Closes the manual-tag-push workaround. Tracked as CR-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)