### PR TITLE
chore: release v1.0.0-18

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "contextuai-solo",
   "description": "ContextuAI Solo — Personal AI Desktop App",
   "private": true,
-  "version": "1.0.0-17",
+  "version": "1.0.0-18",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contextuai-solo"
-version = "1.0.0-17"
+version = "1.0.0-18"
 description = "ContextuAI Solo - Your AI Business Assistant"
 authors = ["ContextuAI"]
 edition = "2021"

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "ContextuAI Solo",
-  "version": "1.0.0-17",
+  "version": "1.0.0-18",
   "identifier": "com.contextuai.solo",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Release **v1.0.0-18**.

Bumps the three version files (package.json, tauri.conf.json, Cargo.toml) in sync. Squash-merging to `main` triggers the Release workflow (tag → build all platforms → publish + latest.json).

### What ships
- **Anthropic** as a first-class provider — live model discovery (`/v1/models`, no rot), crew routing via the dispatcher (saved key + accurate cost).
- Fixes: connection probe (was pinging a retired model), `temperature`+`top_p` conflict, and **adaptive param retry** so the newest Claude models (sonnet-5, temperature deprecated) just work.
- Verified live end-to-end incl. a Crew that wrote and auto-published a LinkedIn post on sonnet-5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)