### PR TITLE
feat(memory): SPEC-14 unified memory layer PR-A — store + panel + manual facts

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -48,6 +48,7 @@ from routers.scheduled_jobs import router as scheduled_jobs_router
 from routers.connections import router as connections_router
 from routers.knowledge_base import router as knowledge_base_router
 from routers.personal_docs import router as personal_docs_router
+from routers.memory import router as memory_router
 from routers.automations import router as automations_router
 from routers.cloud_providers import router as cloud_providers_router
 from routers.coder_projects import router as coder_projects_router
@@ -107,6 +108,7 @@ app.include_router(scheduled_jobs_router)
 app.include_router(connections_router)
 app.include_router(knowledge_base_router)
 app.include_router(personal_docs_router)
+app.include_router(memory_router)
 app.include_router(automations_router)
 app.include_router(cloud_providers_router)
 app.include_router(coder_projects_router)

--- a/backend/models/memory_models.py
+++ b/backend/models/memory_models.py
@@ -1,0 +1,114 @@
+"""Pydantic v2 models for the Unified Memory Layer (SPEC-14 PR-A).
+
+PR-A scope: the memory store + manual facts + semantic search + export +
+settings/kill-switch. No automatic extraction (PR-C) and no prompt-injection
+wiring (PR-B) yet — the models here exist to support the manual-fact CRUD
+and the recall/search primitives that PR-B will reuse.
+"""
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+# A memory scope is intentionally kept as a plain string — "global" or
+# "crew:<id>" today, forward-compatible with future scope kinds (e.g.
+# "worker:<id>" per SPEC-18) without a model change. See design doc §3.
+MemoryScope = str
+
+
+def _validate_scope(value: str) -> str:
+    if not (value.startswith("global") or value.startswith("crew:")):
+        raise ValueError('scope must be "global" or start with "crew:"')
+    return value
+
+
+class MemoryFact(BaseModel):
+    """Full read model for a memory fact (embedding vector never exposed)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str = Field(..., alias="_id")
+    scope: MemoryScope = "global"
+    subject: str
+    predicate: str
+    value: str
+    text: str
+    confidence: float = Field(1.0, ge=0.0, le=1.0)
+    status: str = "active"
+    pinned: bool = False
+    source_kind: str = "user"
+    source_id: Optional[str] = None
+    source_label: Optional[str] = None
+    origin: str = "user"
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    last_used_at: Optional[str] = None
+
+
+class MemoryFactCreate(BaseModel):
+    """Manual fact creation — origin is always forced to "user" server-side."""
+
+    subject: str = Field(..., min_length=1, max_length=300)
+    predicate: str = Field(..., min_length=1, max_length=300)
+    value: str = Field(..., min_length=1, max_length=2000)
+    text: Optional[str] = Field(None, max_length=4000)
+    scope: MemoryScope = Field("global", max_length=200)
+
+    @field_validator("scope")
+    @classmethod
+    def _check_scope(cls, v: str) -> str:
+        return _validate_scope(v)
+
+
+class MemoryFactUpdate(BaseModel):
+    subject: Optional[str] = Field(None, min_length=1, max_length=300)
+    predicate: Optional[str] = Field(None, min_length=1, max_length=300)
+    value: Optional[str] = Field(None, min_length=1, max_length=2000)
+    text: Optional[str] = Field(None, max_length=4000)
+    pinned: Optional[bool] = None
+    status: Optional[str] = None
+    scope: Optional[MemoryScope] = None
+    confidence: Optional[float] = Field(None, ge=0.0, le=1.0)
+
+    @field_validator("scope")
+    @classmethod
+    def _check_scope(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        return _validate_scope(v)
+
+    @field_validator("status")
+    @classmethod
+    def _check_status(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        if v not in ("active", "review"):
+            raise ValueError('status must be "active" or "review"')
+        return v
+
+
+class MemoryFactPin(BaseModel):
+    pinned: bool
+
+
+class MemorySearchRequest(BaseModel):
+    query: str = Field(..., min_length=1, max_length=2000)
+    top_k: int = Field(8, ge=1, le=50)
+    scopes: Optional[List[str]] = None
+
+
+class MemorySettings(BaseModel):
+    """Master kill switch + per-surface toggles. Channels default OFF (privacy posture)."""
+
+    enabled: bool = True
+    chat_enabled: bool = True
+    crews_enabled: bool = True
+    channels_enabled: bool = False
+    confidence_threshold: float = Field(0.6, ge=0.0, le=1.0)
+
+
+class MemorySettingsUpdate(BaseModel):
+    enabled: Optional[bool] = None
+    chat_enabled: Optional[bool] = None
+    crews_enabled: Optional[bool] = None
+    channels_enabled: Optional[bool] = None
+    confidence_threshold: Optional[float] = Field(None, ge=0.0, le=1.0)

--- a/backend/repositories/memory_repository.py
+++ b/backend/repositories/memory_repository.py
@@ -1,0 +1,31 @@
+"""Fact persistence — text + optional 384-dim embedding, inline JSON envelope.
+
+Mirrors ``repositories/chunk_repository.py``: a thin ``BaseRepository``
+subclass over a hard-coded collection name. The table auto-creates on first
+write — no migration needed.
+"""
+from typing import Any, Dict, List, Optional
+
+from motor.motor_asyncio import AsyncIOMotorDatabase
+
+from repositories.base_repository import BaseRepository
+
+
+class MemoryRepository(BaseRepository):
+    def __init__(self, db: AsyncIOMotorDatabase):
+        super().__init__(db, "memory_facts")
+
+    async def list_by_scope(
+        self, scopes: List[str], statuses: Optional[List[str]] = None
+    ) -> List[Dict[str, Any]]:
+        """Raw documents (preserves `_id` + `embedding`) for the given scopes."""
+        query: Dict[str, Any] = {"scope": {"$in": scopes}}
+        if statuses:
+            query["status"] = {"$in": statuses}
+        cursor = self.collection.find(query)
+        return await cursor.to_list(length=None)
+
+    async def list_all(self) -> List[Dict[str, Any]]:
+        """Every fact, raw (preserves `_id` + `embedding`)."""
+        cursor = self.collection.find({})
+        return await cursor.to_list(length=None)

--- a/backend/repositories/memory_settings_repository.py
+++ b/backend/repositories/memory_settings_repository.py
@@ -1,0 +1,48 @@
+"""Single-row settings doc for the Unified Memory Layer kill switch + toggles.
+
+There is exactly one settings document, ``_id="default"``. Mirrors the
+KB pattern of talking to ``self.collection`` directly rather than going
+through the generic ``BaseRepository.create``/``update`` helpers, since we
+want full control over the fixed id and a merge-with-defaults read path.
+"""
+from datetime import datetime
+from typing import Any, Dict
+
+from motor.motor_asyncio import AsyncIOMotorDatabase
+
+from repositories.base_repository import BaseRepository
+
+_SETTINGS_ID = "default"
+
+DEFAULT_SETTINGS: Dict[str, Any] = {
+    "enabled": True,
+    "chat_enabled": True,
+    "crews_enabled": True,
+    "channels_enabled": False,
+    "confidence_threshold": 0.6,
+}
+
+
+class MemorySettingsRepository(BaseRepository):
+    def __init__(self, db: AsyncIOMotorDatabase):
+        super().__init__(db, "memory_settings")
+
+    async def get_settings(self) -> Dict[str, Any]:
+        """Return stored settings merged over defaults; defaults alone if absent."""
+        doc = await self.collection.find_one({"_id": _SETTINGS_ID})
+        if not doc:
+            return {"_id": _SETTINGS_ID, **DEFAULT_SETTINGS}
+        return {**DEFAULT_SETTINGS, **doc}
+
+    async def update_settings(self, patch: Dict[str, Any]) -> Dict[str, Any]:
+        current = await self.get_settings()
+        current.update(patch)
+        current["_id"] = _SETTINGS_ID
+        current["updated_at"] = datetime.utcnow().isoformat()
+
+        existing = await self.collection.find_one({"_id": _SETTINGS_ID})
+        if existing:
+            await self.collection.update_one({"_id": _SETTINGS_ID}, {"$set": current})
+        else:
+            await self.collection.insert_one(current)
+        return current

--- a/backend/routers/memory.py
+++ b/backend/routers/memory.py
@@ -1,0 +1,154 @@
+"""Unified Memory Layer REST API (SPEC-14 PR-A).
+
+Endpoints
+---------
+- GET    /api/v1/memory/facts?scope=&status=&q=   — list / text-or-semantic search facts
+- POST   /api/v1/memory/facts                     — add a manual fact
+- GET    /api/v1/memory/facts/{id}                — read a fact
+- PUT    /api/v1/memory/facts/{id}                — edit a fact (re-embeds if text changes)
+- DELETE /api/v1/memory/facts/{id}                — delete a fact
+- POST   /api/v1/memory/facts/{id}/pin            — pin/unpin a fact
+- POST   /api/v1/memory/search                    — semantic search (recall primitive)
+- GET    /api/v1/memory/export                    — full JSON export
+- GET    /api/v1/memory/settings                  — kill switch + scope toggles
+- PUT    /api/v1/memory/settings                  — update settings
+
+PR-A scope only: no automatic extraction (PR-C) and no prompt-injection
+wiring (PR-B) — this router only covers the manual store + panel needs.
+"""
+import logging
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from database import get_database
+from models.memory_models import (
+    MemoryFactCreate,
+    MemoryFactPin,
+    MemoryFactUpdate,
+    MemorySearchRequest,
+    MemorySettingsUpdate,
+)
+from repositories.memory_repository import MemoryRepository
+from repositories.memory_settings_repository import MemorySettingsRepository
+from services.memory_service import MemoryService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/memory", tags=["memory"])
+
+
+def _memory_repo(db=Depends(get_database)) -> MemoryRepository:
+    return MemoryRepository(db)
+
+
+def _settings_repo(db=Depends(get_database)) -> MemorySettingsRepository:
+    return MemorySettingsRepository(db)
+
+
+def _memory_service(
+    memory_repo: MemoryRepository = Depends(_memory_repo),
+    settings_repo: MemorySettingsRepository = Depends(_settings_repo),
+) -> MemoryService:
+    return MemoryService(memory_repo, settings_repo)
+
+
+# ---------------------------------------------------------------------------
+# Facts
+# ---------------------------------------------------------------------------
+
+@router.get("/facts")
+async def list_facts(
+    scope: Optional[str] = None,
+    status: Optional[str] = None,
+    q: Optional[str] = None,
+    service: MemoryService = Depends(_memory_service),
+) -> Dict[str, Any]:
+    items = await service.list_facts(scope=scope, status=status, q=q)
+    return {"items": items}
+
+
+@router.post("/facts")
+async def create_fact(
+    payload: MemoryFactCreate, service: MemoryService = Depends(_memory_service)
+) -> Dict[str, Any]:
+    item = await service.add_fact(payload)
+    return {"item": item}
+
+
+@router.get("/facts/{fact_id}")
+async def get_fact(
+    fact_id: str, service: MemoryService = Depends(_memory_service)
+) -> Dict[str, Any]:
+    item = await service.get_fact(fact_id)
+    if not item:
+        raise HTTPException(404, "Fact not found")
+    return {"item": item}
+
+
+@router.put("/facts/{fact_id}")
+async def update_fact(
+    fact_id: str,
+    payload: MemoryFactUpdate,
+    service: MemoryService = Depends(_memory_service),
+) -> Dict[str, Any]:
+    item = await service.update_fact(fact_id, payload)
+    if not item:
+        raise HTTPException(404, "Fact not found")
+    return {"item": item}
+
+
+@router.delete("/facts/{fact_id}")
+async def delete_fact(
+    fact_id: str, service: MemoryService = Depends(_memory_service)
+) -> Dict[str, Any]:
+    existing = await service.get_fact(fact_id)
+    if not existing:
+        raise HTTPException(404, "Fact not found")
+    await service.delete_fact(fact_id)
+    return {"deleted": True}
+
+
+@router.post("/facts/{fact_id}/pin")
+async def pin_fact(
+    fact_id: str,
+    payload: MemoryFactPin,
+    service: MemoryService = Depends(_memory_service),
+) -> Dict[str, Any]:
+    item = await service.set_pinned(fact_id, payload.pinned)
+    if not item:
+        raise HTTPException(404, "Fact not found")
+    return {"item": item}
+
+
+# ---------------------------------------------------------------------------
+# Search / export
+# ---------------------------------------------------------------------------
+
+@router.post("/search")
+async def search_facts(
+    payload: MemorySearchRequest, service: MemoryService = Depends(_memory_service)
+) -> Dict[str, Any]:
+    results: List[Dict[str, Any]] = await service.search(payload)
+    return {"query": payload.query, "items": results}
+
+
+@router.get("/export")
+async def export_facts(service: MemoryService = Depends(_memory_service)) -> Dict[str, Any]:
+    return await service.export_all()
+
+
+# ---------------------------------------------------------------------------
+# Settings
+# ---------------------------------------------------------------------------
+
+@router.get("/settings")
+async def get_settings(service: MemoryService = Depends(_memory_service)) -> Dict[str, Any]:
+    return await service.get_settings()
+
+
+@router.put("/settings")
+async def update_settings(
+    payload: MemorySettingsUpdate, service: MemoryService = Depends(_memory_service)
+) -> Dict[str, Any]:
+    return await service.update_settings(payload)

--- a/backend/services/memory_service.py
+++ b/backend/services/memory_service.py
@@ -1,0 +1,292 @@
+"""Memory service — CRUD, semantic search, and prompt-block formatting for
+the Unified Memory Layer (SPEC-14 PR-A).
+
+PR-A scope only: the store + manual facts + semantic search + export +
+settings. No automatic extraction (PR-C) — facts are added by the user via
+the API. No prompt-injection wiring (PR-B) — `format_memory_block` and
+`search` are implemented now because PR-B reuses them unchanged, but nothing
+in this codebase calls them from the chat/crew paths yet.
+
+Mirrors ``services/rag_service.py``'s embed/store/retrieve pattern: inline
+``"embedding": list[float]`` in the doc, numpy dot-product retrieval.
+"""
+import asyncio
+import logging
+import uuid
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+from models.memory_models import (
+    MemoryFactCreate,
+    MemoryFactUpdate,
+    MemorySearchRequest,
+    MemorySettingsUpdate,
+)
+from repositories.memory_repository import MemoryRepository
+from repositories.memory_settings_repository import MemorySettingsRepository
+from services.embedding_service import embedding_service
+
+logger = logging.getLogger(__name__)
+
+# Cosine-similarity threshold above which two same-subject facts are treated
+# as duplicates. Unused in PR-A (manual facts are never auto-deduped) — PR-C's
+# extraction/dedupe pass wires this up.
+DEDUPE_SIMILARITY = 0.92
+
+DEFAULT_TOP_K = 8
+
+# Editing any of these fields changes the rendered `text`, so the fact needs
+# to be re-embedded.
+_TEXT_FIELDS = ("subject", "predicate", "value", "text")
+
+
+class MemoryService:
+    def __init__(self, memory_repo: MemoryRepository, settings_repo: MemorySettingsRepository):
+        self.memory_repo = memory_repo
+        self.settings_repo = settings_repo
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _normalize(fact: Dict[str, Any]) -> Dict[str, Any]:
+        """Strip the raw embedding vector; ensure both `_id` and `id` are set.
+
+        Facts read via raw `collection.find()` carry `_id`; facts read via
+        the inherited `BaseRepository.get_by_id`/`update` carry `id`
+        (converted from `_id`). Callers (router/tests) shouldn't have to
+        care which path produced the dict.
+        """
+        fact = dict(fact)
+        fact.pop("embedding", None)
+        if "_id" in fact and "id" not in fact:
+            fact["id"] = fact["_id"]
+        elif "id" in fact and "_id" not in fact:
+            fact["_id"] = fact["id"]
+        return fact
+
+    @staticmethod
+    async def _embed(text: str) -> Optional[List[float]]:
+        """Best-effort embed. Returns None if the ONNX model isn't available
+        (missing onnxruntime/tokenizers -> RuntimeError, missing model files
+        -> FileNotFoundError) so callers can still save the fact without a
+        vector — it just won't be eligible for semantic search."""
+        try:
+            return await asyncio.to_thread(embedding_service.embed, text)
+        except (RuntimeError, FileNotFoundError) as e:
+            logger.warning("Embedding unavailable, saving fact without a vector: %s", e)
+            return None
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+
+    async def add_fact(self, data: MemoryFactCreate) -> Dict[str, Any]:
+        text = data.text or f"{data.subject} {data.predicate} {data.value}".strip()
+        vector = await self._embed(text)
+
+        now = datetime.utcnow().isoformat()
+        doc: Dict[str, Any] = {
+            "_id": str(uuid.uuid4()),
+            "scope": data.scope,
+            "subject": data.subject,
+            "predicate": data.predicate,
+            "value": data.value,
+            "text": text,
+            "confidence": 1.0,
+            "status": "active",
+            "pinned": False,
+            "source_kind": "user",
+            "source_id": None,
+            "source_label": None,
+            "origin": "user",
+            "created_at": now,
+            "updated_at": now,
+            "last_used_at": None,
+        }
+        if vector is not None:
+            doc["embedding"] = vector
+
+        await self.memory_repo.collection.insert_one(doc)
+        return self._normalize(doc)
+
+    async def list_facts(
+        self,
+        scope: Optional[str] = None,
+        status: Optional[str] = None,
+        q: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        if q:
+            req = MemorySearchRequest(
+                query=q, top_k=DEFAULT_TOP_K, scopes=[scope] if scope else None
+            )
+            results = await self.search(req)
+            if status:
+                results = [f for f in results if f.get("status") == status]
+            return results
+
+        if scope:
+            facts = await self.memory_repo.list_by_scope(
+                [scope], [status] if status else None
+            )
+        else:
+            facts = await self.memory_repo.list_all()
+            if status:
+                facts = [f for f in facts if f.get("status") == status]
+
+        facts.sort(
+            key=lambda f: (bool(f.get("pinned")), f.get("updated_at") or ""),
+            reverse=True,
+        )
+        return [self._normalize(f) for f in facts]
+
+    async def get_fact(self, fact_id: str) -> Optional[Dict[str, Any]]:
+        fact = await self.memory_repo.get_by_id(fact_id)
+        return self._normalize(fact) if fact else None
+
+    async def update_fact(
+        self, fact_id: str, data: MemoryFactUpdate
+    ) -> Optional[Dict[str, Any]]:
+        existing = await self.memory_repo.get_by_id(fact_id)
+        if not existing:
+            return None
+
+        patch = data.model_dump(exclude_unset=True, exclude_none=True)
+        if not patch:
+            return self._normalize(existing)
+
+        if any(f in patch for f in _TEXT_FIELDS):
+            subject = patch.get("subject", existing.get("subject"))
+            predicate = patch.get("predicate", existing.get("predicate"))
+            value = patch.get("value", existing.get("value"))
+            text = patch.get("text") or f"{subject} {predicate} {value}".strip()
+            patch["text"] = text
+
+            vector = await self._embed(text)
+            if vector is not None:
+                patch["embedding"] = vector
+            else:
+                # Model unavailable — drop any stale vector rather than keep
+                # an embedding that no longer matches the new text.
+                await self.memory_repo.collection.update_one(
+                    {"_id": fact_id}, {"$unset": {"embedding": ""}}
+                )
+
+        updated = await self.memory_repo.update(fact_id, patch)
+        return self._normalize(updated) if updated else None
+
+    async def delete_fact(self, fact_id: str) -> bool:
+        return await self.memory_repo.delete(fact_id)
+
+    async def set_pinned(self, fact_id: str, pinned: bool) -> Optional[Dict[str, Any]]:
+        updated = await self.memory_repo.update(fact_id, {"pinned": pinned})
+        return self._normalize(updated) if updated else None
+
+    # ------------------------------------------------------------------
+    # Recall / search — the primitive PR-B reuses for prompt-build recall
+    # ------------------------------------------------------------------
+
+    async def search(self, req: MemorySearchRequest) -> List[Dict[str, Any]]:
+        """Semantic search over active + pinned facts that have an embedding.
+
+        Bumps `last_used_at` on every returned fact. Gracefully returns []
+        if the embedding model isn't available — search should never raise
+        just because the ONNX model hasn't been downloaded yet.
+        """
+        query = (req.query or "").strip()
+        if not query:
+            return []
+
+        try:
+            q_vec = await asyncio.to_thread(embedding_service.embed, query)
+        except (RuntimeError, FileNotFoundError) as e:
+            logger.warning("Embedding service unavailable — memory search returning no results: %s", e)
+            return []
+
+        scopes = req.scopes or ["global"]
+        top_k = req.top_k or DEFAULT_TOP_K
+
+        all_facts = await self.memory_repo.list_by_scope(scopes, None)
+        candidates = [
+            f
+            for f in all_facts
+            if f.get("embedding") and (f.get("status") == "active" or f.get("pinned"))
+        ]
+        if not candidates:
+            return []
+
+        q = np.asarray(q_vec, dtype=np.float32)
+        emb = np.asarray([f["embedding"] for f in candidates], dtype=np.float32)
+        scores = emb @ q  # cosine for unit vectors
+        order = np.argsort(-scores)[:top_k]
+
+        results: List[Dict[str, Any]] = []
+        used_ids: List[str] = []
+        for idx in order:
+            i = int(idx)
+            f = candidates[i]
+            fact = self._normalize(f)
+            fact["score"] = float(scores[i])
+            results.append(fact)
+            used_ids.append(f["_id"])
+
+        if used_ids:
+            now = datetime.utcnow().isoformat()
+            await self.memory_repo.collection.update_many(
+                {"_id": {"$in": used_ids}}, {"$set": {"last_used_at": now}}
+            )
+
+        return results
+
+    @staticmethod
+    def format_memory_block(facts: List[Dict[str, Any]]) -> str:
+        """Render a compact "## What I know" block for prompt injection.
+
+        One bullet per fact, capped at ~12 lines. Returns "" if there's
+        nothing to show — callers should skip prepending an empty block.
+        """
+        if not facts:
+            return ""
+
+        lines = ["## What I know"]
+        for f in facts[:12]:
+            text = f.get("text") or f"{f.get('subject', '')} {f.get('predicate', '')} {f.get('value', '')}".strip()
+            if text:
+                lines.append(f"- {text}")
+
+        if len(lines) == 1:
+            return ""
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    # Export
+    # ------------------------------------------------------------------
+
+    async def export_all(self) -> Dict[str, Any]:
+        """Full JSON export of every fact, minus the raw embedding arrays."""
+        facts = await self.memory_repo.list_all()
+        exported: List[Dict[str, Any]] = []
+        for f in facts:
+            has_embedding = bool(f.get("embedding"))
+            fact = self._normalize(f)
+            fact["has_embedding"] = has_embedding
+            exported.append(fact)
+        return {"exported_at": datetime.utcnow().isoformat(), "facts": exported}
+
+    # ------------------------------------------------------------------
+    # Settings / kill switch
+    # ------------------------------------------------------------------
+
+    async def get_settings(self) -> Dict[str, Any]:
+        settings = await self.settings_repo.get_settings()
+        settings.pop("_id", None)
+        return settings
+
+    async def update_settings(self, patch: MemorySettingsUpdate) -> Dict[str, Any]:
+        data = patch.model_dump(exclude_unset=True, exclude_none=True)
+        settings = await self.settings_repo.update_settings(data)
+        settings.pop("_id", None)
+        return settings

--- a/backend/tests/test_memory.py
+++ b/backend/tests/test_memory.py
@@ -1,0 +1,367 @@
+"""Smoke tests for the Unified Memory Layer scaffold (SPEC-14 PR-A).
+
+Exercises CRUD, pinning, settings, and export on manual facts. Semantic
+search additionally needs the bundled all-MiniLM-L6-v2 ONNX embedding model
+on disk; tests that need it are skipped if the model is unavailable — mirrors
+`test_knowledge_base.py`.
+"""
+import os
+from pathlib import Path
+
+import pytest
+
+from services.memory_service import MemoryService
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _embedding_model_available() -> bool:
+    """Check whether the bundled MiniLM ONNX model is on disk."""
+    base = os.environ.get(
+        "MODELS_DIR",
+        os.path.join(Path.home(), ".contextuai-solo", "models"),
+    )
+    onnx = Path(base) / "embedding" / "all-MiniLM-L6-v2" / "model.onnx"
+    return onnx.exists()
+
+
+needs_embeddings = pytest.mark.skipif(
+    not _embedding_model_available(),
+    reason="all-MiniLM-L6-v2 ONNX model not present (skipping semantic search tests)",
+)
+
+
+# ---------------------------------------------------------------------------
+# Facts CRUD (no embeddings required — add_fact guards embedding failures)
+# ---------------------------------------------------------------------------
+
+def test_list_facts_empty(test_app):
+    r = test_app.get("/api/v1/memory/facts")
+    assert r.status_code == 200
+    assert r.json() == {"items": []}
+
+
+def test_create_fact(test_app):
+    r = test_app.post(
+        "/api/v1/memory/facts",
+        json={"subject": "pricing", "predicate": "is", "value": "$49/mo"},
+    )
+    assert r.status_code == 200
+    item = r.json()["item"]
+    assert item["subject"] == "pricing"
+    assert item["predicate"] == "is"
+    assert item["value"] == "$49/mo"
+    assert item["text"] == "pricing is $49/mo"
+    assert item["scope"] == "global"
+    assert item["origin"] == "user"
+    assert item["confidence"] == 1.0
+    assert item["status"] == "active"
+    assert item["pinned"] is False
+    assert item["source_kind"] == "user"
+    assert item["_id"]
+    assert item["id"] == item["_id"]
+    assert "embedding" not in item
+
+
+def test_create_fact_custom_text_and_scope(test_app):
+    r = test_app.post(
+        "/api/v1/memory/facts",
+        json={
+            "subject": "client Acme",
+            "predicate": "prefers",
+            "value": "email over calls",
+            "text": "Acme prefers to be contacted by email, not phone.",
+            "scope": "crew:sales-crew",
+        },
+    )
+    assert r.status_code == 200
+    item = r.json()["item"]
+    assert item["text"] == "Acme prefers to be contacted by email, not phone."
+    assert item["scope"] == "crew:sales-crew"
+
+
+def test_create_fact_validation(test_app):
+    # Missing required fields
+    r = test_app.post("/api/v1/memory/facts", json={})
+    assert r.status_code == 422
+    # Empty subject
+    r = test_app.post(
+        "/api/v1/memory/facts",
+        json={"subject": "", "predicate": "is", "value": "x"},
+    )
+    assert r.status_code == 422
+    # Invalid scope
+    r = test_app.post(
+        "/api/v1/memory/facts",
+        json={"subject": "a", "predicate": "is", "value": "b", "scope": "nonsense"},
+    )
+    assert r.status_code == 422
+
+
+def test_get_fact(test_app):
+    created = test_app.post(
+        "/api/v1/memory/facts",
+        json={"subject": "the user", "predicate": "works at", "value": "ContextuAI"},
+    ).json()["item"]
+    fact_id = created["_id"]
+
+    r = test_app.get(f"/api/v1/memory/facts/{fact_id}")
+    assert r.status_code == 200
+    assert r.json()["item"]["subject"] == "the user"
+
+
+def test_get_fact_404(test_app):
+    r = test_app.get("/api/v1/memory/facts/does-not-exist")
+    assert r.status_code == 404
+
+
+def test_list_facts_after_create(test_app):
+    test_app.post(
+        "/api/v1/memory/facts",
+        json={"subject": "a", "predicate": "is", "value": "1"},
+    )
+    test_app.post(
+        "/api/v1/memory/facts",
+        json={"subject": "b", "predicate": "is", "value": "2"},
+    )
+    r = test_app.get("/api/v1/memory/facts")
+    assert r.status_code == 200
+    items = r.json()["items"]
+    assert len(items) == 2
+
+
+def test_list_facts_filtered_by_scope(test_app):
+    test_app.post(
+        "/api/v1/memory/facts",
+        json={"subject": "a", "predicate": "is", "value": "1", "scope": "global"},
+    )
+    test_app.post(
+        "/api/v1/memory/facts",
+        json={"subject": "b", "predicate": "is", "value": "2", "scope": "crew:x"},
+    )
+    r = test_app.get("/api/v1/memory/facts", params={"scope": "crew:x"})
+    assert r.status_code == 200
+    items = r.json()["items"]
+    assert len(items) == 1
+    assert items[0]["scope"] == "crew:x"
+
+
+def test_update_fact(test_app):
+    created = test_app.post(
+        "/api/v1/memory/facts",
+        json={"subject": "pricing", "predicate": "is", "value": "$49/mo"},
+    ).json()["item"]
+    fact_id = created["_id"]
+
+    r = test_app.put(
+        f"/api/v1/memory/facts/{fact_id}",
+        json={"value": "$59/mo"},
+    )
+    assert r.status_code == 200
+    item = r.json()["item"]
+    assert item["value"] == "$59/mo"
+    # Text-affecting field changed -> text re-composed
+    assert item["text"] == "pricing is $59/mo"
+
+
+def test_update_fact_pinned_only_does_not_touch_text(test_app):
+    created = test_app.post(
+        "/api/v1/memory/facts",
+        json={"subject": "pricing", "predicate": "is", "value": "$49/mo"},
+    ).json()["item"]
+    fact_id = created["_id"]
+
+    r = test_app.put(f"/api/v1/memory/facts/{fact_id}", json={"pinned": True})
+    assert r.status_code == 200
+    item = r.json()["item"]
+    assert item["pinned"] is True
+    assert item["text"] == "pricing is $49/mo"
+
+
+def test_update_fact_404(test_app):
+    r = test_app.put("/api/v1/memory/facts/missing", json={"value": "x"})
+    assert r.status_code == 404
+
+
+def test_delete_fact(test_app):
+    created = test_app.post(
+        "/api/v1/memory/facts",
+        json={"subject": "temp", "predicate": "is", "value": "gone soon"},
+    ).json()["item"]
+    fact_id = created["_id"]
+
+    r = test_app.delete(f"/api/v1/memory/facts/{fact_id}")
+    assert r.status_code == 200
+    assert r.json()["deleted"] is True
+
+    r = test_app.get(f"/api/v1/memory/facts/{fact_id}")
+    assert r.status_code == 404
+
+
+def test_delete_fact_404(test_app):
+    r = test_app.delete("/api/v1/memory/facts/missing")
+    assert r.status_code == 404
+
+
+def test_pin_fact(test_app):
+    created = test_app.post(
+        "/api/v1/memory/facts",
+        json={"subject": "important", "predicate": "is", "value": "true"},
+    ).json()["item"]
+    fact_id = created["_id"]
+
+    r = test_app.post(f"/api/v1/memory/facts/{fact_id}/pin", json={"pinned": True})
+    assert r.status_code == 200
+    assert r.json()["item"]["pinned"] is True
+
+    r = test_app.post(f"/api/v1/memory/facts/{fact_id}/pin", json={"pinned": False})
+    assert r.status_code == 200
+    assert r.json()["item"]["pinned"] is False
+
+
+def test_pin_fact_404(test_app):
+    r = test_app.post("/api/v1/memory/facts/missing/pin", json={"pinned": True})
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Settings / kill switch
+# ---------------------------------------------------------------------------
+
+def test_get_settings_defaults(test_app):
+    r = test_app.get("/api/v1/memory/settings")
+    assert r.status_code == 200
+    settings = r.json()
+    assert settings["enabled"] is True
+    assert settings["chat_enabled"] is True
+    assert settings["crews_enabled"] is True
+    assert settings["channels_enabled"] is False
+    assert settings["confidence_threshold"] == 0.6
+
+
+def test_update_settings(test_app):
+    r = test_app.put(
+        "/api/v1/memory/settings",
+        json={"enabled": False, "channels_enabled": True},
+    )
+    assert r.status_code == 200
+    settings = r.json()
+    assert settings["enabled"] is False
+    assert settings["channels_enabled"] is True
+    # Untouched fields keep their prior values
+    assert settings["chat_enabled"] is True
+
+    # Persisted across a fresh GET
+    r = test_app.get("/api/v1/memory/settings")
+    assert r.json()["enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+
+def test_export_empty(test_app):
+    r = test_app.get("/api/v1/memory/export")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["facts"] == []
+    assert "exported_at" in body
+
+
+def test_export_includes_facts_without_embedding_key(test_app):
+    test_app.post(
+        "/api/v1/memory/facts",
+        json={"subject": "a", "predicate": "is", "value": "1"},
+    )
+    r = test_app.get("/api/v1/memory/export")
+    assert r.status_code == 200
+    facts = r.json()["facts"]
+    assert len(facts) == 1
+    assert "embedding" not in facts[0]
+    assert "has_embedding" in facts[0]
+
+
+# ---------------------------------------------------------------------------
+# Search — requires the embedding model; degrades gracefully without it
+# ---------------------------------------------------------------------------
+
+def test_search_without_embeddings_returns_empty_gracefully(test_app):
+    """Even if the ONNX model is unavailable, search must not 500."""
+    test_app.post(
+        "/api/v1/memory/facts",
+        json={"subject": "pricing", "predicate": "is", "value": "$49/mo"},
+    )
+    r = test_app.post("/api/v1/memory/search", json={"query": "how much does it cost"})
+    assert r.status_code == 200
+    assert "items" in r.json()
+
+
+@needs_embeddings
+def test_search_finds_semantically_close_fact(test_app):
+    test_app.post(
+        "/api/v1/memory/facts",
+        json={"subject": "pricing", "predicate": "is", "value": "$49 per month"},
+    )
+    test_app.post(
+        "/api/v1/memory/facts",
+        json={"subject": "the user", "predicate": "likes", "value": "dark mode"},
+    )
+
+    r = test_app.post(
+        "/api/v1/memory/search", json={"query": "what does the subscription cost"}
+    )
+    assert r.status_code == 200
+    items = r.json()["items"]
+    assert len(items) >= 1
+    assert any("49" in it["text"] for it in items)
+    assert all("score" in it for it in items)
+    assert all("embedding" not in it for it in items)
+
+
+@needs_embeddings
+def test_search_bumps_last_used_at(test_app):
+    created = test_app.post(
+        "/api/v1/memory/facts",
+        json={"subject": "pricing", "predicate": "is", "value": "$49/mo"},
+    ).json()["item"]
+    assert created["last_used_at"] is None
+
+    test_app.post("/api/v1/memory/search", json={"query": "pricing"})
+
+    r = test_app.get(f"/api/v1/memory/facts/{created['_id']}")
+    assert r.json()["item"]["last_used_at"] is not None
+
+
+# ---------------------------------------------------------------------------
+# format_memory_block — pure unit test, no DB needed
+# ---------------------------------------------------------------------------
+
+def test_format_memory_block_empty():
+    assert MemoryService.format_memory_block([]) == ""
+
+
+def test_format_memory_block_renders_bullets():
+    facts = [
+        {"text": "pricing is $49/mo"},
+        {"text": "client Acme prefers email"},
+    ]
+    block = MemoryService.format_memory_block(facts)
+    assert block.startswith("## What I know")
+    assert "- pricing is $49/mo" in block
+    assert "- client Acme prefers email" in block
+
+
+def test_format_memory_block_caps_at_twelve_lines():
+    facts = [{"text": f"fact number {i}"} for i in range(20)]
+    block = MemoryService.format_memory_block(facts)
+    lines = block.split("\n")
+    # 1 header + at most 12 bullets
+    assert len(lines) <= 13
+
+
+def test_format_memory_block_falls_back_to_subject_predicate_value():
+    facts = [{"subject": "pricing", "predicate": "is", "value": "$49/mo", "text": ""}]
+    block = MemoryService.format_memory_block(facts)
+    assert "pricing is $49/mo" in block

--- a/docs/planning/specs/SPEC-14-DESIGN-memory-layer.md
+++ b/docs/planning/specs/SPEC-14-DESIGN-memory-layer.md
@@ -1,0 +1,97 @@
+# SPEC-14 — Unified Memory Layer · Detailed Design (for review before coding)
+
+- **Parent spec:** `SPEC-14-unified-memory-layer.md` (roadmap F-1, Q3 2026 flagship)
+- **Status:** ✅ reviewed 2026-07-08 — decisions confirmed (all 5 recommendations accepted). Building PR-A.
+- **Author:** implementing agent, grounded in a code map of `crew_memory_service`, `rag_service`/`embedding_service`, and the `personal_docs` job pattern.
+
+---
+
+## 1. What we're building (one paragraph)
+
+A local, structured, user-visible memory that Solo builds automatically from chats and crew runs. Atomic **facts** ("pricing is $49/mo", "client X prefers email") and session **episodes** are extracted in the background, embedded with the bundled MiniLM model, and stored as JSON rows in SQLite — mirroring the KB/RAG pattern exactly. At prompt-build time we retrieve the top-k relevant facts and prepend a compact **"What I know"** block, clearly separated from KB citations. A new `/memory` route lets the user search, edit, pin, delete, review low-confidence candidates, toggle scopes, and export everything. Nothing leaves the machine.
+
+## 2. How it reuses what already exists (no new infra)
+
+The three research passes confirm the memory layer is a **copy of patterns already in the repo** — no new dependencies, no ANN index, no migration framework, no schema files (tables auto-create on first write via the SQLite adapter).
+
+| Concern | Existing template we copy | Where |
+|---|---|---|
+| Embedding | `embedding_service.embed()/embed_batch()` — 384-dim, L2-normalized singleton | `services/embedding_service.py` |
+| Vector store + retrieval | inline `"embedding": list[float]` in the doc; `embeddings @ q`; `argsort(-scores)[:k]` | `services/rag_service.py` |
+| Repository | thin `BaseRepository` subclass, hard-coded collection name, auto-created table | `repositories/chunk_repository.py` |
+| Background job | `asyncio.create_task` + `self._tasks` dict + DB `cancel_requested` flag polled between units | `services/personal_docs_service.py` |
+| Job states + SSE | `queued→running→done/error/cancelled`, DB-poll SSE generator | `index_job_repository.py`, `routers/personal_docs.py` |
+| Router + DI | `Depends(get_database)` factory functions; register in `app.py` | `routers/knowledge_base.py` |
+
+## 3. Data model
+
+Two new collections (tables auto-create on first write):
+
+**`memory_facts`**
+```
+_id            str (uuid4)
+scope          "global" | "crew:<id>"        # forward-compat for worker:<id> (SPEC-18)
+subject        str        # "pricing", "client Acme", "the user"
+predicate      str        # "is", "prefers", "decided"
+value          str        # "$49/mo", "email over calls"
+text           str        # canonical rendered sentence — what we embed & show
+embedding      list[float]  # 384-dim, inline JSON array (kb_chunks pattern)
+confidence     float 0..1
+status         "active" | "review"           # < threshold → review queue, not auto-recalled
+pinned         bool                          # user-pinned facts always eligible for recall
+source_kind    "chat" | "crew"
+source_id      str        # session_id or crew_run/execution id
+source_label   str        # "chat on Jul 3", "Sales crew run"
+origin         "extracted" | "user"          # user-added facts skip extraction/dedupe
+created_at, updated_at, last_used_at   ISO strings
+```
+
+**`memory_episodes`** — same envelope, but `text` is a 1–3 sentence summary of a notable session/run, `subject/predicate/value` omitted. Used for "remind me what that Reddit thread was about" style recall. **Phaseable** (see §8).
+
+**Extraction job** (`memory_jobs`, copy of `kb_index_jobs`): `_id, source_kind, source_id, status, cand_total/saved/review/deduped, error, cancel_requested, started_at, finished_at`.
+
+## 4. The three flows
+
+### 4a. Extraction (background, never blocks chat)
+- **Chat hook:** after the assistant reply is stored (`ai_chat.py` — after each `update_session_stats`, all five model paths). Enqueue a **debounced** job keyed on `session_id`: if a job is already running/queued for that session, skip — coalesce so at most one extraction per session is in flight. Plus a final flush on `archive_session`/`delete_session`.
+- **Crew hook:** `orchestrator.py::finalize_execution` success branch (~line 745), keyed on `execution_id`.
+- **The job:** pull the recent transcript → ask the extraction model for candidate facts as JSON (`subject/predicate/value/confidence`) → embed each `text` → **dedupe** (cosine ≥ 0.92 against existing same-`subject` facts → update/skip; else insert) → below the confidence threshold → `status="review"`. Cancellable via the `cancel_requested` flag polled between candidates. Adds **0 ms** to perceived chat latency.
+
+### 4b. Recall (at prompt-build)
+- **Chat:** `ai_chat.py:282–306`, right where KB context is built. Embed the user prompt, load candidate facts for `scope in {global}` (+ crew scope in crew path), score `cosine·w₁ + confidence·w₂ + recency·w₃`, take top-k active/pinned, render a `## What I know` block, prepend to `effective_prompt` (separate from and above KB citations). Bump `last_used_at` on recalled facts.
+- **Crew:** `agent_runner.py:244–254`, mirroring the KB prepend into `system_prompt` (scope = `global` + `crew:<id>`).
+- **Kill switch / scope-off** ⇒ the block is empty; recall is skipped entirely.
+
+### 4c. Memory panel (`/memory`)
+Searchable list (semantic + text), edit/delete/pin, per-fact **source link** ("learned from chat on Jul 3"), a **review queue** for low-confidence candidates (approve → active, reject → delete), global on/off + per-scope toggles (chat / crews / channels), and **full JSON export**. New route + sidebar entry; `lib/api/memory-client.ts`; components mirror the KB page.
+
+## 5. Files (all additive)
+
+**Backend:** `models/memory_models.py`, `repositories/memory_repository.py` (+ `memory_episode_repository.py`, `memory_job_repository.py`), `services/memory_service.py` (extract/dedupe/recall/CRUD), `routers/memory.py`; hooks edited in `ai_chat.py`, `chat_sessions.py`, `workspace/orchestrator.py`, `workspace/agent_runner.py`; register router + startup orphan-reset in `app.py`. Tests mirror `test_knowledge_base.py` / `test_personal_docs_service.py`.
+**Frontend:** `routes/memory.tsx`, `lib/api/memory-client.ts`, `components/memory/*`, sidebar entry, Settings → Memory toggles.
+
+## 6. Recommended calls on the open questions
+
+| # | Question | Recommendation | Why |
+|---|---|---|---|
+| Q1 | Extraction model | **Reuse the session/run's own model** (Settings override to force a small dedicated one) | Local model stays RAM-resident; a *different* model forces a costly reload/swap every extraction. Reusing the loaded model = zero swap, consistent quality. Cloud sessions reuse their own cheap model. |
+| Q2 | Fact aging / TTL | **Keep until edited/deleted; no auto-decay.** Use `last_used_at`/recency only as a *ranking* signal | Surprising auto-deletions erode the "visible memory = trust" moat. Aging can rank stale facts down without removing them. |
+| Q3 | Injection mechanism | **System-prompt text block in v1** (recall-as-tool deferred) | Must work with local non-tool-capable models; SPEC-29 exists precisely because local tool-calling is unreliable. Tool-based recall is a v2/enterprise option. |
+| Q4 | Crew memory (migrate vs federate) | **Federate in v1** — leave `crew_memory_service` in place; new layer owns global + semantic facts and can also read crew-scoped facts | `crew_memories` is a shipped, battle-tested, self-contained plain-text store with its own orchestrator injection. Migrating risks regressing a live path for no v1 user benefit. Consolidate in the enterprise port. |
+| Q5 | Channel traffic default | **Off by default** for channels; on for chat + crews | Privacy posture (spec §5). User can opt channels in per-scope. |
+
+## 7. Acceptance criteria (from spec §5)
+
+- Tell Solo a fact in chat; two sessions later a different agent uses it, and it's visible in `/memory` with a source link.
+- Deleting a fact removes it from all future recalls; kill switch empties the block.
+- Extraction is fully async — no added perceived chat latency — and works local-only.
+- Channel memory off by default; chat/crews on.
+
+## 8. Suggested build phasing (each independently shippable behind additive changes)
+
+1. **PR-A — Store + panel + manual facts.** Models, repos, `memory_service` CRUD, `routers/memory.py`, `/memory` UI, export, kill switch. User can add/see/edit/delete facts manually. *No extraction yet — safe, visible, testable.*
+2. **PR-B — Recall.** Wire the "What I know" block into chat + crew prompt-build. Now manual facts influence answers.
+3. **PR-C — Extraction (facts).** Background job on chat + crew hooks, dedupe, review queue.
+4. **PR-D — Episodes** (optional / can fold into a later release).
+
+Phasing lets you review the moat-critical, low-risk pieces (visible store + user control) before the higher-variance extraction lands.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,7 @@ import SettingsPage from "@/routes/settings";
 import ApprovalsPage from "@/routes/approvals";
 import BlueprintsPage from "@/routes/blueprints";
 import KnowledgePage from "@/routes/knowledge";
+import MemoryPage from "@/routes/memory";
 import AutomationsPage from "@/routes/automations";
 import WizardPage from "@/routes/wizard";
 import CoderProjectsPage from "@/routes/coder/projects";
@@ -184,6 +185,7 @@ export default function App() {
                 <Route path="/workspace/:id" element={<WorkspacePage />} />
                 <Route path="/connections" element={<ConnectionsPage />} />
                 <Route path="/knowledge" element={<KnowledgePage />} />
+                <Route path="/memory" element={<MemoryPage />} />
                 <Route path="/automations" element={<AutomationsPage />} />
                 <Route path="/approvals" element={<ApprovalsPage />} />
                 <Route path="/analytics" element={<AnalyticsPage />} />

--- a/frontend/src/components/memory/fact-form-modal.tsx
+++ b/frontend/src/components/memory/fact-form-modal.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Dialog } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import type { MemoryFact } from "@/lib/api/memory-client";
+
+export interface FactFormValues {
+  subject: string;
+  predicate: string;
+  value: string;
+}
+
+export function FactFormModal({
+  open,
+  editingFact,
+  onClose,
+  onSubmit,
+}: {
+  open: boolean;
+  editingFact: MemoryFact | null;
+  onClose: () => void;
+  onSubmit: (values: FactFormValues) => Promise<void>;
+}) {
+  const [subject, setSubject] = useState("");
+  const [predicate, setPredicate] = useState("");
+  const [value, setValue] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setSubject(editingFact?.subject ?? "");
+      setPredicate(editingFact?.predicate ?? "is");
+      setValue(editingFact?.value ?? "");
+      setError(null);
+    }
+  }, [open, editingFact]);
+
+  async function handleSubmit() {
+    if (!value.trim()) {
+      setError("Value is required");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await onSubmit({
+        subject: subject.trim() || "the user",
+        predicate: predicate.trim() || "is",
+        value: value.trim(),
+      });
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const preview = `${subject.trim() || "the user"} ${predicate.trim() || "is"} ${value.trim() || "…"}`;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title={editingFact ? "Edit memory" : "Add memory"}
+      actions={
+        <>
+          <Button variant="ghost" onClick={onClose} disabled={saving}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={saving}>
+            {saving && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
+            {editingFact ? "Save" : "Add"}
+          </Button>
+        </>
+      }
+    >
+      <div className="space-y-4">
+        <div className="grid grid-cols-2 gap-3">
+          <Input
+            label="Subject"
+            placeholder="e.g. pricing, the user"
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+            autoFocus
+          />
+          <Input
+            label="Predicate"
+            placeholder="e.g. is, prefers"
+            value={predicate}
+            onChange={(e) => setPredicate(e.target.value)}
+          />
+        </div>
+        <Input
+          label="Value"
+          placeholder="e.g. $49/mo, email over calls"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          error={error ?? undefined}
+        />
+        <p className="text-xs text-neutral-500 dark:text-neutral-400">
+          Solo will remember: <span className="italic">"{preview}"</span>
+        </p>
+      </div>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/memory/fact-row.tsx
+++ b/frontend/src/components/memory/fact-row.tsx
@@ -1,0 +1,160 @@
+import { useState } from "react";
+import { Check, Pencil, Pin, Trash2, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { MemoryFact } from "@/lib/api/memory-client";
+
+function formatDate(iso?: string | null): string | null {
+  if (!iso) return null;
+  try {
+    return new Date(iso).toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+    });
+  } catch {
+    return null;
+  }
+}
+
+function ConfidenceDot({ confidence }: { confidence: number }) {
+  const pct = Math.round(confidence * 100);
+  const color =
+    confidence >= 0.8
+      ? "bg-emerald-500"
+      : confidence >= 0.6
+        ? "bg-amber-500"
+        : "bg-red-500";
+  return (
+    <span
+      className="inline-flex items-center gap-1 text-[11px] text-neutral-500 dark:text-neutral-400"
+      title={`Extraction confidence: ${pct}%`}
+    >
+      <span className={cn("w-1.5 h-1.5 rounded-full", color)} />
+      {pct}%
+    </span>
+  );
+}
+
+export function FactRow({
+  fact,
+  onEdit,
+  onDelete,
+  onTogglePin,
+}: {
+  fact: MemoryFact;
+  onEdit: () => void;
+  onDelete: () => Promise<void> | void;
+  onTogglePin: () => Promise<void> | void;
+}) {
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [pinning, setPinning] = useState(false);
+
+  const sourceText =
+    fact.origin === "user"
+      ? "added by you"
+      : `learned from ${fact.source_label || fact.source_kind}`;
+  const created = formatDate(fact.created_at);
+
+  async function handleConfirmDelete() {
+    setDeleting(true);
+    try {
+      await onDelete();
+    } finally {
+      setDeleting(false);
+      setConfirmingDelete(false);
+    }
+  }
+
+  async function handleTogglePin() {
+    setPinning(true);
+    try {
+      await onTogglePin();
+    } finally {
+      setPinning(false);
+    }
+  }
+
+  return (
+    <li
+      className={cn(
+        "flex items-start gap-3 px-4 py-3 text-sm",
+        fact.status === "review" && "bg-amber-50/50 dark:bg-amber-500/[0.04]",
+      )}
+    >
+      <div className="min-w-0 flex-1">
+        <p className="text-neutral-900 dark:text-white leading-snug">
+          {fact.text}
+        </p>
+        <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-neutral-500 dark:text-neutral-400">
+          <span>{sourceText}</span>
+          {created && <span>· {created}</span>}
+          {fact.status === "review" && (
+            <span className="inline-flex items-center px-1.5 py-0.5 rounded-full bg-amber-100 dark:bg-amber-500/15 text-amber-700 dark:text-amber-400 font-medium">
+              Needs review
+            </span>
+          )}
+          {fact.origin === "extracted" && (
+            <ConfidenceDot confidence={fact.confidence} />
+          )}
+          {typeof fact.score === "number" && (
+            <span className="font-mono">match {fact.score.toFixed(2)}</span>
+          )}
+        </div>
+      </div>
+
+      {confirmingDelete ? (
+        <div className="flex items-center gap-1.5 flex-shrink-0">
+          <span className="text-xs text-neutral-500 dark:text-neutral-400 mr-1">
+            Delete?
+          </span>
+          <button
+            onClick={handleConfirmDelete}
+            disabled={deleting}
+            className="p-1.5 rounded-lg text-white bg-red-500 hover:bg-red-600 disabled:opacity-60 transition-colors"
+            title="Confirm delete"
+          >
+            <Check className="w-3.5 h-3.5" />
+          </button>
+          <button
+            onClick={() => setConfirmingDelete(false)}
+            disabled={deleting}
+            className="p-1.5 rounded-lg text-neutral-500 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+            title="Cancel"
+          >
+            <X className="w-3.5 h-3.5" />
+          </button>
+        </div>
+      ) : (
+        <div className="flex items-center gap-1 flex-shrink-0">
+          <button
+            onClick={handleTogglePin}
+            disabled={pinning}
+            className={cn(
+              "p-1.5 rounded-lg transition-colors",
+              fact.pinned
+                ? "text-primary-500 hover:bg-primary-50 dark:hover:bg-primary-500/10"
+                : "text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-800",
+            )}
+            title={fact.pinned ? "Unpin" : "Pin"}
+          >
+            <Pin className={cn("w-3.5 h-3.5", fact.pinned && "fill-current")} />
+          </button>
+          <button
+            onClick={onEdit}
+            className="p-1.5 rounded-lg text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+            title="Edit"
+          >
+            <Pencil className="w-3.5 h-3.5" />
+          </button>
+          <button
+            onClick={() => setConfirmingDelete(true)}
+            className="p-1.5 rounded-lg text-neutral-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-500/10 transition-colors"
+            title="Delete"
+          >
+            <Trash2 className="w-3.5 h-3.5" />
+          </button>
+        </div>
+      )}
+    </li>
+  );
+}

--- a/frontend/src/components/memory/memory-settings-card.tsx
+++ b/frontend/src/components/memory/memory-settings-card.tsx
@@ -1,0 +1,90 @@
+import { useState } from "react";
+import { ChevronDown, ChevronUp, Settings2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Switch } from "@/components/ui/switch";
+import type { MemorySettings } from "@/lib/api/memory-client";
+
+function SettingRow({
+  label,
+  description,
+  checked,
+  onChange,
+  disabled,
+}: {
+  label: string;
+  description: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-4 py-3">
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-neutral-900 dark:text-white">
+          {label}
+        </p>
+        <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-0.5">
+          {description}
+        </p>
+      </div>
+      <Switch checked={checked} onChange={onChange} disabled={disabled} size="sm" />
+    </div>
+  );
+}
+
+export function MemorySettingsCard({
+  settings,
+  onUpdate,
+}: {
+  settings: MemorySettings;
+  onUpdate: (patch: Partial<MemorySettings>) => Promise<void>;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="rounded-xl border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900">
+      <button
+        onClick={() => setExpanded((v) => !v)}
+        className="w-full flex items-center justify-between px-4 py-3 text-left"
+      >
+        <span className="flex items-center gap-2 text-sm font-medium text-neutral-900 dark:text-white">
+          <Settings2 className="w-4 h-4 text-neutral-400" />
+          Where memory applies
+        </span>
+        {expanded ? (
+          <ChevronUp className="w-4 h-4 text-neutral-400" />
+        ) : (
+          <ChevronDown className="w-4 h-4 text-neutral-400" />
+        )}
+      </button>
+      <div
+        className={cn(
+          "px-4 divide-y divide-neutral-100 dark:divide-neutral-800 border-t border-neutral-200 dark:border-neutral-800",
+          expanded ? "block" : "hidden",
+        )}
+      >
+        <SettingRow
+          label="Chat"
+          description="Recall relevant facts while chatting and (later) learn new ones from conversations."
+          checked={settings.chat_enabled}
+          onChange={(v) => onUpdate({ chat_enabled: v })}
+          disabled={!settings.enabled}
+        />
+        <SettingRow
+          label="Crews"
+          description="Share memory with multi-agent crew runs."
+          checked={settings.crews_enabled}
+          onChange={(v) => onUpdate({ crews_enabled: v })}
+          disabled={!settings.enabled}
+        />
+        <SettingRow
+          label="Channels"
+          description="Off by default — records facts from third-party messages (Telegram, Discord, Reddit, etc.)."
+          checked={settings.channels_enabled}
+          onChange={(v) => onUpdate({ channels_enabled: v })}
+          disabled={!settings.enabled}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/navigation/desktop-sidebar.tsx
+++ b/frontend/src/components/navigation/desktop-sidebar.tsx
@@ -18,6 +18,7 @@ import {
   Zap,
   Plug,
   Bot,
+  Brain,
 } from "lucide-react";
 import { useAiMode } from "@/contexts/ai-mode-context";
 import logoImg from "@/assets/logo.png";
@@ -33,9 +34,13 @@ interface NavItem {
 // the prompt-agent library; the database/api/mcp/web/file kinds live under
 // Connectors. "Crews" page renamed to "Workspace" (same /crews route),
 // with internal Crews | Projects | Runs tabs.
+// SPEC-14 PR-A: added "Memory" (11th item) next to Knowledge — the
+// user-visible memory panel (facts store, search, pin/edit/delete, export,
+// kill switch).
 const navItems: NavItem[] = [
   { label: "Chat", path: "/", icon: MessageSquare },
   { label: "Knowledge", path: "/knowledge", icon: Library },
+  { label: "Memory", path: "/memory", icon: Brain },
   { label: "Connectors", path: "/personas", icon: Plug },
   { label: "Agents", path: "/agents", icon: Bot },
   { label: "Automations", path: "/automations", icon: Zap },

--- a/frontend/src/components/ui/switch.tsx
+++ b/frontend/src/components/ui/switch.tsx
@@ -1,0 +1,41 @@
+import { cn } from "@/lib/utils";
+
+interface SwitchProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  disabled?: boolean;
+  label?: string;
+  size?: "sm" | "md";
+}
+
+export function Switch({ checked, onChange, disabled, label, size = "md" }: SwitchProps) {
+  const track = size === "sm" ? "h-5 w-9" : "h-6 w-11";
+  const thumb = size === "sm" ? "h-3.5 w-3.5" : "h-4 w-4";
+  const translate = size === "sm" ? (checked ? "translate-x-4" : "translate-x-1") : (checked ? "translate-x-6" : "translate-x-1");
+
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+      className={cn(
+        "relative inline-flex flex-shrink-0 items-center rounded-full transition-colors",
+        "focus:outline-none focus:ring-2 focus:ring-primary-500/40",
+        track,
+        checked ? "bg-primary-500" : "bg-neutral-300 dark:bg-neutral-700",
+        disabled && "opacity-60 cursor-not-allowed"
+      )}
+    >
+      <span
+        className={cn(
+          "inline-block transform rounded-full bg-white shadow transition-transform",
+          thumb,
+          translate
+        )}
+      />
+    </button>
+  );
+}

--- a/frontend/src/lib/api/memory-client.ts
+++ b/frontend/src/lib/api/memory-client.ts
@@ -1,0 +1,160 @@
+import { api } from "@/lib/transport";
+
+export interface MemoryFact {
+  id: string;
+  scope: string;
+  subject: string;
+  predicate: string;
+  value: string;
+  text: string;
+  confidence: number;
+  status: "active" | "review";
+  pinned: boolean;
+  source_kind: string;
+  source_id?: string | null;
+  source_label?: string | null;
+  origin: "extracted" | "user";
+  created_at?: string | null;
+  updated_at?: string | null;
+  last_used_at?: string | null;
+  /** Present only on search/query results (semantic similarity, 0..1). */
+  score?: number;
+}
+
+export interface MemorySettings {
+  enabled: boolean;
+  chat_enabled: boolean;
+  crews_enabled: boolean;
+  channels_enabled: boolean;
+  confidence_threshold: number;
+}
+
+export interface MemoryExport {
+  exported_at: string;
+  facts: (MemoryFact & { has_embedding?: boolean })[];
+}
+
+function normalizeFact(raw: Record<string, unknown>): MemoryFact {
+  return {
+    id: (raw.id as string) || (raw._id as string),
+    scope: (raw.scope as string) || "global",
+    subject: raw.subject as string,
+    predicate: raw.predicate as string,
+    value: raw.value as string,
+    text: raw.text as string,
+    confidence: typeof raw.confidence === "number" ? raw.confidence : 1.0,
+    status: (raw.status as MemoryFact["status"]) || "active",
+    pinned: Boolean(raw.pinned),
+    source_kind: (raw.source_kind as string) || "user",
+    source_id: (raw.source_id as string | null) ?? null,
+    source_label: (raw.source_label as string | null) ?? null,
+    origin: (raw.origin as MemoryFact["origin"]) || "user",
+    created_at: (raw.created_at as string | null) ?? null,
+    updated_at: (raw.updated_at as string | null) ?? null,
+    last_used_at: (raw.last_used_at as string | null) ?? null,
+    ...(typeof raw.score === "number" ? { score: raw.score as number } : {}),
+  };
+}
+
+export async function listFacts(params?: {
+  scope?: string;
+  status?: string;
+  q?: string;
+}): Promise<MemoryFact[]> {
+  const search = new URLSearchParams();
+  if (params?.scope) search.set("scope", params.scope);
+  if (params?.status) search.set("status", params.status);
+  if (params?.q) search.set("q", params.q);
+  const qs = search.toString();
+  const { data } = await api.get<{ items: Record<string, unknown>[] }>(
+    `/memory/facts${qs ? `?${qs}` : ""}`,
+  );
+  return (data.items || []).map(normalizeFact);
+}
+
+export async function getFact(id: string): Promise<MemoryFact> {
+  const { data } = await api.get<{ item: Record<string, unknown> }>(
+    `/memory/facts/${id}`,
+  );
+  return normalizeFact(data.item);
+}
+
+export async function createFact(payload: {
+  subject: string;
+  predicate: string;
+  value: string;
+  text?: string;
+  scope?: string;
+}): Promise<MemoryFact> {
+  const { data } = await api.post<{ item: Record<string, unknown> }>(
+    "/memory/facts",
+    payload,
+  );
+  return normalizeFact(data.item);
+}
+
+export async function updateFact(
+  id: string,
+  payload: Partial<{
+    subject: string;
+    predicate: string;
+    value: string;
+    text: string;
+    pinned: boolean;
+    status: "active" | "review";
+    scope: string;
+  }>,
+): Promise<MemoryFact> {
+  const { data } = await api.put<{ item: Record<string, unknown> }>(
+    `/memory/facts/${id}`,
+    payload,
+  );
+  return normalizeFact(data.item);
+}
+
+export async function deleteFact(id: string): Promise<boolean> {
+  const { data } = await api.delete<{ deleted: boolean }>(
+    `/memory/facts/${id}`,
+  );
+  return data.deleted;
+}
+
+export async function pinFact(
+  id: string,
+  pinned: boolean,
+): Promise<MemoryFact> {
+  const { data } = await api.post<{ item: Record<string, unknown> }>(
+    `/memory/facts/${id}/pin`,
+    { pinned },
+  );
+  return normalizeFact(data.item);
+}
+
+export async function searchFacts(
+  query: string,
+  topK = 8,
+  scopes?: string[],
+): Promise<MemoryFact[]> {
+  const { data } = await api.post<{ items: Record<string, unknown>[] }>(
+    "/memory/search",
+    { query, top_k: topK, scopes },
+  );
+  return (data.items || []).map(normalizeFact);
+}
+
+export async function exportMemory(): Promise<MemoryExport> {
+  const { data } = await api.get<MemoryExport>("/memory/export");
+  return data;
+}
+
+export async function getMemorySettings(): Promise<MemorySettings> {
+  const { data } = await api.get<MemorySettings>("/memory/settings");
+  return data;
+}
+
+export async function updateMemorySettings(
+  payload: Partial<MemorySettings>,
+): Promise<MemorySettings> {
+  const { data } = await api.put<MemorySettings>("/memory/settings", payload);
+  return data;
+}

--- a/frontend/src/routes/memory.tsx
+++ b/frontend/src/routes/memory.tsx
@@ -1,0 +1,342 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Brain, Download, Loader2, Plus, Search, ShieldOff, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { FactRow } from "@/components/memory/fact-row";
+import { FactFormModal, type FactFormValues } from "@/components/memory/fact-form-modal";
+import { MemorySettingsCard } from "@/components/memory/memory-settings-card";
+import { cn } from "@/lib/utils";
+import {
+  createFact,
+  deleteFact,
+  exportMemory,
+  getMemorySettings,
+  listFacts,
+  pinFact,
+  updateFact,
+  updateMemorySettings,
+  type MemoryFact,
+  type MemorySettings,
+} from "@/lib/api/memory-client";
+
+type StatusFilter = "all" | "active" | "review";
+
+const FILTERS: { id: StatusFilter; label: string }[] = [
+  { id: "all", label: "All" },
+  { id: "active", label: "Active" },
+  { id: "review", label: "Review" },
+];
+
+export default function MemoryPage() {
+  const [facts, setFacts] = useState<MemoryFact[]>([]);
+  const [loadingFacts, setLoadingFacts] = useState(true);
+  const [listError, setListError] = useState<string | null>(null);
+
+  const [searchInput, setSearchInput] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+
+  const [settings, setSettings] = useState<MemorySettings | null>(null);
+  const [settingsLoading, setSettingsLoading] = useState(true);
+
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingFact, setEditingFact] = useState<MemoryFact | null>(null);
+
+  const [exporting, setExporting] = useState(false);
+
+  // Debounce the search box — semantic search hits the embedding model.
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedQuery(searchInput.trim()), 350);
+    return () => clearTimeout(t);
+  }, [searchInput]);
+
+  const reloadFacts = useCallback(async () => {
+    setLoadingFacts(true);
+    setListError(null);
+    try {
+      const items = await listFacts({
+        status: statusFilter === "all" ? undefined : statusFilter,
+        q: debouncedQuery || undefined,
+      });
+      setFacts(items);
+    } catch (e) {
+      setListError(e instanceof Error ? e.message : "Failed to load memory");
+    } finally {
+      setLoadingFacts(false);
+    }
+  }, [statusFilter, debouncedQuery]);
+
+  useEffect(() => {
+    reloadFacts();
+  }, [reloadFacts]);
+
+  const loadSettings = useCallback(async () => {
+    setSettingsLoading(true);
+    try {
+      setSettings(await getMemorySettings());
+    } catch (e) {
+      console.error("Failed to load memory settings:", e);
+    } finally {
+      setSettingsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadSettings();
+  }, [loadSettings]);
+
+  async function handleUpdateSettings(patch: Partial<MemorySettings>) {
+    const previous = settings;
+    // Optimistic update — settings toggles should feel instant.
+    if (previous) setSettings({ ...previous, ...patch });
+    try {
+      setSettings(await updateMemorySettings(patch));
+    } catch (e) {
+      if (previous) setSettings(previous);
+      alert(e instanceof Error ? e.message : "Failed to update settings");
+    }
+  }
+
+  async function handleCreateOrUpdate(values: FactFormValues) {
+    if (editingFact) {
+      const updated = await updateFact(editingFact.id, values);
+      setFacts((prev) => prev.map((f) => (f.id === updated.id ? updated : f)));
+    } else {
+      const created = await createFact(values);
+      setFacts((prev) => [created, ...prev]);
+    }
+  }
+
+  async function handleDelete(fact: MemoryFact) {
+    await deleteFact(fact.id);
+    setFacts((prev) => prev.filter((f) => f.id !== fact.id));
+  }
+
+  async function handleTogglePin(fact: MemoryFact) {
+    const updated = await pinFact(fact.id, !fact.pinned);
+    setFacts((prev) => prev.map((f) => (f.id === updated.id ? updated : f)));
+  }
+
+  async function handleExport() {
+    setExporting(true);
+    try {
+      const data = await exportMemory();
+      const blob = new Blob([JSON.stringify(data, null, 2)], {
+        type: "application/json",
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "contextuai-memory.json";
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      alert(e instanceof Error ? e.message : "Export failed");
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  // Pinned facts always float to the top, preserving relative order within
+  // each group (the backend already does this for the non-search path).
+  const orderedFacts = useMemo(() => {
+    const pinned = facts.filter((f) => f.pinned);
+    const rest = facts.filter((f) => !f.pinned);
+    return [...pinned, ...rest];
+  }, [facts]);
+
+  const isSearching = debouncedQuery.length > 0;
+  const noFactsAtAll =
+    !loadingFacts && facts.length === 0 && !isSearching && statusFilter === "all";
+
+  return (
+    <div className="h-full overflow-y-auto bg-neutral-50 dark:bg-neutral-950">
+      <div className="max-w-3xl mx-auto px-6 py-8 space-y-6">
+        {/* Header */}
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex items-start gap-3">
+            <div className="w-10 h-10 rounded-xl bg-primary-50 dark:bg-primary-500/10 flex items-center justify-center flex-shrink-0">
+              <Brain className="w-5 h-5 text-primary-500" />
+            </div>
+            <div>
+              <h1 className="text-xl font-semibold text-neutral-900 dark:text-white">
+                Memory
+              </h1>
+              <p className="text-sm text-neutral-500 dark:text-neutral-400 mt-0.5">
+                What Solo remembers about you and your work — you're in full
+                control.
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2 flex-shrink-0">
+            <span className="text-xs font-medium text-neutral-500 dark:text-neutral-400">
+              Memory enabled
+            </span>
+            <Switch
+              checked={settings?.enabled ?? false}
+              onChange={(v) => handleUpdateSettings({ enabled: v })}
+              disabled={settingsLoading || !settings}
+            />
+          </div>
+        </div>
+
+        {/* Kill-switch banner */}
+        {settings && !settings.enabled && (
+          <div className="flex items-center gap-2.5 px-4 py-3 rounded-xl bg-neutral-100 dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-800 text-sm text-neutral-600 dark:text-neutral-400">
+            <ShieldOff className="w-4 h-4 flex-shrink-0" />
+            Memory is off — nothing is being recalled.
+          </div>
+        )}
+
+        {/* Toolbar */}
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="relative flex-1 min-w-[220px]">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-neutral-400" />
+            <input
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
+              placeholder="Search memory…"
+              className={cn(
+                "w-full pl-9 pr-9 py-2.5 rounded-xl text-sm",
+                "bg-white dark:bg-neutral-900",
+                "border border-neutral-200 dark:border-neutral-700",
+                "text-neutral-900 dark:text-white",
+                "placeholder:text-neutral-400 dark:placeholder:text-neutral-500",
+                "focus:outline-none focus:ring-2 focus:ring-primary-500/40 focus:border-primary-500",
+              )}
+            />
+            {searchInput && (
+              <button
+                onClick={() => setSearchInput("")}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300"
+              >
+                <X className="w-3.5 h-3.5" />
+              </button>
+            )}
+          </div>
+
+          <Button
+            variant="secondary"
+            size="md"
+            onClick={handleExport}
+            disabled={exporting}
+          >
+            {exporting ? (
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            ) : (
+              <Download className="w-3.5 h-3.5" />
+            )}
+            Export
+          </Button>
+
+          <Button
+            size="md"
+            onClick={() => {
+              setEditingFact(null);
+              setFormOpen(true);
+            }}
+          >
+            <Plus className="w-3.5 h-3.5" />
+            Add memory
+          </Button>
+        </div>
+
+        {/* Filter chips */}
+        <div className="flex items-center gap-2">
+          {FILTERS.map((f) => (
+            <button
+              key={f.id}
+              onClick={() => setStatusFilter(f.id)}
+              className={cn(
+                "px-3 py-1.5 rounded-full text-xs font-medium transition-colors",
+                statusFilter === f.id
+                  ? "bg-primary-500 text-white"
+                  : "bg-white dark:bg-neutral-900 text-neutral-600 dark:text-neutral-400 border border-neutral-200 dark:border-neutral-700 hover:bg-neutral-100 dark:hover:bg-neutral-800",
+              )}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Settings */}
+        {settings && (
+          <MemorySettingsCard settings={settings} onUpdate={handleUpdateSettings} />
+        )}
+
+        {/* Fact list */}
+        <div>
+          {loadingFacts && (
+            <div className="flex items-center gap-2 px-1 py-6 text-sm text-neutral-500">
+              <Loader2 className="w-4 h-4 animate-spin" /> Loading…
+            </div>
+          )}
+
+          {!loadingFacts && listError && (
+            <p className="text-sm text-red-500 px-1 py-4">{listError}</p>
+          )}
+
+          {!loadingFacts && !listError && noFactsAtAll && (
+            <div className="flex flex-col items-center justify-center text-center px-6 py-16 rounded-2xl border border-dashed border-neutral-300 dark:border-neutral-700">
+              <Brain className="w-10 h-10 text-neutral-300 dark:text-neutral-700 mb-3" />
+              <p className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
+                No memory yet
+              </p>
+              <p className="text-sm text-neutral-500 dark:text-neutral-400 mt-1 max-w-sm">
+                Solo will start filling this in automatically as you chat.
+                For now, you can add facts by hand — try something like
+                "pricing is $49/mo".
+              </p>
+              <Button
+                size="sm"
+                className="mt-4"
+                onClick={() => {
+                  setEditingFact(null);
+                  setFormOpen(true);
+                }}
+              >
+                <Plus className="w-3.5 h-3.5" />
+                Add memory
+              </Button>
+            </div>
+          )}
+
+          {!loadingFacts && !listError && !noFactsAtAll && facts.length === 0 && (
+            <p className="text-sm text-neutral-500 dark:text-neutral-400 px-1 py-8 text-center">
+              {isSearching
+                ? "No matches. Try a different phrasing."
+                : "No facts in this filter."}
+            </p>
+          )}
+
+          {!loadingFacts && !listError && facts.length > 0 && (
+            <ul className="rounded-xl border border-neutral-200 dark:border-neutral-800 divide-y divide-neutral-200 dark:divide-neutral-800 bg-white dark:bg-neutral-900">
+              {orderedFacts.map((fact) => (
+                <FactRow
+                  key={fact.id}
+                  fact={fact}
+                  onEdit={() => {
+                    setEditingFact(fact);
+                    setFormOpen(true);
+                  }}
+                  onDelete={() => handleDelete(fact)}
+                  onTogglePin={() => handleTogglePin(fact)}
+                />
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      <FactFormModal
+        open={formOpen}
+        editingFact={editingFact}
+        onClose={() => setFormOpen(false)}
+        onSubmit={handleCreateOrUpdate}
+      />
+    </div>
+  );
+}

--- a/frontend/tests/e2e/navigation/navigation.spec.ts
+++ b/frontend/tests/e2e/navigation/navigation.spec.ts
@@ -19,13 +19,13 @@ test("DC-NAV-01: sidebar shows all navigation items", async () => {
   await expect(nav.sidebar).toBeVisible();
 
   const labels = await nav.getNavLabels();
-  const expectedItems = ["Chat", "Knowledge", "Connectors", "Agents", "Automations", "Workspace", "Approvals", "Distributions", "Models", "Settings"];
+  const expectedItems = ["Chat", "Knowledge", "Memory", "Connectors", "Agents", "Automations", "Workspace", "Approvals", "Distributions", "Models", "Settings"];
 
   for (const item of expectedItems) {
     expect(labels).toContain(item);
   }
 
-  expect(labels.length).toBe(10);
+  expect(labels.length).toBe(11);
 });
 
 // DC-NAV-02: Navigate to each page and verify heading
@@ -33,6 +33,7 @@ test("DC-NAV-02: navigate to each page and verify heading", async ({ page }) => 
   const routes: { label: string; heading: string }[] = [
     { label: "Chat", heading: "Start a conversation" },
     { label: "Knowledge", heading: "Knowledge Bases" },
+    { label: "Memory", heading: "Memory" },
     { label: "Connectors", heading: "Connectors" },
     { label: "Agents", heading: "Agents" },
     { label: "Automations", heading: "Automations" },
@@ -101,12 +102,12 @@ test("DC-NAV-04: sidebar collapse/expand toggle works", async ({ page }) => {
   expect(expandedBox!.width).toBeGreaterThan(100);
 
   const expandedLabels = await nav.getNavLabels();
-  expect(expandedLabels.length).toBe(10);
+  expect(expandedLabels.length).toBe(11);
 });
 
 // DC-NAV-05: Page transitions are smooth (no flash)
 test("DC-NAV-05: page transitions are smooth", async ({ page }) => {
-  const routes = ["Chat", "Knowledge", "Connectors", "Agents", "Automations", "Workspace", "Approvals", "Distributions", "Models", "Settings"];
+  const routes = ["Chat", "Knowledge", "Memory", "Connectors", "Agents", "Automations", "Workspace", "Approvals", "Distributions", "Models", "Settings"];
 
   for (const route of routes) {
     await nav.navigateTo(route);


### PR DESCRIPTION
## Summary

PR-A of 4 for the **SPEC-14 Unified Memory Layer** (Q3 2026 flagship, "Solo remembers"). Ships the local, user-visible **memory store + Memory panel + manual facts** — the trust-critical, low-risk foundation. Fully additive.

Design doc: `docs/planning/specs/SPEC-14-DESIGN-memory-layer.md`.

## What's in this PR (PR-A)
- **Store** — `memory_facts` + `memory_settings` collections. Mirrors the KB/RAG pattern exactly: MiniLM embeddings stored inline as JSON in SQLite, numpy cosine retrieval. No new deps, no migration (tables auto-create).
- **Backend** — `models/memory_models.py`, `repositories/memory_repository.py` + `memory_settings_repository.py`, `services/memory_service.py`, `routers/memory.py` (`/api/v1/memory`), registered in `app.py`.
- **Frontend** — `/memory` route + panel: add/search(semantic)/pin/edit/delete facts, JSON export, per-scope toggles, master kill-switch. `memory-client.ts`, `components/memory/*`, reusable `components/ui/switch.tsx`. Sidebar gains a **Memory** entry.
- **Defaults** — channels off, chat + crews on (privacy posture).

## Deliberately NOT in PR-A (follow-ups)
- **PR-B** — recall: prepend a "What I know" block into chat + crew prompts. `search()`/`format_memory_block()` already exist and are tested for this.
- **PR-C** — automatic extraction from chats/crew runs (background job).
- **PR-D** — episodes.

So this ships "a Memory panel you manage," not yet "Solo remembers on its own."

## Testing
- Backend: **26 new tests** pass; full suite **1099** pass.
- Frontend: `npm run build` clean.
- Verified the full API loop live via curl (add → list → semantic search → pin → update/re-embed → export → kill-switch → delete). Semantic search correctly ranks a pricing fact 0.585 vs an unrelated fact -0.012 for "how much does it cost".

## Notes
- Adds a reusable `ui/switch.tsx` (none existed).
- Solo sidebar goes 8 → 9 items (Memory added); CLAUDE.md doc update to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)