### PR TITLE
chore: release v1.0.0-17

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "contextuai-solo",
   "description": "ContextuAI Solo — Personal AI Desktop App",
   "private": true,
-  "version": "1.0.0-16",
+  "version": "1.0.0-17",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contextuai-solo"
-version = "1.0.0-16"
+version = "1.0.0-17"
 description = "ContextuAI Solo - Your AI Business Assistant"
 authors = ["ContextuAI"]
 edition = "2021"

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "ContextuAI Solo",
-  "version": "1.0.0-16",
+  "version": "1.0.0-17",
   "identifier": "com.contextuai.solo",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Release **v1.0.0-17**.

Bumps the three version files (package.json, tauri.conf.json, Cargo.toml) in sync. Squash-merging to `main` triggers the Release workflow (tag → build all platforms → publish + latest.json).

### What ships in this release
- **OpenAI-compatible provider** (`openai_compat`) — connect any `/v1` server (vLLM/LM Studio/llama.cpp/TGI/Ollama/Azure/LiteLLM/OpenRouter); closes #45, #48.
- **Cloud routing unified on the dispatcher** across Chat + Crews + `/v1` — OpenAI/Anthropic/Google now actually work in the desktop app.
- **Live OpenAI model discovery** (filtered, no rot) + models seed on Save.
- **gpt-5/o-series** param handling + adaptive retry; clear cloud errors.
- **Crew run cost** shown + Run Progress panel field fixes.
- **Approvals** post before marking approved (verified: LinkedIn personal post 201).
- Release workflow **Create Tag 404 fix** (this is the first release to test it end-to-end).
- GPU-offload docs + TODO sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)