### PR TITLE
chore: release v1.0.0-19

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "contextuai-solo",
   "description": "ContextuAI Solo — Personal AI Desktop App",
   "private": true,
-  "version": "1.0.0-17",
+  "version": "1.0.0-19",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contextuai-solo"
-version = "1.0.0-17"
+version = "1.0.0-19"
 description = "ContextuAI Solo - Your AI Business Assistant"
 authors = ["ContextuAI"]
 edition = "2021"

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "ContextuAI Solo",
-  "version": "1.0.0-17",
+  "version": "1.0.0-19",
   "identifier": "com.contextuai.solo",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Release **v1.0.0-19**.

Bumps the three version files (`frontend/package.json`, `frontend/src-tauri/tauri.conf.json`, `frontend/src-tauri/Cargo.toml`) to `1.0.0-19`.

### Ships since v1.0.0-18
- **Google (Gemini) full parity** (#61): live model discovery (18 chat models, non-chat variants filtered), adaptive param retry, unary fallback for streaming-restricted keys, and a provider config-state fix ("Not configured" badge). Verified live: Test/Save, discovery, chat, and a crew run.

Squash-merging this PR (subject `chore: release v1.0.0-19`) auto-triggers the Release workflow → tag → build (Win/macOS/Linux) → publish.