### PR TITLE
feat(providers): Anthropic live discovery + crew routing + probe/param fixes

### DIFF
--- a/backend/services/anthropic_direct_service.py
+++ b/backend/services/anthropic_direct_service.py
@@ -22,6 +22,28 @@ logger = logging.getLogger(__name__)
 ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
 ANTHROPIC_VERSION = "2023-06-01"
 DEFAULT_TIMEOUT_SECONDS = 60.0
+_MAX_PARAM_RETRIES = 3
+
+
+def _detect_anthropic_param_fix(error_text: str, body: dict) -> Optional[str]:
+    """Detect a param incompatibility we can adapt to and retry.
+
+    Claude models differ on sampling params: some reject temperature+top_p
+    together ("use only one"), and the newest (e.g. sonnet-5) deprecate
+    temperature entirely. Adapt at runtime instead of hardcoding per-model.
+    """
+    t = error_text.lower()
+    if "temperature" in t and "temperature" in body and (
+        "deprecat" in t or "not supported" in t or "unsupported" in t
+        or "cannot both" in t or "only one" in t
+    ):
+        return "drop_temperature"
+    if "top_p" in t and "top_p" in body and (
+        "deprecat" in t or "not supported" in t or "unsupported" in t
+        or "cannot both" in t or "only one" in t
+    ):
+        return "drop_top_p"
+    return None
 
 
 class AnthropicDirectService:
@@ -163,40 +185,53 @@ class AnthropicDirectService:
         finish_reason = "stop"
 
         async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT_SECONDS * 2) as client:
-            async with client.stream("POST", ANTHROPIC_API_URL, headers=headers, json=body) as resp:
-                if resp.status_code < 200 or resp.status_code >= 300:
-                    body_text = await resp.aread()
-                    raise RuntimeError(
-                        f"Anthropic stream failed: HTTP {resp.status_code} {body_text[:500].decode(errors='replace')}"
-                    )
-                async for line in resp.aiter_lines():
-                    line = line.strip()
-                    if not line or not line.startswith("data:"):
-                        continue
-                    raw = line[5:].strip()
-                    if raw == "[DONE]":
-                        break
-                    try:
-                        evt = json.loads(raw)
-                    except json.JSONDecodeError:
-                        continue
+            attempt = 0
+            while True:
+                async with client.stream("POST", ANTHROPIC_API_URL, headers=headers, json=body) as resp:
+                    if resp.status_code < 200 or resp.status_code >= 300:
+                        err_body = await resp.aread()
+                        fix = (
+                            _detect_anthropic_param_fix(err_body.decode(errors="replace"), body)
+                            if attempt < _MAX_PARAM_RETRIES
+                            else None
+                        )
+                        if fix:
+                            body.pop("temperature" if fix == "drop_temperature" else "top_p", None)
+                            attempt += 1
+                            continue  # retry with adjusted params
+                        raise RuntimeError(
+                            f"Anthropic stream failed: HTTP {resp.status_code} "
+                            f"{err_body[:500].decode(errors='replace')}"
+                        )
+                    async for line in resp.aiter_lines():
+                        line = line.strip()
+                        if not line or not line.startswith("data:"):
+                            continue
+                        raw = line[5:].strip()
+                        if raw == "[DONE]":
+                            break
+                        try:
+                            evt = json.loads(raw)
+                        except json.JSONDecodeError:
+                            continue
 
-                    evt_type = evt.get("type", "")
-                    if evt_type == "message_start":
-                        usage = evt.get("message", {}).get("usage") or {}
-                        input_tokens = int(usage.get("input_tokens") or 0)
-                    elif evt_type == "content_block_delta":
-                        delta = evt.get("delta") or {}
-                        if delta.get("type") == "text_delta":
-                            text = delta.get("text") or ""
-                            if text:
-                                yield {"type": "delta", "content": text}
-                    elif evt_type == "message_delta":
-                        usage = evt.get("usage") or {}
-                        output_tokens = int(usage.get("output_tokens") or 0)
-                        finish_reason = evt.get("delta", {}).get("stop_reason") or "stop"
-                    elif evt_type == "message_stop":
-                        break
+                        evt_type = evt.get("type", "")
+                        if evt_type == "message_start":
+                            usage = evt.get("message", {}).get("usage") or {}
+                            input_tokens = int(usage.get("input_tokens") or 0)
+                        elif evt_type == "content_block_delta":
+                            delta = evt.get("delta") or {}
+                            if delta.get("type") == "text_delta":
+                                text = delta.get("text") or ""
+                                if text:
+                                    yield {"type": "delta", "content": text}
+                        elif evt_type == "message_delta":
+                            usage = evt.get("usage") or {}
+                            output_tokens = int(usage.get("output_tokens") or 0)
+                            finish_reason = evt.get("delta", {}).get("stop_reason") or "stop"
+                        elif evt_type == "message_stop":
+                            break
+                break  # streamed successfully
 
         yield {
             "type": "done",

--- a/backend/services/anthropic_direct_service.py
+++ b/backend/services/anthropic_direct_service.py
@@ -144,11 +144,12 @@ class AnthropicDirectService:
             "anthropic-version": ANTHROPIC_VERSION,
             "content-type": "application/json",
         }
+        # Anthropic rejects temperature + top_p together ("use only one") on
+        # newer models — send just temperature (the primary control).
         body: Dict[str, Any] = {
             "model": clean_model,
             "max_tokens": max_tokens,
             "temperature": temperature,
-            "top_p": top_p,
             "stream": True,
             "messages": user_messages,
         }

--- a/backend/services/cloud_model_seeder.py
+++ b/backend/services/cloud_model_seeder.py
@@ -108,6 +108,33 @@ async def _discover_openai_compat_models(
     return ids
 
 
+ANTHROPIC_MODELS_URL = "https://api.anthropic.com/v1/models"
+ANTHROPIC_VERSION = "2023-06-01"
+
+
+async def _discover_anthropic_models(api_key: str) -> List[Tuple[str, str]]:
+    """Fetch (id, display_name) for the account's Claude models.
+
+    GET https://api.anthropic.com/v1/models with x-api-key + anthropic-version.
+    Response: ``{"data": [{"id": "claude-…", "display_name": "…"}], ...}``.
+    Raises on error so the caller can fall back to the static catalog.
+    """
+    headers = {"x-api-key": api_key, "anthropic-version": ANTHROPIC_VERSION}
+    async with httpx.AsyncClient(timeout=_DISCOVERY_TIMEOUT_SECONDS) as client:
+        resp = await client.get(ANTHROPIC_MODELS_URL, headers=headers)
+    resp.raise_for_status()
+    data = resp.json()
+    items = data.get("data") if isinstance(data, dict) else data
+    out: List[Tuple[str, str]] = []
+    for m in items or []:
+        if not isinstance(m, dict):
+            continue
+        mid = m.get("id")
+        if mid:
+            out.append((str(mid), str(m.get("display_name") or mid)))
+    return out
+
+
 async def sync_cloud_models_to_db(db) -> int:
     """Upsert cloud model rows for each connected provider.
 
@@ -162,6 +189,18 @@ async def sync_cloud_models_to_db(db) -> int:
             except Exception as exc:
                 logger.warning(
                     "OpenAI model discovery failed (%s) — using static catalog", exc
+                )
+        elif ptype == "anthropic":
+            # Live discovery so the Claude list never rots. Anthropic's list is
+            # small and all chat models, so no filtering needed.
+            try:
+                pairs = await _discover_anthropic_models(cfg.get("api_key"))
+                if pairs:
+                    entries = [(mid, name, "Anthropic") for mid, name in pairs]
+                    logger.info("Anthropic: discovered %d models", len(pairs))
+            except Exception as exc:
+                logger.warning(
+                    "Anthropic model discovery failed (%s) — using static catalog", exc
                 )
 
         for short_id, display_name, description in entries:

--- a/backend/services/cloud_provider_service.py
+++ b/backend/services/cloud_provider_service.py
@@ -250,25 +250,17 @@ class CloudProviderService:
 # ---------------------------------------------------------------------------
 
 async def _probe_anthropic(cfg: Dict[str, Any]):
+    # Validate via GET /v1/models (no hardcoded model-name dependency — the old
+    # /v1/messages ping used claude-3-haiku-20240307, which Anthropic retired,
+    # so the probe failed for every valid key).
     api_key = cfg.get("api_key") or ""
     if not api_key:
         return False, "Missing api_key"
-    headers = {
-        "x-api-key": api_key,
-        "anthropic-version": "2023-06-01",
-        "content-type": "application/json",
-    }
-    body = {
-        "model": "claude-3-haiku-20240307",
-        "max_tokens": 1,
-        "messages": [{"role": "user", "content": "ping"}],
-    }
+    headers = {"x-api-key": api_key, "anthropic-version": "2023-06-01"}
     try:
         async with httpx.AsyncClient(timeout=PROBE_TIMEOUT_SECONDS) as client:
-            resp = await client.post(
-                "https://api.anthropic.com/v1/messages",
-                headers=headers,
-                json=body,
+            resp = await client.get(
+                "https://api.anthropic.com/v1/models", headers=headers
             )
         if 200 <= resp.status_code < 300:
             return True, None

--- a/backend/services/crew_orchestrator.py
+++ b/backend/services/crew_orchestrator.py
@@ -643,11 +643,13 @@ class CrewOrchestrator:
             return await self._invoke_via_ollama(agent_cfg, prompt, model_id)
 
         # Cloud providers that route through the unified model_dispatcher
-        # (direct provider APIs using saved keys / base_url). Anthropic stays on
-        # the Claude SDK path below (works without a saved cloud key).
+        # (direct provider APIs using saved keys / base_url). An explicitly
+        # selected `anthropic:` model uses the saved key + that exact model +
+        # accurate cost; a crew with NO model selected falls through to the
+        # Claude SDK path below (native tool-use, its own auth).
         if model_id and any(
             model_id.lower().startswith(p)
-            for p in ("openai:", "openai_compat:", "google:")
+            for p in ("openai:", "openai_compat:", "anthropic:", "google:")
         ):
             return await self._invoke_via_dispatcher(agent_cfg, prompt, model_id)
 

--- a/backend/tests/test_anthropic_discovery.py
+++ b/backend/tests/test_anthropic_discovery.py
@@ -1,0 +1,57 @@
+"""Anthropic live model discovery in the cloud model seeder."""
+
+import pytest
+
+from services.cloud_model_seeder import sync_cloud_models_to_db
+
+
+async def _ids(db):
+    out = []
+    async for m in db["models"].find({}):
+        out.append(m.get("_id") or m.get("id"))
+    return out
+
+
+@pytest.mark.asyncio
+async def test_anthropic_discovery_seeds_live_models(db_proxy, monkeypatch):
+    await db_proxy["cloud_providers"].insert_one({
+        "provider_id": "a1",
+        "provider_type": "anthropic",
+        "config": {"api_key": "sk-ant-x"},
+    })
+
+    async def fake_disc(api_key):
+        assert api_key == "sk-ant-x"
+        return [("claude-opus-4-9", "Claude Opus 4.9"), ("claude-sonnet-4-7", "Claude Sonnet 4.7")]
+
+    monkeypatch.setattr(
+        "services.cloud_model_seeder._discover_anthropic_models", fake_disc
+    )
+
+    await sync_cloud_models_to_db(db_proxy)
+    ids = await _ids(db_proxy)
+    assert "anthropic:claude-opus-4-9" in ids
+    assert "anthropic:claude-sonnet-4-7" in ids
+    # the static-catalog id must NOT be seeded when discovery succeeds
+    assert "anthropic:claude-opus-4-7" not in ids
+
+
+@pytest.mark.asyncio
+async def test_anthropic_discovery_falls_back_to_static(db_proxy, monkeypatch):
+    await db_proxy["cloud_providers"].insert_one({
+        "provider_id": "a1",
+        "provider_type": "anthropic",
+        "config": {"api_key": "sk-ant-x"},
+    })
+
+    async def boom(api_key):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(
+        "services.cloud_model_seeder._discover_anthropic_models", boom
+    )
+
+    await sync_cloud_models_to_db(db_proxy)
+    ids = await _ids(db_proxy)
+    # static catalog is used on discovery failure
+    assert any(str(i).startswith("anthropic:claude-") for i in ids)


### PR DESCRIPTION
Gives **Anthropic** the same treatment as OpenAI — live model discovery, crew routing via the dispatcher, and two real bug fixes found testing with a live key.

## What's in it
- **Live model discovery** — Claude models pulled from Anthropic's `/v1/models` (x-api-key + anthropic-version) so the list never rots; falls back to the static catalog on failure.
- **Crew routing** — an explicitly-selected `anthropic:` model runs through the dispatcher (saved key + exact model + accurate cost); crews with no model selected still use the Claude SDK (native tool-use).
- **Fix: connection probe** — `_probe_anthropic` pinged a retired hardcoded model (`claude-3-haiku-20240307`), so Test Connection failed for every valid key. Now uses `GET /v1/models`.
- **Fix: temperature+top_p** — newer Claude models reject both together ("use only one"); the streaming client now sends just `temperature`.

## Verified live (real key)
Test Connection ✅ · discovery (10 Claude models incl. opus-4-8/sonnet-5) ✅ · chat stream + non-stream ✅ · 3-step crew on claude-haiku-4-5 with **cost $0.0071** ✅ · error surfacing (bogus model → 404) ✅.

Tests: `test_anthropic_discovery.py` (seeds live models + fallback). No frontend changes (Anthropic card already exists).

Advances CR-2 (cloud endpoint review): Anthropic now ✅ alongside Ollama/OpenAI/openai_compat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)