### PR TITLE
chore: release v1.0.0-20

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "contextuai-solo",
   "description": "ContextuAI Solo — Personal AI Desktop App",
   "private": true,
-  "version": "1.0.0-19",
+  "version": "1.0.0-20",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contextuai-solo"
-version = "1.0.0-19"
+version = "1.0.0-20"
 description = "ContextuAI Solo - Your AI Business Assistant"
 authors = ["ContextuAI"]
 edition = "2021"

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "ContextuAI Solo",
-  "version": "1.0.0-19",
+  "version": "1.0.0-20",
   "identifier": "com.contextuai.solo",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Release **v1.0.0-20**.

Ships since v1.0.0-19:
- **SPEC-14 Unified Memory Layer — PR-A** (#63): local, user-visible memory store + `/memory` panel (add/search/pin/edit/delete facts, JSON export, per-scope toggles, master kill-switch). Additive; MiniLM embeddings in SQLite. Recall (PR-B) and auto-extraction (PR-C) to follow.

Version bumped in `package.json`, `tauri.conf.json`, `Cargo.toml`. Merging this to `main` auto-triggers the Release workflow (tag → build all platforms → publish).