### PR TITLE
feat(providers): OpenAI-compatible provider + unify cloud routing (closes #45, #48)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ The backend was ported from MongoDB. A compatibility layer preserves the Motor A
 - **Crew system**: Multi-agent teams with persistent memory (`crew_memory_service.py`)
 
 ### Local AI Models (`backend/routers/local_models.py`)
-GGUF models downloaded from HuggingFace, stored in `~/.contextuai-solo/models/`. Inference via llama-cpp-python on CPU.
+GGUF models downloaded from HuggingFace, stored in `~/.contextuai-solo/models/`. Inference via llama-cpp-python, with automatic GPU offload (Apple Metal / NVIDIA CUDA / Vulkan) when the installed build supports it, falling back to CPU. Offload is gated by `llama_cpp.llama_supports_gpu_offload()` and tunable via the `LOCAL_MODEL_GPU_LAYERS` env var (`auto` (default) / `0` to force CPU / `<N>` layers); the loaded model stays resident in RAM across messages and only reloads on a model swap.
 - 41 curated GGUF models (Gemma 4, Qwen 3/3.5, DeepSeek R1, Llama 3, Mistral, Phi-4, etc.) from 0.5B to 70B
 - Download: `POST /api/v1/local-models/{model_id}/download` (SSE progress)
 - Sync to DB: `POST /api/v1/local-models/sync` (registers downloaded models in the `models` collection)

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Solo is built for people who run a business with a small team — or no team at 
 
 Solo runs 100% on your desktop. No accounts. No cloud sync. No telemetry.
 
-- **AI models run locally** on your CPU — download once, use forever, no internet required
+- **AI models run locally** — on your GPU when available (Apple Metal / NVIDIA CUDA / Vulkan), CPU otherwise — download once, use forever, no internet required
 - **All data stored locally** in SQLite — conversations, agents, crews, everything
 - **No sign-up, no login** — you're the admin, always
 - **Bring Your Own Key** — optionally connect Anthropic, OpenAI, Google, or AWS Bedrock when you need cloud-scale power
@@ -202,9 +202,9 @@ Solo is a native desktop app that runs ~500 MB installed. If you bring your own 
 | **RAM** | 4 GB | 8–32 GB depending on model — see the table in the Local Models section below |
 | **Disk** | ~500 MB for the app | +1–40 GB per downloaded model (keep several; swap between them) |
 | **Network** | Required for cloud provider calls | One-time model download from HuggingFace; fully offline after |
-| **GPU** | Not used | Not used (CPU-only inference in the current build) |
+| **GPU** | Not used | Used automatically when available — Apple Metal (Apple Silicon), NVIDIA CUDA, or Vulkan; falls back to CPU |
 
-**On local inference speed:** llama-cpp-python runs entirely on CPU. On a modern laptop, expect roughly 5–20 tokens/sec on 7–14B models, 1–3 tokens/sec on 70B models. If you need faster 70B output, route to a cloud provider via BYOK instead.
+**On local inference speed:** llama-cpp-python offloads to your GPU automatically when the installed build supports it (Apple Metal, NVIDIA CUDA, Vulkan) — several times faster than CPU on the same model — and falls back to CPU otherwise. On CPU, expect roughly 5–20 tokens/sec on 7–14B models and 1–3 tokens/sec on 70B models; on Apple Silicon or a discrete GPU, substantially more. Set `LOCAL_MODEL_GPU_LAYERS=0` to force CPU, or route 70B output to a cloud provider via BYOK.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 # TODO — ContextuAI Solo Moonshot
 
 > Master task list. Prioritized by phases. Check off as completed.
-> **Created:** 2026-03-19 | **Last synced with code:** 2026-06-29
+> **Created:** 2026-03-19 | **Last synced with code:** 2026-06-30
 
 ---
 
@@ -14,6 +14,34 @@ Phases 0–4 and Phase 5 (Coder multi-agent) are shipped and verified against th
 - **CI: bundle the all-MiniLM-L6-v2 ONNX weights** so the KB lifecycle + Personal Docs folder e2e tests can run on GitHub Actions (currently `test.skip(!!process.env.CI)`).
 - **Phase 3/4 dead-code cleanup** — `frontend/src/routes/distribution.tsx`, `frontend/src/routes/schedule.tsx`, `frontend/src/routes/personas.tsx` (banner-only, one-release deprecation), `frontend/src/routes/workspace.tsx`. Delete after one more release cycle past v1.0.0-11.
 - **Backlog (BL-4 / BL-5 / BL-6 / BL-7)** — BL-2 (coding agents) absorbed into Phase 4 PR 6 coder-companion category. The rest are nice-to-haves, none committed.
+
+---
+
+## CLOUD PROVIDERS & RELEASE (in flight — 2026-06-30)
+
+Tracked after the v1.0.0-16 release (crew run-flow fixes + Ollama provider).
+
+### CR-1: Fix `Create Tag` 404 handling in release workflow ⭐
+`.github/workflows/release.yml` "Create Tag" step mis-handles a 404: `existing_sha=$(gh api .../git/ref/tags/$TAG --jq '.object.sha' 2>/dev/null || echo "")` captures the 404 body into `existing_sha` (the `|| echo ""` is *inside* the `$()`), so a non-existent tag is read as "already exists at a different SHA" and the job hard-fails.
+- [ ] Move the fallback outside the substitution: `existing_sha=$(gh api … 2>/dev/null) || existing_sha=""`.
+- Symptom: the auto-triggered release on `main` fired correctly but died at Create Tag; v1.0.0-16 had to be published via a manual `git push origin v1.0.0-16` (tag-push path skips this job). Until fixed, every normal release needs that manual recovery.
+
+### CR-2: Cloud endpoint review (verify each provider end-to-end)
+Test connection → save/persist → chat → crew, per provider:
+- [x] **Ollama** — Test/Save (`/api/tags` probe), chat (localhost base_url), crew routing. Done in v1.0.0-16.
+- [ ] **OpenAI** — paste real key, Test/Save, chat (gpt-4o), crew.
+- [ ] **Anthropic** — re-test (current stored row is a 31-char dummy `sk-ant-…` placeholder, never validated → delete it; add a real key).
+- [ ] **Google (Gemini)** — Test/Save, chat, crew.
+- [ ] **AWS Bedrock** — Test/Save (boto3 list-foundation-models), chat, crew.
+
+### CR-3: Generic `openai_compat` provider (#48 — closes #45)
+One integration to support **any** OpenAI-compatible server (vLLM / LM Studio / llama.cpp server / TGI). NOT covered by the existing OpenAI provider, which hardcodes `https://api.openai.com/v1` (`openai_direct_service.py:19`, used at :64/:156), passes no base_url in the dispatcher, probes a hardcoded URL, and seeds a hardcoded model catalog (no `/v1/models` discovery).
+- [ ] Add `OPENAI_COMPAT = "openai_compat"` to `CloudProviderType`; require `base_url` (key optional); add to `SENSITIVE_KEYS`.
+- [ ] Parameterize the endpoint in `openai_direct_service.stream_chat()` / `call_model()`.
+- [ ] `_probe_openai()` accepts `base_url`; add `openai_compat` branch in `cloud_provider_service`.
+- [ ] `model_dispatcher`: add `openai_compat` to `_KNOWN_PREFIXES`, route with `base_url` from creds.
+- [ ] `cloud_model_seeder`: dynamic model discovery via the server's `/v1/models`.
+- [ ] Frontend: provider guide (`base_url` required + optional `api_key`) + Settings card.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -28,20 +28,35 @@ Tracked after the v1.0.0-16 release (crew run-flow fixes + Ollama provider).
 
 ### CR-2: Cloud endpoint review (verify each provider end-to-end)
 Test connection → save/persist → chat → crew, per provider:
-- [x] **Ollama** — Test/Save (`/api/tags` probe), chat (localhost base_url), crew routing. Done in v1.0.0-16.
-- [ ] **OpenAI** — paste real key, Test/Save, chat (gpt-4o), crew.
-- [ ] **Anthropic** — re-test (current stored row is a 31-char dummy `sk-ant-…` placeholder, never validated → delete it; add a real key).
-- [ ] **Google (Gemini)** — Test/Save, chat, crew.
+- [x] **Ollama** — Test/Save (`/api/tags` probe), chat, crew routing. Done in v1.0.0-16.
+- [x] **OpenAI** — Test/Save, **live model discovery** (filtered from `/v1/models`, no rot), chat + crew via dispatcher, classic (gpt-4o) + reasoning (gpt-5.x/o-series) models, adaptive param retry, clear errors, **cost shown**. Done in PR #57.
+- [x] **Anthropic** — dummy `sk-ant-…` placeholder deleted; routes via Claude SDK (crews) / dispatcher (chat). Real-key test + live discovery still TODO.
+- [ ] **Google (Gemini)** — Test/Save, chat, crew + live discovery.
 - [ ] **AWS Bedrock** — Test/Save (boto3 list-foundation-models), chat, crew.
 
-### CR-3: Generic `openai_compat` provider (#48 — closes #45)
-One integration to support **any** OpenAI-compatible server (vLLM / LM Studio / llama.cpp server / TGI). NOT covered by the existing OpenAI provider, which hardcodes `https://api.openai.com/v1` (`openai_direct_service.py:19`, used at :64/:156), passes no base_url in the dispatcher, probes a hardcoded URL, and seeds a hardcoded model catalog (no `/v1/models` discovery).
-- [ ] Add `OPENAI_COMPAT = "openai_compat"` to `CloudProviderType`; require `base_url` (key optional); add to `SENSITIVE_KEYS`.
-- [ ] Parameterize the endpoint in `openai_direct_service.stream_chat()` / `call_model()`.
-- [ ] `_probe_openai()` accepts `base_url`; add `openai_compat` branch in `cloud_provider_service`.
-- [ ] `model_dispatcher`: add `openai_compat` to `_KNOWN_PREFIXES`, route with `base_url` from creds.
-- [ ] `cloud_model_seeder`: dynamic model discovery via the server's `/v1/models`.
-- [ ] Frontend: provider guide (`base_url` required + optional `api_key`) + Settings card.
+Also shipped in PR #57 (surfaced during the review):
+- Cloud routing **unified on `model_dispatcher`** across Chat + Crews + `/v1` (OpenAI/Anthropic/Google/openai_compat were dead in Chat/Crews before — only local/ollama/bedrock worked).
+- Models **seed on Save** (gated on credential, not the never-set `connected` flag); removed on delete.
+- **Run cost** shown in the crew Run Progress panel + fixed field mismatches (agents→steps, total_cost_usd→cost_usd, duration_ms→duration_seconds, progress). Pricing table rots + can't cover new families (gpt-5.x → $0 until priced).
+- **Approvals** post before marking approved (no false "approved" on a failed publish); 502 + provider message on failure.
+
+### CR-3: Generic `openai_compat` provider (#48 — closes #45) — ✅ DONE (PR #57)
+One integration for **any** OpenAI-compatible server (vLLM / LM Studio / llama.cpp / TGI / Ollama `/v1` / Azure OpenAI / LiteLLM / OpenRouter).
+- [x] `OPENAI_COMPAT` provider type (base_url required, key optional).
+- [x] Parameterized endpoint + optional key in `openai_direct_service`.
+- [x] `_probe_openai(base_url, require_key)` + `openai_compat` test branch.
+- [x] `model_dispatcher` prefix + routing; also wired into Chat + Crews + `/v1`.
+- [x] Dynamic model discovery via the server's `/v1/models` (preserve-on-failure).
+- [x] Frontend provider guide + Settings card.
+- [x] Adaptive param retry → works even when a compat endpoint fronts gpt-5/o-series.
+
+### CR-4: LinkedIn company-page (organization) posting — follow-up
+Personal posting works end-to-end (verified: crew → approval → `/v2/ugcPosts` 201).
+Company-page posting is blocked by **LinkedIn app permissions**, not our code:
+- [ ] Company posting needs the **Community Management API** product (`w_organization_social`), which LinkedIn requires to be the **only** product on a dedicated app → **create a separate LinkedIn app** for it (current app has OpenID + Share products; Request-access is greyed out). Requires a **Privacy Policy URL** on the app + LinkedIn approval + the member being an **admin** of the org.
+- [ ] Then: point the LinkedIn connection at the new app's `client_id`/`client_secret`, add `w_organization_social` to requested scopes, set `author_urn = urn:li:organization:<id>`.
+- ContextuAI side is mostly config (per-connection creds + scope list already stored) — no architectural change.
+- Interim: channel `author_urn` set to `urn:li:person:<id>` (posts as the member).
 
 ---
 

--- a/backend/models/cloud_provider_models.py
+++ b/backend/models/cloud_provider_models.py
@@ -26,6 +26,7 @@ class CloudProviderType(str, Enum):
     GOOGLE = "google"
     BEDROCK = "bedrock"
     OLLAMA = "ollama"
+    OPENAI_COMPAT = "openai_compat"
 
 
 # Sensitive keys per provider type — these are masked in responses.
@@ -36,6 +37,7 @@ SENSITIVE_KEYS = {
     CloudProviderType.GOOGLE.value: {"api_key"},
     CloudProviderType.BEDROCK.value: {"aws_secret_access_key"},
     CloudProviderType.OLLAMA.value: set(),
+    CloudProviderType.OPENAI_COMPAT.value: {"api_key"},
 }
 
 MASK = "***"
@@ -97,6 +99,10 @@ class CloudProviderCreate(BaseModel):
             for key in ("aws_access_key_id", "aws_secret_access_key", "aws_region"):
                 if not cfg.get(key):
                     raise ValueError(f"bedrock config requires {key}")
+        elif ptype == "openai_compat":
+            # Base URL is required; api_key is optional (keyless servers exist).
+            if not cfg.get("base_url"):
+                raise ValueError("openai_compat config requires base_url")
         return self
 
 

--- a/backend/routers/ai_chat.py
+++ b/backend/routers/ai_chat.py
@@ -705,6 +705,89 @@ async def ai_chat(request: ChatRequest, http_request: Request = None):
                 })
         # ── End Ollama intercept ──────────────────────────────────────
 
+        # ── Cloud provider intercept (OpenAI / OpenAI-compatible / Anthropic / Google) ──
+        # These route through the unified model_dispatcher (direct provider APIs
+        # using saved keys / base_url), instead of the Bedrock/Strands path below
+        # which only speaks AWS Bedrock. Tool-calling is not applied on this path.
+        from services.model_dispatcher import (
+            _parse_provider as _dispatch_parse,
+            stream_chat as _dispatch_stream,
+        )
+        _disp_provider, _ = _dispatch_parse(model_id)
+        if _disp_provider in ("openai", "openai_compat", "anthropic", "google"):
+            logger.info(f"🌐 ROUTING: {_disp_provider} via model_dispatcher ({model_id})")
+
+            user_message_id = await store_message(session_id, "user", request.prompt)
+
+            sys_prompt = None
+            if request.persona_id:
+                try:
+                    persona_service = PersonaService()
+                    pctx = await persona_service.build_persona_context(request.persona_id)
+                    sys_prompt = (pctx or {}).get("system_prompt")
+                except Exception as e:
+                    logger.warning(f"⚠️ Failed to build persona context: {e}")
+
+            disp_messages: list = []
+            if sys_prompt:
+                disp_messages.append({"role": "system", "content": sys_prompt})
+            for _m in history_messages:
+                _role = _m.get("role", "user")
+                _cp = _m.get("content", [])
+                _txt = _cp[0].get("text", "") if _cp else ""
+                if _txt:
+                    disp_messages.append({"role": _role, "content": _txt})
+            disp_messages.append({"role": "user", "content": effective_prompt})
+
+            if request.stream:
+                async def dispatcher_event_generator() -> AsyncGenerator[str, None]:
+                    collected: list = []
+                    try:
+                        async for evt in _dispatch_stream(
+                            model_id, disp_messages, db=db,
+                            temperature=request.temperature, max_tokens=request.max_tokens,
+                        ):
+                            if evt.get("type") == "delta":
+                                t = evt.get("content", "")
+                                if t:
+                                    collected.append(t)
+                                    yield f"data: {json.dumps({'chunk': t})}\n\n"
+                    except Exception as e:
+                        logger.error(f"❌ Dispatcher streaming error: {e}")
+                        yield f"data: {json.dumps({'status': 'error', 'error': True, 'message': str(e)})}\n\n"
+                    yield "data: [DONE]\n\n"
+
+                    full_response = "".join(collected)
+                    if full_response:
+                        await store_message(session_id, "assistant", full_response)
+                    await update_session_stats(session_id)
+                    if is_first_message and full_response:
+                        try:
+                            await update_session_title_from_first_message(session_id, request.prompt, max_length=20)
+                        except Exception:
+                            pass
+
+                return StreamingResponse(dispatcher_event_generator(), media_type="text/plain")
+            else:
+                parts: list = []
+                async for evt in _dispatch_stream(
+                    model_id, disp_messages, db=db,
+                    temperature=request.temperature, max_tokens=request.max_tokens,
+                ):
+                    if evt.get("type") == "delta":
+                        parts.append(evt.get("content", ""))
+                response_str = "".join(parts)
+                if response_str:
+                    await store_message(session_id, "assistant", response_str)
+                await update_session_stats(session_id)
+                return JSONResponse(content={
+                    "result": response_str,
+                    "session": session_id,
+                    "status": "success",
+                    "user_message_id": user_message_id,
+                    "metadata": {"model_id": model_id},
+                })
+
         bedrock_model = BedrockModel(
             model_id=bedrock_model_id,
             temperature=request.temperature,

--- a/backend/routers/ai_chat.py
+++ b/backend/routers/ai_chat.py
@@ -770,12 +770,27 @@ async def ai_chat(request: ChatRequest, http_request: Request = None):
                 return StreamingResponse(dispatcher_event_generator(), media_type="text/plain")
             else:
                 parts: list = []
-                async for evt in _dispatch_stream(
-                    model_id, disp_messages, db=db,
-                    temperature=request.temperature, max_tokens=request.max_tokens,
-                ):
-                    if evt.get("type") == "delta":
-                        parts.append(evt.get("content", ""))
+                try:
+                    async for evt in _dispatch_stream(
+                        model_id, disp_messages, db=db,
+                        temperature=request.temperature, max_tokens=request.max_tokens,
+                    ):
+                        if evt.get("type") == "delta":
+                            parts.append(evt.get("content", ""))
+                except Exception as e:
+                    logger.error(f"❌ Dispatcher error ({_disp_provider}): {e}")
+                    return JSONResponse(
+                        status_code=502,
+                        content={
+                            "result": "",
+                            "session": session_id,
+                            "status": "error",
+                            "error": True,
+                            "message": str(e),
+                            "user_message_id": user_message_id,
+                            "metadata": {"model_id": model_id},
+                        },
+                    )
                 response_str = "".join(parts)
                 if response_str:
                     await store_message(session_id, "assistant", response_str)

--- a/backend/routers/approvals.py
+++ b/backend/routers/approvals.py
@@ -94,8 +94,10 @@ async def approve(
     except ValueError as e:
         raise HTTPException(404, str(e))
     except Exception as e:
+        # Upstream channel/provider failure (e.g. expired token). The approval
+        # stays pending so it can be retried after fixing the connection.
         logger.error("Approval send failed: %s", e)
-        raise HTTPException(500, f"Failed to send: {e}")
+        raise HTTPException(502, f"Failed to send: {e}")
 
 
 @router.post("/{approval_id}/reject")

--- a/backend/routers/openai_compat.py
+++ b/backend/routers/openai_compat.py
@@ -65,7 +65,7 @@ _CLOUD_MODELS: Dict[str, List[str]] = {
     # Ollama models are discovered dynamically via list_models().
 }
 
-_KNOWN_PREFIXES = ("anthropic", "google", "openai", "bedrock", "ollama")
+_KNOWN_PREFIXES = ("anthropic", "google", "openai_compat", "openai", "bedrock", "ollama")
 
 
 # ── Request / Response models ────────────────────────────────────────────────
@@ -476,6 +476,15 @@ async def _cloud_stream_iter(
         from services.ollama_direct_service import OllamaDirectService
         svc = OllamaDirectService()
         return svc.stream_chat(messages, base_url=base_url, **kwargs)
+
+    if provider == "openai_compat":
+        base_url = creds.get("base_url")
+        if not base_url:
+            raise HTTPException(401, "OpenAI-compatible base_url not configured")
+        api_key = creds.get("api_key") or None  # optional for keyless servers
+        from services.openai_direct_service import OpenAIDirectService
+        svc = OpenAIDirectService()
+        return svc.stream_chat(messages, api_key=api_key, base_url=base_url, **kwargs)
 
     raise HTTPException(400, f"Unknown provider: {provider!r}")
 

--- a/backend/services/approval_service.py
+++ b/backend/services/approval_service.py
@@ -66,20 +66,27 @@ class ApprovalService:
         edited_response: Optional[str] = None,
         reviewed_by: str = "desktop-user",
     ) -> Dict[str, Any]:
-        """Approve (optionally edit) and send the response via the channel."""
-        approval = await self.repo.approve(
-            approval_id,
-            reviewed_by=reviewed_by,
-            edited_response=edited_response,
-        )
-        if not approval:
+        """Approve (optionally edit) and send the response via the channel.
+
+        Sends FIRST and only marks the approval ``approved`` if the send
+        actually succeeds — so a failed post (e.g. an expired channel token)
+        leaves the item ``pending`` to retry, instead of falsely showing as
+        approved-but-not-posted.
+        """
+        existing = await self.repo.get_by_id(approval_id)
+        if not existing:
             raise ValueError(f"Approval '{approval_id}' not found")
 
-        response_text = approval.get("final_response") or approval.get("draft_response", "")
-        channel_type = approval["channel_type"]
-        channel_id = approval["channel_id"]
+        response_text = (
+            edited_response
+            or existing.get("final_response")
+            or existing.get("draft_response", "")
+            or existing.get("content", "")
+        )
+        channel_type = existing["channel_type"]
+        channel_id = existing["channel_id"]
 
-        # Send via the appropriate channel
+        # Send first — raises on failure, leaving the approval pending to retry.
         try:
             await self._send_via_channel(channel_type, channel_id, response_text)
             logger.info(
@@ -89,6 +96,15 @@ class ApprovalService:
         except Exception as e:
             logger.error("Failed to send approved response: %s", e)
             raise
+
+        # Sent successfully — now persist the approved/edited state.
+        approval = await self.repo.approve(
+            approval_id,
+            reviewed_by=reviewed_by,
+            edited_response=edited_response,
+        )
+        if not approval:
+            raise ValueError(f"Approval '{approval_id}' not found")
 
         # Store in channel message history
         session_id = approval.get("session_id")

--- a/backend/services/cloud_model_seeder.py
+++ b/backend/services/cloud_model_seeder.py
@@ -18,9 +18,13 @@ so saved keys produce model entries immediately.
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
+
+import httpx
 
 logger = logging.getLogger(__name__)
+
+_DISCOVERY_TIMEOUT_SECONDS = 10.0
 
 # (model_short_id, display_name, description)
 ANTHROPIC_MODELS: List[Tuple[str, str, str]] = [
@@ -51,7 +55,31 @@ _PROVIDER_DISPLAY: Dict[str, str] = {
     "anthropic": "Anthropic",
     "openai": "OpenAI",
     "google": "Google",
+    "openai_compat": "OpenAI-Compatible",
 }
+
+
+async def _discover_openai_compat_models(
+    base_url: str, api_key: Optional[str]
+) -> List[str]:
+    """Fetch model ids from an OpenAI-compatible server's ``/models`` endpoint.
+
+    Raises on connectivity / HTTP error so the caller can preserve existing
+    rows rather than wiping them on a transient outage.
+    """
+    url = f"{base_url.rstrip('/')}/models"
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    async with httpx.AsyncClient(timeout=_DISCOVERY_TIMEOUT_SECONDS) as client:
+        resp = await client.get(url, headers=headers)
+    resp.raise_for_status()
+    data = resp.json()
+    items = data.get("data") if isinstance(data, dict) else data
+    ids: List[str] = []
+    for m in items or []:
+        mid = (m or {}).get("id") if isinstance(m, dict) else None
+        if mid:
+            ids.append(str(mid))
+    return ids
 
 
 async def sync_cloud_models_to_db(db) -> int:
@@ -68,12 +96,17 @@ async def sync_cloud_models_to_db(db) -> int:
     models_coll = db["models"]
 
     # Map provider_type -> connected boolean for everything in the table.
+    # Also stash the openai_compat row config (base_url/api_key) for dynamic
+    # model discovery below.
     connected_types: Dict[str, bool] = {}
+    openai_compat_cfg: Optional[Dict[str, Any]] = None
     async for row in providers_coll.find({}):
         ptype = row.get("provider_type")
         if not ptype:
             continue
         connected_types[ptype] = bool(row.get("connected", False))
+        if ptype == "openai_compat":
+            openai_compat_cfg = dict(row.get("config") or {})
 
     seeded = 0
     desired_ids: set = set()
@@ -108,9 +141,53 @@ async def sync_cloud_models_to_db(db) -> int:
                 logger.info("Registered cloud model: %s", doc_id)
             seeded += 1
 
+    # Dynamic discovery for openai_compat — model ids come from the server's
+    # own /v1/models, not a static catalog. Gate on the provider row existing
+    # (not the `connected` flag): discovery validates connectivity itself, and
+    # a freshly-saved provider hasn't been marked connected yet.
+    if openai_compat_cfg:
+        base_url = openai_compat_cfg.get("base_url") or ""
+        api_key = openai_compat_cfg.get("api_key") or None
+        discovered: Optional[List[str]] = None
+        if base_url:
+            try:
+                discovered = await _discover_openai_compat_models(base_url, api_key)
+            except Exception as exc:
+                logger.warning(
+                    "openai_compat model discovery failed (%s) — preserving existing rows",
+                    exc,
+                )
+        if discovered is not None:
+            for short_id in discovered:
+                doc_id = f"openai_compat:{short_id}"
+                desired_ids.add(doc_id)
+                doc = _build_model_doc(
+                    doc_id=doc_id,
+                    provider_type="openai_compat",
+                    short_id=short_id,
+                    display_name=short_id,
+                    description="OpenAI-compatible server",
+                )
+                existing = await models_coll.find_one({"_id": doc_id})
+                if existing:
+                    await models_coll.find_one_and_update({"_id": doc_id}, {"$set": doc})
+                else:
+                    doc_to_insert = dict(doc)
+                    doc_to_insert["_id"] = doc_id
+                    await models_coll.insert_one(doc_to_insert)
+                    logger.info("Registered openai_compat model: %s", doc_id)
+                seeded += 1
+        else:
+            # Discovery unavailable: keep whatever openai_compat rows exist so a
+            # transient outage doesn't wipe the user's model list.
+            async for row in models_coll.find({}):
+                rid = row.get("_id") or row.get("id") or ""
+                if isinstance(rid, str) and rid.startswith("openai_compat:"):
+                    desired_ids.add(rid)
+
     # Remove stale cloud model rows: any row whose _id starts with a known
     # cloud prefix but no longer corresponds to a connected provider.
-    known_prefixes = tuple(f"{p}:" for p in _PROVIDER_CATALOGS)
+    known_prefixes = tuple(f"{p}:" for p in _PROVIDER_CATALOGS) + ("openai_compat:",)
     async for stale in models_coll.find({}):
         stale_id = stale.get("_id") or stale.get("id") or ""
         if not isinstance(stale_id, str):

--- a/backend/services/cloud_model_seeder.py
+++ b/backend/services/cloud_model_seeder.py
@@ -95,16 +95,17 @@ async def sync_cloud_models_to_db(db) -> int:
     providers_coll = db["cloud_providers"]
     models_coll = db["models"]
 
-    # Map provider_type -> connected boolean for everything in the table.
-    # Also stash the openai_compat row config (base_url/api_key) for dynamic
-    # model discovery below.
-    connected_types: Dict[str, bool] = {}
+    # Capture each provider's saved config so we can seed based on the
+    # presence of the required credential (api_key), not on the `connected`
+    # probe flag — which isn't set on Save, so gating on it left valid keys
+    # with no selectable models.
+    provider_cfgs: Dict[str, Dict[str, Any]] = {}
     openai_compat_cfg: Optional[Dict[str, Any]] = None
     async for row in providers_coll.find({}):
         ptype = row.get("provider_type")
         if not ptype:
             continue
-        connected_types[ptype] = bool(row.get("connected", False))
+        provider_cfgs[ptype] = dict(row.get("config") or {})
         if ptype == "openai_compat":
             openai_compat_cfg = dict(row.get("config") or {})
 
@@ -112,9 +113,11 @@ async def sync_cloud_models_to_db(db) -> int:
     desired_ids: set = set()
 
     for ptype, catalog in _PROVIDER_CATALOGS.items():
-        if not connected_types.get(ptype):
-            # Not connected — skip seeding, fall through to stale cleanup below
-            # so previously-seeded rows for a disconnected provider are removed.
+        cfg = provider_cfgs.get(ptype)
+        # Static-catalog providers (anthropic/openai/google) need an api_key.
+        # No row or no key → skip seeding (stale cleanup below removes any
+        # previously-seeded rows for a now-removed provider).
+        if not cfg or not cfg.get("api_key"):
             continue
 
         for short_id, display_name, description in catalog:

--- a/backend/services/cloud_model_seeder.py
+++ b/backend/services/cloud_model_seeder.py
@@ -18,6 +18,7 @@ so saved keys produce model entries immediately.
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any, Dict, List, Optional, Tuple
 
 import httpx
@@ -25,6 +26,31 @@ import httpx
 logger = logging.getLogger(__name__)
 
 _DISCOVERY_TIMEOUT_SECONDS = 10.0
+
+OPENAI_BASE_URL = "https://api.openai.com/v1"
+
+# Curated chat-model filter for OpenAI's /v1/models (it returns 100+ ids incl.
+# tts / transcribe / audio / image / embedding / moderation / instruct /
+# search variants and dated snapshots). Keep current general-purpose chat
+# models; collapse dated snapshots to their base alias (gpt-4o, not
+# gpt-4o-2024-05-13).
+_CHAT_PREFIXES = ("gpt-", "o1", "o3", "o4", "chatgpt")
+_NON_CHAT_SUBSTRINGS = (
+    "tts", "transcribe", "audio", "realtime", "image", "embedding", "embed",
+    "moderation", "instruct", "search", "whisper", "dall", "-edit",
+)
+_DATE_SNAPSHOT = re.compile(r"-\d{4}-\d{2}-\d{2}$|-\d{4}$")
+
+
+def _is_current_chat_model(model_id: str) -> bool:
+    low = model_id.lower()
+    if not low.startswith(_CHAT_PREFIXES):
+        return False
+    if any(s in low for s in _NON_CHAT_SUBSTRINGS):
+        return False
+    if _DATE_SNAPSHOT.search(low):  # drop dated snapshots, keep base aliases
+        return False
+    return True
 
 # (model_short_id, display_name, description)
 ANTHROPIC_MODELS: List[Tuple[str, str, str]] = [
@@ -120,7 +146,25 @@ async def sync_cloud_models_to_db(db) -> int:
         if not cfg or not cfg.get("api_key"):
             continue
 
-        for short_id, display_name, description in catalog:
+        # OpenAI: discover the account's live models (filtered to current chat
+        # models) so the list never rots (e.g. o1-preview being removed). Fall
+        # back to the static catalog if discovery fails or returns nothing.
+        entries = catalog
+        if ptype == "openai":
+            try:
+                ids = await _discover_openai_compat_models(
+                    OPENAI_BASE_URL, cfg.get("api_key")
+                )
+                chat_ids = sorted(i for i in ids if _is_current_chat_model(i))
+                if chat_ids:
+                    entries = [(i, i, "OpenAI") for i in chat_ids]
+                    logger.info("OpenAI: discovered %d chat models", len(chat_ids))
+            except Exception as exc:
+                logger.warning(
+                    "OpenAI model discovery failed (%s) — using static catalog", exc
+                )
+
+        for short_id, display_name, description in entries:
             doc_id = f"{ptype}:{short_id}"
             desired_ids.add(doc_id)
             doc = _build_model_doc(

--- a/backend/services/cloud_provider_service.py
+++ b/backend/services/cloud_provider_service.py
@@ -90,25 +90,26 @@ class CloudProviderService:
             # Merge non-masked values onto existing config so partial updates work.
             merged = dict(existing.get("config") or {})
             merged.update(merged_config)
-            updated = await self.repo.update(
+            saved = await self.repo.update(
                 existing.get("provider_id") or existing.get("id") or existing.get("_id"),
                 {
                     "display_name": display_name,
                     "config": merged,
                 },
+            ) or existing
+        else:
+            saved = await self.repo.create(
+                provider_type=ptype,
+                display_name=display_name,
+                config=merged_config,
             )
-            self.invalidate_cache(ptype)
-            await self._sync_cloud_models_safe()
-            return CloudProviderResponse.from_row(updated or existing)
 
-        row = await self.repo.create(
-            provider_type=ptype,
-            display_name=display_name,
-            config=merged_config,
-        )
         self.invalidate_cache(ptype)
+        # Seed this provider's models on Save (the seeder gates on the saved
+        # config having the required credential, not on a network probe — so
+        # models become selectable immediately without blocking the save).
         await self._sync_cloud_models_safe()
-        return CloudProviderResponse.from_row(row)
+        return CloudProviderResponse.from_row(saved)
 
     async def update(
         self, provider_id: str, payload: CloudProviderUpdate
@@ -145,6 +146,8 @@ class CloudProviderService:
             self.invalidate_cache(existing.get("provider_type"))
         else:
             self.invalidate_cache()
+        # Remove this provider's seeded model rows now that it's gone.
+        await self._sync_cloud_models_safe()
 
     # ------------------------------------------------------------------
     # Credentials lookup (used by inference paths)
@@ -235,6 +238,10 @@ class CloudProviderService:
             result.ok,
             result.error,
         )
+        # Connection state changed — refresh the seeded model rows so a now-
+        # connected provider's models become selectable immediately.
+        self.invalidate_cache(ptype)
+        await self._sync_cloud_models_safe()
         return result
 
 

--- a/backend/services/cloud_provider_service.py
+++ b/backend/services/cloud_provider_service.py
@@ -212,6 +212,8 @@ class CloudProviderService:
                 ok, error = await _probe_bedrock(cfg)
             elif provider_type == CloudProviderType.OLLAMA.value:
                 ok, error = await _probe_ollama(cfg)
+            elif provider_type == CloudProviderType.OPENAI_COMPAT.value:
+                ok, error = await _probe_openai(cfg, require_key=False)
             else:
                 ok, error = False, f"Unsupported provider type: {provider_type!r}"
         except Exception as exc:  # safety net
@@ -268,22 +270,31 @@ async def _probe_anthropic(cfg: Dict[str, Any]):
         return False, _short_error(exc)
 
 
-async def _probe_openai(cfg: Dict[str, Any]):
+async def _probe_openai(cfg: Dict[str, Any], *, require_key: bool = True):
+    """Probe an OpenAI(-compatible) server via GET ``{base_url}/models``.
+
+    For real OpenAI ``require_key=True`` and ``base_url`` defaults to
+    ``https://api.openai.com/v1``. For a custom OpenAI-compatible server
+    (``openai_compat``) the key is optional and ``base_url`` comes from config.
+    """
     api_key = cfg.get("api_key") or ""
-    if not api_key:
+    base_url = (cfg.get("base_url") or "https://api.openai.com/v1").rstrip("/")
+    if require_key and not api_key:
         return False, "Missing api_key"
-    headers = {"Authorization": f"Bearer {api_key}"}
+    headers = {}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
     try:
         async with httpx.AsyncClient(timeout=PROBE_TIMEOUT_SECONDS) as client:
-            resp = await client.get(
-                "https://api.openai.com/v1/models",
-                headers=headers,
-            )
+            resp = await client.get(f"{base_url}/models", headers=headers)
         if 200 <= resp.status_code < 300:
             return True, None
         return False, _extract_error_message(resp, default=f"HTTP {resp.status_code}")
     except httpx.HTTPError as exc:
-        return False, _short_error(exc)
+        return False, (
+            f"Could not reach {base_url} ({_short_error(exc)})"
+            if not require_key else _short_error(exc)
+        )
 
 
 async def _probe_google(cfg: Dict[str, Any]):
@@ -368,6 +379,7 @@ def _default_display_name(provider_type: str) -> str:
         "google": "Google AI",
         "bedrock": "AWS Bedrock",
         "ollama": "Ollama (Local)",
+        "openai_compat": "OpenAI-Compatible",
     }.get(provider_type, provider_type.title())
 
 

--- a/backend/services/crew_orchestrator.py
+++ b/backend/services/crew_orchestrator.py
@@ -642,6 +642,15 @@ class CrewOrchestrator:
             # Ollama model selected — do NOT fall through to Claude/Bedrock.
             return await self._invoke_via_ollama(agent_cfg, prompt, model_id)
 
+        # Cloud providers that route through the unified model_dispatcher
+        # (direct provider APIs using saved keys / base_url). Anthropic stays on
+        # the Claude SDK path below (works without a saved cloud key).
+        if model_id and any(
+            model_id.lower().startswith(p)
+            for p in ("openai:", "openai_compat:", "google:")
+        ):
+            return await self._invoke_via_dispatcher(agent_cfg, prompt, model_id)
+
         if CLAUDE_SDK_AVAILABLE:
             try:
                 return await self._invoke_via_claude_sdk(agent_cfg, prompt)
@@ -731,6 +740,43 @@ class CrewOrchestrator:
         tokens_used = usage.get("total_tokens", 0)
         logger.info(
             f"Crew agent '{agent_name}' completed via Ollama (tokens={tokens_used})"
+        )
+        return {"output": output, "tokens_used": tokens_used, "cost": 0.0}
+
+    async def _invoke_via_dispatcher(
+        self, agent_cfg: Dict[str, Any], prompt: str, model_id: str
+    ) -> Dict[str, Any]:
+        """Invoke an agent via the unified model_dispatcher (cloud providers).
+
+        Routes openai / openai_compat / google models through their direct
+        provider APIs using credentials saved in Settings -> AI Providers.
+        """
+        from database import get_database
+        from services.model_dispatcher import stream_chat
+
+        agent_name = agent_cfg.get("name", "Agent")
+        system_prompt = await self._resolve_instructions(agent_cfg)
+
+        messages: List[Dict[str, str]] = []
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+        messages.append({"role": "user", "content": prompt})
+
+        logger.info(f"Running crew agent '{agent_name}' via dispatcher: {model_id}")
+
+        db = await get_database()
+        parts: List[str] = []
+        usage: Dict[str, Any] = {}
+        async for evt in stream_chat(model_id, messages, db=db, max_tokens=4096):
+            if evt.get("type") == "delta":
+                parts.append(evt.get("content", ""))
+            elif evt.get("type") == "done":
+                usage = evt.get("usage", {})
+
+        output = "".join(parts)
+        tokens_used = usage.get("total_tokens", 0)
+        logger.info(
+            f"Crew agent '{agent_name}' completed via dispatcher (tokens={tokens_used})"
         )
         return {"output": output, "tokens_used": tokens_used, "cost": 0.0}
 

--- a/backend/services/crew_orchestrator.py
+++ b/backend/services/crew_orchestrator.py
@@ -774,11 +774,20 @@ class CrewOrchestrator:
                 usage = evt.get("usage", {})
 
         output = "".join(parts)
-        tokens_used = usage.get("total_tokens", 0)
+        prompt_tokens = int(usage.get("prompt_tokens", 0) or 0)
+        completion_tokens = int(usage.get("completion_tokens", 0) or 0)
+        tokens_used = usage.get("total_tokens", 0) or (prompt_tokens + completion_tokens)
+
+        # Best-effort cost from a maintained price table (providers don't return
+        # cost). Unknown models → 0.0 (tokens still shown).
+        from services.model_pricing import estimate_cost
+        cost = estimate_cost(model_id, prompt_tokens, completion_tokens)
+
         logger.info(
-            f"Crew agent '{agent_name}' completed via dispatcher (tokens={tokens_used})"
+            f"Crew agent '{agent_name}' completed via dispatcher "
+            f"(tokens={tokens_used}, cost=${cost:.4f})"
         )
-        return {"output": output, "tokens_used": tokens_used, "cost": 0.0}
+        return {"output": output, "tokens_used": tokens_used, "cost": cost}
 
     async def _resolve_instructions(self, agent_cfg: Dict[str, Any]) -> str:
         """Resolve agent instructions, falling back to library agent if instructions are too short."""

--- a/backend/services/model_dispatcher.py
+++ b/backend/services/model_dispatcher.py
@@ -29,7 +29,10 @@ from typing import Any, AsyncIterator, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
-_KNOWN_PREFIXES = ("anthropic", "google", "openai", "bedrock", "ollama")
+# Order matters: "openai_compat" must come before "openai" so an
+# "openai_compat:<model>" id isn't mis-parsed (though the ":" separator
+# already prevents overlap, keep it explicit and unambiguous).
+_KNOWN_PREFIXES = ("anthropic", "google", "openai_compat", "openai", "bedrock", "ollama")
 
 DEFAULT_SENTINEL = "__DEFAULT__"
 
@@ -175,6 +178,15 @@ async def _cloud_stream(
         from services.ollama_direct_service import OllamaDirectService
         svc = OllamaDirectService()
         return svc.stream_chat(messages, base_url=base_url, **kwargs)
+
+    if provider == "openai_compat":
+        base_url = creds.get("base_url")
+        if not base_url:
+            raise ProviderUnavailable("OpenAI-compatible base_url not configured")
+        api_key = creds.get("api_key") or None  # optional for keyless servers
+        from services.openai_direct_service import OpenAIDirectService
+        svc = OpenAIDirectService()
+        return svc.stream_chat(messages, api_key=api_key, base_url=base_url, **kwargs)
 
     raise ProviderUnavailable(f"Unknown provider: {provider!r}")
 

--- a/backend/services/model_pricing.py
+++ b/backend/services/model_pricing.py
@@ -1,0 +1,74 @@
+"""
+Best-effort cost estimation for cloud LLM calls.
+
+Providers don't return a per-call price and there's no pricing API, so this is
+a maintained table of approximate USD rates per 1,000,000 tokens (input,
+output). Matched by longest model-id prefix. Unknown models (and local /
+self-hosted ones) return 0.0 — the caller shows tokens but no dollar figure.
+
+⚠️ Rates approximate (2026) and WILL drift — update when providers change
+pricing or when a new family ships (e.g. gpt-5.x below is a placeholder until
+official pricing is known).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+# model-id prefix -> (input $/1M, output $/1M)
+_PRICES: Dict[str, Tuple[float, float]] = {
+    # OpenAI
+    "gpt-4o-mini": (0.15, 0.60),
+    "gpt-4o": (2.50, 10.00),
+    "gpt-4.1-nano": (0.10, 0.40),
+    "gpt-4.1-mini": (0.40, 1.60),
+    "gpt-4.1": (2.00, 8.00),
+    "gpt-4-turbo": (10.00, 30.00),
+    "gpt-4": (30.00, 60.00),
+    "gpt-3.5-turbo": (0.50, 1.50),
+    "o1-mini": (1.10, 4.40),
+    "o1": (15.00, 60.00),
+    "o3-mini": (1.10, 4.40),
+    "o3": (2.00, 8.00),
+    "o4-mini": (1.10, 4.40),
+    # gpt-5.x: placeholder — official pricing unknown; update when published.
+    # Left out deliberately so it reads as "unknown" ($0) rather than wrong.
+
+    # Anthropic
+    "claude-opus": (15.00, 75.00),
+    "claude-sonnet": (3.00, 15.00),
+    "claude-haiku": (0.80, 4.00),
+
+    # Google
+    "gemini-1.5-pro": (1.25, 5.00),
+    "gemini-2.0-pro": (1.25, 5.00),
+    "gemini-2.0-flash": (0.10, 0.40),
+    "gemini-1.5-flash": (0.075, 0.30),
+}
+
+
+def _strip_prefix(model_id: str) -> str:
+    for p in ("openai_compat:", "openai:", "anthropic:", "google:", "bedrock:"):
+        if model_id.startswith(p):
+            return model_id[len(p):]
+    return model_id
+
+
+def estimate_cost(model_id: str, prompt_tokens: int, completion_tokens: int) -> float:
+    """Approximate USD cost for a call. Returns 0.0 when the model is unknown
+    (or local / self-hosted), in which case the UI shows tokens only."""
+    name = _strip_prefix(model_id or "").lower()
+    # Longest matching prefix wins (so gpt-4o-mini beats gpt-4o).
+    match = max(
+        (p for p in _PRICES if name.startswith(p)),
+        key=len,
+        default=None,
+    )
+    if not match:
+        return 0.0
+    in_rate, out_rate = _PRICES[match]
+    return round(
+        (prompt_tokens / 1_000_000) * in_rate
+        + (completion_tokens / 1_000_000) * out_rate,
+        6,
+    )

--- a/backend/services/openai_direct_service.py
+++ b/backend/services/openai_direct_service.py
@@ -16,12 +16,29 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
-OPENAI_API_URL = "https://api.openai.com/v1/chat/completions"
+DEFAULT_BASE_URL = "https://api.openai.com/v1"
+OPENAI_API_URL = f"{DEFAULT_BASE_URL}/chat/completions"
 DEFAULT_TIMEOUT_SECONDS = 60.0
 
 
+def _chat_url(base_url: Optional[str]) -> str:
+    """Resolve the chat-completions endpoint from a ``/v1`` base URL.
+
+    Defaults to OpenAI. A custom OpenAI-compatible server (vLLM, LM Studio,
+    llama.cpp server, TGI, Ollama's ``/v1``, …) passes its own base URL.
+    """
+    return f"{(base_url or DEFAULT_BASE_URL).rstrip('/')}/chat/completions"
+
+
+def _strip_provider_prefix(model_id: str) -> str:
+    for prefix in ("openai_compat:", "openai:"):
+        if model_id.startswith(prefix):
+            return model_id[len(prefix):]
+    return model_id
+
+
 class OpenAIDirectService:
-    """Thin async client for the OpenAI Chat Completions API."""
+    """Thin async client for the OpenAI (or OpenAI-compatible) Chat API."""
 
     async def call_model(
         self,
@@ -31,26 +48,19 @@ class OpenAIDirectService:
         max_tokens: int = 2048,
         temperature: float = 0.7,
         api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
     ) -> Dict[str, Any]:
-        if not api_key:
-            raise RuntimeError(
-                "OpenAI API key not configured. "
-                "Save one in Settings → Models → Cloud."
-            )
-
-        clean_model = model_id
-        if clean_model.startswith("openai:"):
-            clean_model = clean_model[len("openai:"):]
+        # api_key is optional for OpenAI-compatible servers (often keyless).
+        clean_model = _strip_provider_prefix(model_id)
 
         messages = []
         if system_prompt:
             messages.append({"role": "system", "content": system_prompt})
         messages.append({"role": "user", "content": prompt})
 
-        headers = {
-            "Authorization": f"Bearer {api_key}",
-            "Content-Type": "application/json",
-        }
+        headers = {"Content-Type": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
         body: Dict[str, Any] = {
             "model": clean_model,
             "messages": messages,
@@ -61,7 +71,7 @@ class OpenAIDirectService:
         try:
             async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT_SECONDS) as client:
                 resp = await client.post(
-                    OPENAI_API_URL, headers=headers, json=body
+                    _chat_url(base_url), headers=headers, json=body
                 )
         except httpx.HTTPError as exc:
             raise RuntimeError(f"OpenAI API call failed: {exc}") from exc
@@ -113,29 +123,28 @@ class OpenAIDirectService:
         messages: List[Dict[str, Any]],
         *,
         model_id: str,
-        api_key: str,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
         max_tokens: int = 2048,
         temperature: float = 0.7,
         top_p: float = 1.0,
         stop: Optional[List[str]] = None,
     ) -> AsyncIterator[Dict[str, Any]]:
-        """Stream tokens from the OpenAI Chat Completions SSE endpoint.
+        """Stream tokens from an OpenAI(-compatible) Chat Completions SSE endpoint.
 
-        Yields normalized event dicts:
+        ``api_key`` is optional (OpenAI-compatible servers are often keyless);
+        ``base_url`` defaults to OpenAI. Yields normalized event dicts:
         - ``{"type": "delta", "content": "..."}``
         - ``{"type": "done", "finish_reason": "...", "usage": {...}}``
         """
-        clean_model = model_id
-        if clean_model.startswith("openai:"):
-            clean_model = clean_model[len("openai:"):]
+        clean_model = _strip_provider_prefix(model_id)
 
         # Pass messages as-is — OpenAI format already matches.
         openai_messages = [{"role": m["role"], "content": m["content"]} for m in messages]
 
-        headers = {
-            "Authorization": f"Bearer {api_key}",
-            "Content-Type": "application/json",
-        }
+        headers = {"Content-Type": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
         body: Dict[str, Any] = {
             "model": clean_model,
             "messages": openai_messages,
@@ -153,7 +162,7 @@ class OpenAIDirectService:
         output_tokens = 0
 
         async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT_SECONDS * 2) as client:
-            async with client.stream("POST", OPENAI_API_URL, headers=headers, json=body) as resp:
+            async with client.stream("POST", _chat_url(base_url), headers=headers, json=body) as resp:
                 if resp.status_code < 200 or resp.status_code >= 300:
                     body_text = await resp.aread()
                     raise RuntimeError(

--- a/backend/services/openai_direct_service.py
+++ b/backend/services/openai_direct_service.py
@@ -30,6 +30,43 @@ def _chat_url(base_url: Optional[str]) -> str:
     return f"{(base_url or DEFAULT_BASE_URL).rstrip('/')}/chat/completions"
 
 
+def _is_openai_host(base_url: Optional[str]) -> bool:
+    """True when talking to OpenAI itself (not a custom compatible server)."""
+    return base_url is None or "api.openai.com" in base_url
+
+
+def _token_limit_field(base_url: Optional[str]) -> str:
+    """OpenAI's newer models (gpt-5.x, o-series) reject ``max_tokens`` and
+    require ``max_completion_tokens``; it's accepted by their older models too.
+    OpenAI-compatible servers (Ollama/vLLM/LM Studio/TGI) still expect the
+    classic ``max_tokens``.
+    """
+    return "max_completion_tokens" if _is_openai_host(base_url) else "max_tokens"
+
+
+def _is_reasoning_model(clean_model: str) -> bool:
+    """OpenAI reasoning / gpt-5 models only accept default sampling params."""
+    m = clean_model.lower()
+    return m.startswith(("o1", "o3", "o4", "gpt-5"))
+
+
+def _sampling_params(
+    base_url: Optional[str], clean_model: str, temperature: float, top_p: Optional[float]
+) -> Dict[str, Any]:
+    """Sampling params that the target model accepts.
+
+    OpenAI reasoning/gpt-5 models reject non-default ``temperature``/``top_p``
+    (HTTP 400), so omit them and let the API use its defaults. Everything else
+    (gpt-4o, and all OpenAI-compatible servers) takes them as usual.
+    """
+    if _is_openai_host(base_url) and _is_reasoning_model(clean_model):
+        return {}
+    params: Dict[str, Any] = {"temperature": temperature}
+    if top_p is not None:
+        params["top_p"] = top_p
+    return params
+
+
 def _strip_provider_prefix(model_id: str) -> str:
     for prefix in ("openai_compat:", "openai:"):
         if model_id.startswith(prefix):
@@ -95,8 +132,8 @@ class OpenAIDirectService:
         body: Dict[str, Any] = {
             "model": clean_model,
             "messages": messages,
-            "max_tokens": max_tokens,
-            "temperature": temperature,
+            _token_limit_field(base_url): max_tokens,
+            **_sampling_params(base_url, clean_model, temperature, None),
         }
 
         try:
@@ -177,9 +214,8 @@ class OpenAIDirectService:
         body: Dict[str, Any] = {
             "model": clean_model,
             "messages": openai_messages,
-            "max_tokens": max_tokens,
-            "temperature": temperature,
-            "top_p": top_p,
+            _token_limit_field(base_url): max_tokens,
+            **_sampling_params(base_url, clean_model, temperature, top_p),
             "stream": True,
             "stream_options": {"include_usage": True},
         }

--- a/backend/services/openai_direct_service.py
+++ b/backend/services/openai_direct_service.py
@@ -105,6 +105,40 @@ def _friendly_error(status_code: int, raw_body: bytes | str) -> str:
     return msg
 
 
+_MAX_PARAM_RETRIES = 3
+
+
+def _detect_param_fix(error_text: str, body: Dict[str, Any]) -> Optional[str]:
+    """Inspect a 400 body for a known parameter incompatibility we can adapt to.
+
+    Makes the client host-agnostic: the same gpt-5/o-series quirks that affect
+    api.openai.com also apply to any OpenAI-compatible proxy that fronts those
+    models (Azure OpenAI, LiteLLM, OpenRouter, …). Returns an action key or
+    None.
+    """
+    t = error_text.lower()
+    if "max_completion_tokens" in t and "max_tokens" in body:
+        return "swap_max_tokens"
+    if "temperature" in t and "temperature" in body and (
+        "unsupported" in t or "does not support" in t or "only the default" in t
+    ):
+        return "drop_temperature"
+    if "top_p" in t and "top_p" in body and (
+        "unsupported" in t or "does not support" in t or "only the default" in t
+    ):
+        return "drop_top_p"
+    return None
+
+
+def _apply_param_fix(body: Dict[str, Any], fix: str) -> None:
+    if fix == "swap_max_tokens":
+        body["max_completion_tokens"] = body.pop("max_tokens")
+    elif fix == "drop_temperature":
+        body.pop("temperature", None)
+    elif fix == "drop_top_p":
+        body.pop("top_p", None)
+
+
 class OpenAIDirectService:
     """Thin async client for the OpenAI (or OpenAI-compatible) Chat API."""
 
@@ -136,21 +170,26 @@ class OpenAIDirectService:
             **_sampling_params(base_url, clean_model, temperature, None),
         }
 
+        url = _chat_url(base_url)
+        resp = None
         try:
             async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT_SECONDS) as client:
-                resp = await client.post(
-                    _chat_url(base_url), headers=headers, json=body
-                )
+                for _ in range(_MAX_PARAM_RETRIES + 1):
+                    resp = await client.post(url, headers=headers, json=body)
+                    if 200 <= resp.status_code < 300:
+                        break
+                    # Adapt to a known parameter incompatibility and retry.
+                    fix = _detect_param_fix(resp.text or "", body)
+                    if not fix:
+                        break
+                    _apply_param_fix(body, fix)
         except httpx.HTTPError as exc:
             raise RuntimeError(f"OpenAI API call failed: {exc}") from exc
 
-        if resp.status_code < 200 or resp.status_code >= 300:
-            body_text = ""
-            try:
-                body_text = resp.text
-            except Exception:
-                pass
-            raise RuntimeError(f"OpenAI: {_friendly_error(resp.status_code, body_text)}")
+        if resp is None or resp.status_code < 200 or resp.status_code >= 300:
+            body_text = (resp.text if resp is not None else "") or ""
+            status = resp.status_code if resp is not None else 0
+            raise RuntimeError(f"OpenAI: {_friendly_error(status, body_text)}")
 
         try:
             data = resp.json()
@@ -226,37 +265,52 @@ class OpenAIDirectService:
         input_tokens = 0
         output_tokens = 0
 
+        url = _chat_url(base_url)
         async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT_SECONDS * 2) as client:
-            async with client.stream("POST", _chat_url(base_url), headers=headers, json=body) as resp:
-                if resp.status_code < 200 or resp.status_code >= 300:
-                    body_text = await resp.aread()
-                    raise RuntimeError(f"OpenAI: {_friendly_error(resp.status_code, body_text)}")
-                async for line in resp.aiter_lines():
-                    line = line.strip()
-                    if not line or not line.startswith("data:"):
-                        continue
-                    raw = line[5:].strip()
-                    if raw == "[DONE]":
-                        break
-                    try:
-                        evt = json.loads(raw)
-                    except json.JSONDecodeError:
-                        continue
+            attempt = 0
+            while True:
+                async with client.stream("POST", url, headers=headers, json=body) as resp:
+                    if resp.status_code < 200 or resp.status_code >= 300:
+                        err_body = await resp.aread()
+                        fix = (
+                            _detect_param_fix(err_body.decode(errors="replace"), body)
+                            if attempt < _MAX_PARAM_RETRIES
+                            else None
+                        )
+                        if fix:
+                            _apply_param_fix(body, fix)
+                            attempt += 1
+                            continue  # re-open the stream with adjusted params
+                        raise RuntimeError(
+                            f"OpenAI: {_friendly_error(resp.status_code, err_body)}"
+                        )
+                    async for line in resp.aiter_lines():
+                        line = line.strip()
+                        if not line or not line.startswith("data:"):
+                            continue
+                        raw = line[5:].strip()
+                        if raw == "[DONE]":
+                            break
+                        try:
+                            evt = json.loads(raw)
+                        except json.JSONDecodeError:
+                            continue
 
-                    # Usage chunk (stream_options)
-                    usage = evt.get("usage")
-                    if usage:
-                        input_tokens = int(usage.get("prompt_tokens") or 0)
-                        output_tokens = int(usage.get("completion_tokens") or 0)
+                        # Usage chunk (stream_options)
+                        usage = evt.get("usage")
+                        if usage:
+                            input_tokens = int(usage.get("prompt_tokens") or 0)
+                            output_tokens = int(usage.get("completion_tokens") or 0)
 
-                    choices = evt.get("choices") or []
-                    if choices:
-                        first = choices[0] or {}
-                        finish_reason = first.get("finish_reason") or finish_reason
-                        delta = first.get("delta") or {}
-                        text = delta.get("content") or ""
-                        if text:
-                            yield {"type": "delta", "content": text}
+                        choices = evt.get("choices") or []
+                        if choices:
+                            first = choices[0] or {}
+                            finish_reason = first.get("finish_reason") or finish_reason
+                            delta = first.get("delta") or {}
+                            text = delta.get("content") or ""
+                            if text:
+                                yield {"type": "delta", "content": text}
+                break  # streamed successfully
 
         yield {
             "type": "done",

--- a/backend/services/openai_direct_service.py
+++ b/backend/services/openai_direct_service.py
@@ -37,6 +37,37 @@ def _strip_provider_prefix(model_id: str) -> str:
     return model_id
 
 
+_STATUS_HINTS = {
+    401: "invalid or missing API key",
+    403: "access denied for this model/key",
+    404: "model not found or no access",
+    429: "rate limit or quota exceeded — check your plan/billing",
+}
+
+
+def _friendly_error(status_code: int, raw_body: bytes | str) -> str:
+    """Turn an OpenAI(-compatible) error response into a readable message."""
+    text = raw_body.decode(errors="replace") if isinstance(raw_body, bytes) else (raw_body or "")
+    detail = ""
+    try:
+        body = json.loads(text)
+        err = body.get("error") if isinstance(body, dict) else None
+        if isinstance(err, dict):
+            detail = str(err.get("message") or "")
+        elif isinstance(err, str):
+            detail = err
+    except Exception:
+        detail = text[:200]
+    hint = _STATUS_HINTS.get(status_code)
+    parts = [f"HTTP {status_code}"]
+    if hint:
+        parts.append(hint)
+    msg = " — ".join(parts)
+    if detail:
+        msg = f"{msg}: {detail}"
+    return msg
+
+
 class OpenAIDirectService:
     """Thin async client for the OpenAI (or OpenAI-compatible) Chat API."""
 
@@ -82,9 +113,7 @@ class OpenAIDirectService:
                 body_text = resp.text
             except Exception:
                 pass
-            raise RuntimeError(
-                f"OpenAI API call failed: HTTP {resp.status_code} {body_text[:500]}"
-            )
+            raise RuntimeError(f"OpenAI: {_friendly_error(resp.status_code, body_text)}")
 
         try:
             data = resp.json()
@@ -165,9 +194,7 @@ class OpenAIDirectService:
             async with client.stream("POST", _chat_url(base_url), headers=headers, json=body) as resp:
                 if resp.status_code < 200 or resp.status_code >= 300:
                     body_text = await resp.aread()
-                    raise RuntimeError(
-                        f"OpenAI stream failed: HTTP {resp.status_code} {body_text[:500].decode(errors='replace')}"
-                    )
+                    raise RuntimeError(f"OpenAI: {_friendly_error(resp.status_code, body_text)}")
                 async for line in resp.aiter_lines():
                     line = line.strip()
                     if not line or not line.startswith("data:"):

--- a/backend/tests/test_approval_send_ordering.py
+++ b/backend/tests/test_approval_send_ordering.py
@@ -1,0 +1,58 @@
+"""Approve-and-send must post BEFORE marking approved.
+
+A failed channel send (e.g. an expired LinkedIn token) must leave the approval
+``pending`` to retry — not falsely mark it ``approved`` while nothing was posted.
+"""
+
+import pytest
+
+from services.approval_service import ApprovalService
+
+
+def _pending(approval_id="a1"):
+    return {
+        "_id": approval_id,
+        "approval_id": approval_id,
+        "status": "pending",
+        "type": "crew_publish",
+        "channel_type": "linkedin",
+        "channel_id": "c1",
+        "draft_response": "hello world",
+        "content": "hello world",
+    }
+
+
+@pytest.mark.asyncio
+async def test_failed_send_leaves_pending(db_proxy, monkeypatch):
+    svc = ApprovalService(db_proxy)
+    await db_proxy["approval_queue"].insert_one(_pending("a1"))
+
+    async def boom(*_a, **_k):
+        raise RuntimeError("EXPIRED_ACCESS_TOKEN")
+
+    monkeypatch.setattr(svc, "_send_via_channel", boom)
+
+    with pytest.raises(RuntimeError):
+        await svc.approve_and_send("a1")
+
+    doc = await db_proxy["approval_queue"].find_one({"approval_id": "a1"})
+    assert doc["status"] == "pending"  # not falsely approved
+
+
+@pytest.mark.asyncio
+async def test_successful_send_marks_approved(db_proxy, monkeypatch):
+    svc = ApprovalService(db_proxy)
+    await db_proxy["approval_queue"].insert_one(_pending("a2"))
+
+    sent = {}
+
+    async def ok(channel_type, channel_id, text):
+        sent["text"] = text
+
+    monkeypatch.setattr(svc, "_send_via_channel", ok)
+
+    await svc.approve_and_send("a2")
+
+    doc = await db_proxy["approval_queue"].find_one({"approval_id": "a2"})
+    assert doc["status"] == "approved"
+    assert sent["text"] == "hello world"

--- a/backend/tests/test_cloud_keys_plumbing.py
+++ b/backend/tests/test_cloud_keys_plumbing.py
@@ -233,7 +233,10 @@ async def test_sync_cloud_models_skips_when_no_provider(db_proxy):
 
 
 @pytest.mark.asyncio
-async def test_sync_cloud_models_skips_when_provider_disconnected(db_proxy):
+async def test_sync_cloud_models_seeds_when_credential_present(db_proxy):
+    """A saved provider with its required credential seeds its models even if
+    `connected` is False — the connected flag isn't set on Save, so gating on
+    it left valid keys with no selectable models."""
     from services.cloud_model_seeder import sync_cloud_models_to_db
 
     await db_proxy["cloud_providers"].insert_one(
@@ -243,6 +246,25 @@ async def test_sync_cloud_models_skips_when_provider_disconnected(db_proxy):
             "display_name": "Anthropic",
             "connected": False,
             "config": {"api_key": "sk-ant-x"},
+        }
+    )
+
+    seeded = await sync_cloud_models_to_db(db_proxy)
+    assert seeded > 0
+
+
+@pytest.mark.asyncio
+async def test_sync_cloud_models_skips_when_credential_missing(db_proxy):
+    """No api_key → nothing to seed (provider not really configured)."""
+    from services.cloud_model_seeder import sync_cloud_models_to_db
+
+    await db_proxy["cloud_providers"].insert_one(
+        {
+            "provider_id": "p1",
+            "provider_type": "anthropic",
+            "display_name": "Anthropic",
+            "connected": False,
+            "config": {},
         }
     )
 

--- a/backend/tests/test_model_pricing.py
+++ b/backend/tests/test_model_pricing.py
@@ -1,0 +1,34 @@
+"""Tests for best-effort cloud cost estimation."""
+
+from services.model_pricing import estimate_cost
+
+
+def test_gpt_4o_cost():
+    # 2.50/1M input + 10/1M output → 1000 in + 1000 out = 0.0025 + 0.01
+    assert estimate_cost("openai:gpt-4o", 1000, 1000) == 0.0125
+
+
+def test_longest_prefix_wins():
+    # gpt-4o-mini must not be priced as gpt-4o
+    assert estimate_cost("openai:gpt-4o-mini", 1000, 1000) == round(
+        0.15 / 1000 + 0.60 / 1000, 6
+    )
+
+
+def test_anthropic_and_google_priced():
+    assert estimate_cost("anthropic:claude-sonnet-4-6", 1000, 1000) == round(
+        3.0 / 1000 + 15.0 / 1000, 6
+    )
+    assert estimate_cost("google:gemini-2.0-flash", 1000, 1000) > 0
+
+
+def test_unknown_and_local_are_zero():
+    # gpt-5.x has no published pricing yet → unknown → 0
+    assert estimate_cost("openai:gpt-5.5", 1000, 1000) == 0.0
+    # local / self-hosted → free
+    assert estimate_cost("local:gemma4-e4b", 1000, 1000) == 0.0
+    assert estimate_cost("ollama:qwen3-coder:480b-cloud", 1000, 1000) == 0.0
+
+
+def test_zero_tokens_zero_cost():
+    assert estimate_cost("openai:gpt-4o", 0, 0) == 0.0

--- a/backend/tests/test_openai_compat_provider.py
+++ b/backend/tests/test_openai_compat_provider.py
@@ -62,3 +62,32 @@ def test_openai_compat_api_key_optional():
 
 def test_openai_compat_api_key_is_sensitive():
     assert "api_key" in SENSITIVE_KEYS[CloudProviderType.OPENAI_COMPAT.value]
+
+
+# ---------------------------------------------------------------------------
+# OpenAI dynamic-discovery chat-model filter
+# ---------------------------------------------------------------------------
+
+def test_chat_model_filter_keeps_current_chat_models():
+    from services.cloud_model_seeder import _is_current_chat_model
+
+    for keep in ("gpt-4o", "gpt-4o-mini", "gpt-4.1", "o1", "o3-mini", "gpt-5.1", "chatgpt-4o-latest"):
+        assert _is_current_chat_model(keep), keep
+
+
+def test_chat_model_filter_drops_noise_and_snapshots():
+    from services.cloud_model_seeder import _is_current_chat_model
+
+    for drop in (
+        "gpt-4o-mini-tts",
+        "gpt-4o-mini-transcribe",
+        "gpt-3.5-turbo-instruct",
+        "gpt-4o-mini-search-preview",
+        "text-embedding-3-large",
+        "chatgpt-image-latest",
+        "gpt-4o-2024-05-13",   # dated snapshot collapses to gpt-4o
+        "gpt-3.5-turbo-0125",  # dated snapshot
+        "whisper-1",
+        "dall-e-3",
+    ):
+        assert not _is_current_chat_model(drop), drop

--- a/backend/tests/test_openai_compat_provider.py
+++ b/backend/tests/test_openai_compat_provider.py
@@ -1,0 +1,64 @@
+"""Unit tests for the openai_compat provider plumbing.
+
+Covers the pure-function pieces: provider-prefix parsing, endpoint resolution,
+config validation, and sensitive-key masking. End-to-end inference is exercised
+manually against a live OpenAI-compatible server (e.g. Ollama's /v1).
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from services.model_dispatcher import _parse_provider
+from services.openai_direct_service import (
+    _chat_url,
+    _strip_provider_prefix,
+    DEFAULT_BASE_URL,
+)
+from models.cloud_provider_models import (
+    CloudProviderCreate,
+    CloudProviderType,
+    SENSITIVE_KEYS,
+)
+
+
+def test_parse_provider_recognizes_openai_compat():
+    provider, clean = _parse_provider("openai_compat:qwen3-coder:480b-cloud")
+    assert provider == "openai_compat"
+    # only the leading "openai_compat:" is stripped; model ids may contain ":"
+    assert clean == "qwen3-coder:480b-cloud"
+
+
+def test_parse_provider_openai_not_shadowed_by_compat():
+    assert _parse_provider("openai:gpt-4o") == ("openai", "gpt-4o")
+
+
+def test_chat_url_defaults_to_openai():
+    assert _chat_url(None) == f"{DEFAULT_BASE_URL}/chat/completions"
+
+
+def test_chat_url_uses_custom_base_and_trims_slash():
+    assert _chat_url("http://localhost:8000/v1/") == "http://localhost:8000/v1/chat/completions"
+
+
+def test_strip_provider_prefix_handles_both_prefixes():
+    assert _strip_provider_prefix("openai_compat:foo") == "foo"
+    assert _strip_provider_prefix("openai:gpt-4o") == "gpt-4o"
+    assert _strip_provider_prefix("gpt-4o") == "gpt-4o"
+
+
+def test_openai_compat_requires_base_url():
+    with pytest.raises(ValidationError):
+        CloudProviderCreate(provider_type="openai_compat", config={})
+
+
+def test_openai_compat_api_key_optional():
+    # base_url present, no api_key → valid (keyless servers are allowed)
+    req = CloudProviderCreate(
+        provider_type="openai_compat",
+        config={"base_url": "http://localhost:8000/v1"},
+    )
+    assert req.provider_type == CloudProviderType.OPENAI_COMPAT
+
+
+def test_openai_compat_api_key_is_sensitive():
+    assert "api_key" in SENSITIVE_KEYS[CloudProviderType.OPENAI_COMPAT.value]

--- a/backend/tests/test_openai_compat_provider.py
+++ b/backend/tests/test_openai_compat_provider.py
@@ -75,6 +75,36 @@ def test_chat_model_filter_keeps_current_chat_models():
         assert _is_current_chat_model(keep), keep
 
 
+def test_token_field_openai_vs_compat():
+    from services.openai_direct_service import _token_limit_field
+    # OpenAI host → newer models need max_completion_tokens
+    assert _token_limit_field(None) == "max_completion_tokens"
+    assert _token_limit_field("https://api.openai.com/v1") == "max_completion_tokens"
+    # Compat servers still use classic max_tokens
+    assert _token_limit_field("http://localhost:11434/v1") == "max_tokens"
+    assert _token_limit_field("http://localhost:8000/v1") == "max_tokens"
+
+
+def test_reasoning_models_detected():
+    from services.openai_direct_service import _is_reasoning_model
+    for m in ("gpt-5.5", "gpt-5", "o1", "o1-pro", "o3-mini", "o4-mini"):
+        assert _is_reasoning_model(m), m
+    for m in ("gpt-4o", "gpt-4.1", "gpt-3.5-turbo"):
+        assert not _is_reasoning_model(m), m
+
+
+def test_sampling_params_omitted_for_openai_reasoning_models():
+    from services.openai_direct_service import _sampling_params
+    # OpenAI reasoning model → no temperature/top_p (API rejects non-defaults)
+    assert _sampling_params(None, "gpt-5.5", 0.7, 1.0) == {}
+    # OpenAI non-reasoning → params kept
+    assert _sampling_params(None, "gpt-4o", 0.7, 1.0) == {"temperature": 0.7, "top_p": 1.0}
+    # Compat server with a gpt-5-ish name → still send params (not OpenAI host)
+    assert _sampling_params("http://localhost:8000/v1", "gpt-5.5", 0.7, 1.0) == {
+        "temperature": 0.7, "top_p": 1.0,
+    }
+
+
 def test_chat_model_filter_drops_noise_and_snapshots():
     from services.cloud_model_seeder import _is_current_chat_model
 

--- a/frontend/src/data/provider-guides.ts
+++ b/frontend/src/data/provider-guides.ts
@@ -10,7 +10,7 @@ export interface ProviderGuideField {
 }
 
 export interface ProviderGuide {
-  id: "anthropic" | "openai" | "google" | "bedrock" | "ollama";
+  id: "anthropic" | "openai" | "google" | "bedrock" | "ollama" | "openai_compat";
   name: string;
   /** One-liner displayed under the name. */
   short_blurb: string;
@@ -156,6 +156,36 @@ export const PROVIDER_GUIDES: readonly ProviderGuide[] = [
         label: "Ollama URL",
         type: "text",
         placeholder: "http://localhost:11434",
+        required: false,
+      },
+    ],
+  },
+  {
+    id: "openai_compat",
+    name: "OpenAI-Compatible",
+    short_blurb: "Any server with an OpenAI /v1 API — vLLM, LM Studio, llama.cpp, TGI",
+    dashboard_url: "https://platform.openai.com/docs/api-reference",
+    steps: [
+      "Start your OpenAI-compatible server (vLLM, LM Studio, llama.cpp server, TGI, …)",
+      "Find its base URL — it must end in /v1 (e.g. http://localhost:8000/v1)",
+      "Confirm with `curl http://your-server:8000/v1/models`",
+      "Paste the base URL below (and an API key only if your server requires one)",
+      "Save — models are auto-discovered from the server's /v1/models",
+    ],
+    cost_copy: "Depends on your server. Self-hosted is free; hosted endpoints bill per their pricing.",
+    fields: [
+      {
+        key: "base_url",
+        label: "Base URL",
+        type: "text",
+        placeholder: "http://localhost:8000/v1",
+        required: true,
+      },
+      {
+        key: "api_key",
+        label: "API Key (optional)",
+        type: "password",
+        placeholder: "sk-… (leave blank if your server is keyless)",
         required: false,
       },
     ],

--- a/frontend/src/lib/api/cloud-providers-client.ts
+++ b/frontend/src/lib/api/cloud-providers-client.ts
@@ -9,7 +9,8 @@ export type CloudProviderType =
   | "openai"
   | "google"
   | "bedrock"
-  | "ollama";
+  | "ollama"
+  | "openai_compat";
 
 export interface CloudProvider {
   provider_id: string;

--- a/frontend/src/lib/api/crews-client.ts
+++ b/frontend/src/lib/api/crews-client.ts
@@ -119,7 +119,39 @@ export interface CrewRunStep {
   completed_at?: string;
   output?: string;
   tokens_used?: number;
+  cost_usd?: number;
   duration_seconds?: number;
+}
+
+// The backend returns agents/total_cost_usd/duration_ms; the UI reads
+// steps/cost_usd/duration_seconds/phases. Normalize the run shape so the
+// progress panel and run list show tokens, cost, steps, and progress.
+function normalizeRun(raw: Record<string, unknown>): CrewRun {
+  const r = (raw ?? {}) as Record<string, any>;
+  const rawSteps = (r.steps ?? r.agents ?? []) as Record<string, any>[];
+  const steps: CrewRunStep[] = rawSteps.map((a) => ({
+    agent_id: a.agent_id,
+    agent_name: a.agent_name ?? a.name,
+    status: a.status,
+    started_at: a.started_at,
+    completed_at: a.completed_at,
+    output: a.output,
+    tokens_used: a.tokens_used,
+    cost_usd: a.cost_usd,
+    duration_seconds: a.duration_seconds,
+  }));
+  const completed = steps.filter((s) => s.status === "completed").length;
+  return {
+    ...(r as CrewRun),
+    steps,
+    cost_usd: r.cost_usd ?? r.total_cost_usd,
+    total_tokens: r.total_tokens,
+    duration_seconds:
+      r.duration_seconds ??
+      (r.duration_ms != null ? Math.round(r.duration_ms / 1000) : undefined),
+    phases_completed: r.phases_completed ?? completed,
+    total_phases: r.total_phases ?? steps.length,
+  };
 }
 
 export interface LibraryAgent {
@@ -194,7 +226,8 @@ export const crewsApi = {
       : `/crews/runs?limit=${limit}`;
     const { data } = await api.get<{ runs?: CrewRun[]; data?: { runs?: CrewRun[] } }>(path);
     const raw = data as Record<string, unknown>;
-    return (raw.runs ?? (raw.data as Record<string, unknown>)?.runs ?? []) as CrewRun[];
+    const runs = (raw.runs ?? (raw.data as Record<string, unknown>)?.runs ?? []) as Record<string, unknown>[];
+    return runs.map(normalizeRun);
   },
 
   startRun: async (
@@ -213,8 +246,8 @@ export const crewsApi = {
 
   getRun: async (_crewId: string, runId: string): Promise<CrewRun> => {
     // Backend route is /crews/runs/{run_id} (no crew_id in path)
-    const { data } = await api.get<{ data: CrewRun }>(`/crews/runs/${runId}`);
-    return (data as { data: CrewRun }).data;
+    const { data } = await api.get<{ data: Record<string, unknown> }>(`/crews/runs/${runId}`);
+    return normalizeRun((data as { data: Record<string, unknown> }).data);
   },
 
   cancelRun: async (_crewId: string, runId: string): Promise<void> => {

--- a/frontend/src/routes/settings.tsx
+++ b/frontend/src/routes/settings.tsx
@@ -297,8 +297,8 @@ function AIProvidersTab() {
 
   const handleSave = useCallback(
     async (providerType: string, config: Record<string, string>) => {
-      // Ollama isn't tracked as a CloudProvider in the backend; skip saving.
-      if (providerType === "ollama") return;
+      // Ollama and OpenAI-compatible are now first-class provider rows too, so
+      // a typed base_url persists (was previously dropped for Ollama).
       await saveCloudProvider({ provider_type: providerType as CloudProviderType, config });
       await refresh();
     },


### PR DESCRIPTION
## What
Adds a generic **OpenAI-compatible** provider and wires **all** cloud models through the unified `model_dispatcher` in the three user-facing surfaces. Closes #45. Closes #48.

### openai_compat provider (foundation)
- `CloudProviderType.OPENAI_COMPAT` — `base_url` required, `api_key` optional.
- `openai_direct_service`: parameterized `base_url` + optional key.
- `cloud_provider_service`: `/models` probe with base_url; `openai_compat` test branch.
- `model_dispatcher`: prefix + routing.
- `cloud_model_seeder`: **dynamic** model discovery via the server's `/v1/models` (preserve-on-failure).
- Frontend: provider guide (base_url + optional key) + client type.

### Surface unification (the part that makes cloud actually usable)
Before this, the desktop **Chat** and **Crews** only routed local + ollama (+ Bedrock/Claude-SDK); OpenAI/Anthropic/Google/openai_compat fell into `BedrockModel` or were rejected by the `/v1` catalog.
- `ai_chat.py`: dispatcher intercept for openai/openai_compat/anthropic/google.
- `crew_orchestrator.py`: `_invoke_via_dispatcher` for openai/openai_compat/google.
- `openai_compat.py` `/v1` router: recognize `openai_compat:` models.

This fixes **OpenAI, Anthropic, and Google** in Chat + Crews too — not just openai_compat.

## Verified
End-to-end against Ollama's `/v1`: Test/Save/discovery, `/v1/chat/completions`, desktop Chat, and a 3-step Crew all produce real output. 146 backend tests pass; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Also folds in **PR #52** (GPU-offload docs sync for local models — CLAUDE.md + README) via cherry-pick, so this is one consolidated merge.