### PR TITLE
feat(wizard): clear model-download choice + chat no-model nudge

### DIFF
--- a/frontend/src/components/chat/message-list.tsx
+++ b/frontend/src/components/chat/message-list.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { cn } from "@/lib/utils";
-import { Bot, User, Brain, ChevronRight } from "lucide-react";
+import { Bot, User, Brain, ChevronRight, Download, Cloud, ArrowRight } from "lucide-react";
 import type { ChatMessage } from "@/types/chat";
 
 interface MessageListProps {
@@ -8,6 +9,8 @@ interface MessageListProps {
   streamingContent: string;
   streamingThinking: string;
   isStreaming: boolean;
+  /** No usable model is set up yet — show the finish-setup nudge instead of the generic empty state. */
+  noModel?: boolean;
 }
 
 /** Lightweight markdown renderer for AI chat messages. */
@@ -268,11 +271,55 @@ function EmptyState() {
   );
 }
 
+/**
+ * Shown on the empty chat when no usable model is set up yet — the landing spot
+ * for a user who skipped model setup in the first-run wizard. Gives two clear
+ * ways to finish: download a local model, or add a cloud provider key.
+ */
+function NoModelState() {
+  const navigate = useNavigate();
+  return (
+    <div className="flex flex-col items-center justify-center h-full text-center px-8">
+      <div className="flex items-center justify-center w-16 h-16 rounded-2xl bg-emerald-50 dark:bg-emerald-500/10 mb-6">
+        <Download className="w-8 h-8 text-emerald-500" />
+      </div>
+      <h2 className="text-xl font-semibold text-neutral-900 dark:text-white mb-2">
+        Set up an AI model to start chatting
+      </h2>
+      <p className="text-sm text-neutral-500 dark:text-neutral-400 max-w-sm leading-relaxed mb-6">
+        You haven&apos;t set up a model yet. Download a free local model that
+        runs on your machine, or connect a cloud provider with an API key. It
+        only takes a minute.
+      </p>
+      <div className="flex items-center gap-2.5 flex-wrap justify-center">
+        <button
+          onClick={() => navigate("/models")}
+          className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl text-sm font-semibold bg-emerald-500 hover:bg-emerald-600 text-white shadow-lg shadow-emerald-500/25 transition-all"
+          data-testid="chat-download-model"
+        >
+          <Download className="w-4 h-4" />
+          Download a local model
+          <ArrowRight className="w-4 h-4" />
+        </button>
+        <button
+          onClick={() => navigate("/settings?tab=ai-providers")}
+          className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl text-sm font-medium border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 text-neutral-700 dark:text-neutral-200 hover:bg-neutral-50 dark:hover:bg-neutral-700 transition-all"
+          data-testid="chat-add-cloud-key"
+        >
+          <Cloud className="w-4 h-4" />
+          Add a cloud key
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export default function MessageList({
   messages,
   streamingContent,
   streamingThinking,
   isStreaming,
+  noModel,
 }: MessageListProps) {
   const bottomRef = useRef<HTMLDivElement>(null);
 
@@ -281,7 +328,7 @@ export default function MessageList({
   }, [messages, streamingContent, streamingThinking]);
 
   if (messages.length === 0 && !isStreaming) {
-    return <EmptyState />;
+    return noModel ? <NoModelState /> : <EmptyState />;
   }
 
   return (

--- a/frontend/src/routes/chat.tsx
+++ b/frontend/src/routes/chat.tsx
@@ -29,6 +29,9 @@ export default function ChatPage() {
 
   // ── Data state ─────────────────────────────────────────────────
   const [models, setModels] = useState<ModelConfig[]>([]);
+  // True once the first models fetch has resolved — avoids flashing the
+  // no-model nudge during initial load before the model list arrives.
+  const [modelsLoaded, setModelsLoaded] = useState(false);
   const [personas, setPersonas] = useState<Persona[]>([]);
   const [knowledgeBases, setKnowledgeBases] = useState<KnowledgeBase[]>([]);
   const [sessions, setSessions] = useState<ChatSession[]>([]);
@@ -140,6 +143,8 @@ export default function ChatPage() {
       }
     } catch (err) {
       console.warn("Failed to load models:", err);
+    } finally {
+      setModelsLoaded(true);
     }
   }
 
@@ -416,6 +421,7 @@ export default function ChatPage() {
           streamingContent={streamingContent}
           streamingThinking={streamingThinking}
           isStreaming={isStreaming}
+          noModel={modelsLoaded && !models.some((m) => m.enabled)}
         />
 
         <ChatInput

--- a/frontend/src/routes/wizard.tsx
+++ b/frontend/src/routes/wizard.tsx
@@ -284,6 +284,7 @@ export default function WizardPage() {
   const [downloadError, setDownloadError] = useState<string | null>(null);
   const downloadCancelRef = useRef<{ cancel: () => void } | null>(null);
   const [showCloudProviders, setShowCloudProviders] = useState(false);
+  const [confirmSkip, setConfirmSkip] = useState(false);
   const [data, setData] = useState<WizardData>({
     name: "",
     provider: "",
@@ -428,6 +429,16 @@ export default function WizardPage() {
     const needsKey = data.provider && data.provider !== "ollama" && data.provider !== "local";
     const isLocal = data.provider === "local";
     const cloudProviders = PROVIDERS.filter((p) => p.id !== "local");
+
+    // Is the user actually set up to chat after this step?
+    // Local → a model finished downloading; Ollama → assumed running; cloud → key tested OK.
+    const isReady = isLocal
+      ? testResult === "success"
+      : data.provider === "ollama"
+        ? true
+        : needsKey
+          ? testResult === "success"
+          : false;
 
     const handleLocalDownload = async () => {
       if (!data.model) return;
@@ -846,6 +857,53 @@ export default function WizardPage() {
               </div>
             )}
 
+            {/* ── Informed-skip notice: shown when Continue is pressed without a ready model ── */}
+            {confirmSkip && !isReady && (
+              <div className="mb-4 p-4 rounded-xl border border-amber-300 dark:border-amber-800 bg-amber-50 dark:bg-amber-500/10">
+                <div className="flex items-start gap-3">
+                  <Info className="w-4 h-4 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5" />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-semibold text-amber-800 dark:text-amber-300">
+                      No AI model is set up yet
+                    </p>
+                    <p className="text-xs text-amber-700/90 dark:text-amber-400/90 mt-1 leading-relaxed">
+                      {isLocal
+                        ? "You haven't downloaded a model. Without one you won't be able to chat until you download a local model or connect a cloud provider."
+                        : "You haven't connected a provider. Without one you won't be able to chat until you add a cloud key or download a local model."}{" "}
+                      You can do this now, or anytime later from{" "}
+                      <span className="font-semibold">Models</span> in the sidebar.
+                    </p>
+                    <div className="flex flex-wrap items-center gap-2 mt-3">
+                      {isLocal && (
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setConfirmSkip(false);
+                            handleLocalDownload();
+                          }}
+                          disabled={!data.model || downloading}
+                          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold bg-emerald-500 hover:bg-emerald-600 text-white transition-colors disabled:opacity-50"
+                        >
+                          <Download className="w-3.5 h-3.5" />
+                          Download now
+                        </button>
+                      )}
+                      <button
+                        onClick={() => {
+                          setConfirmSkip(false);
+                          setStep(3);
+                        }}
+                        className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold border border-amber-300 dark:border-amber-700 text-amber-800 dark:text-amber-300 hover:bg-amber-100 dark:hover:bg-amber-500/20 transition-colors"
+                      >
+                        Skip &mdash; I&apos;ll set up later
+                        <ArrowRight className="w-3.5 h-3.5" />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+
             {/* Navigation */}
             <div className="flex items-center justify-between pt-4">
               <button
@@ -854,17 +912,39 @@ export default function WizardPage() {
               >
                 Back
               </button>
-              <button
-                onClick={() => {
-                  // Set AI mode based on provider choice
-                  setAiMode(isLocal ? "local" : "cloud");
-                  setStep(3);
-                }}
-                className="flex items-center gap-2 px-6 py-2.5 rounded-xl text-sm font-semibold bg-primary-500 hover:bg-primary-600 text-white shadow-lg shadow-primary-500/25 transition-all"
-              >
-                Continue
-                <ArrowRight className="w-4 h-4" />
-              </button>
+              <div className="flex items-center gap-3">
+                {/* Readiness hint — tells the user where they stand before they proceed */}
+                {isReady ? (
+                  <span className="hidden sm:flex items-center gap-1.5 text-xs font-medium text-emerald-600 dark:text-emerald-400">
+                    <Check className="w-3.5 h-3.5" /> Ready to chat
+                  </span>
+                ) : (
+                  <span className="hidden sm:block text-xs text-neutral-400">
+                    {downloading ? "Download in progress…" : "No model downloaded yet"}
+                  </span>
+                )}
+                <button
+                  onClick={() => {
+                    // Set AI mode based on provider choice
+                    setAiMode(isLocal ? "local" : "cloud");
+                    if (isReady) {
+                      setStep(3);
+                    } else {
+                      // Don't silently proceed — surface the consequence and let them choose.
+                      setConfirmSkip(true);
+                    }
+                  }}
+                  className={cn(
+                    "flex items-center gap-2 px-6 py-2.5 rounded-xl text-sm font-semibold transition-all",
+                    isReady
+                      ? "bg-primary-500 hover:bg-primary-600 text-white shadow-lg shadow-primary-500/25"
+                      : "bg-neutral-200 dark:bg-neutral-700 text-neutral-700 dark:text-neutral-200 hover:bg-neutral-300 dark:hover:bg-neutral-600"
+                  )}
+                >
+                  {isReady ? "Continue" : "Skip for now"}
+                  <ArrowRight className="w-4 h-4" />
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/frontend/tests/e2e/fixtures/page-objects/chat.page.ts
+++ b/frontend/tests/e2e/fixtures/page-objects/chat.page.ts
@@ -83,9 +83,15 @@ export class ChatPage {
     return this.page.locator("button:has(svg.lucide-sparkles)").first();
   }
 
-  /** The empty state heading shown when no messages exist. */
+  /**
+   * The empty-state heading shown when a chat has no messages. Matches either
+   * variant: the normal "Start a conversation" (a usable model exists) or the
+   * "Set up an AI model…" nudge (no model/key configured, e.g. in CI).
+   */
   get emptyStateHeading(): Locator {
-    return this.page.getByText("Start a conversation");
+    return this.page.getByText(
+      /Start a conversation|Set up an AI model to start chatting/
+    );
   }
 
   // ── Actions ─────────────────────────────────────────────────────

--- a/frontend/tests/e2e/navigation/navigation.spec.ts
+++ b/frontend/tests/e2e/navigation/navigation.spec.ts
@@ -30,8 +30,10 @@ test("DC-NAV-01: sidebar shows all navigation items", async () => {
 
 // DC-NAV-02: Navigate to each page and verify heading
 test("DC-NAV-02: navigate to each page and verify heading", async ({ page }) => {
-  const routes: { label: string; heading: string }[] = [
-    { label: "Chat", heading: "Start a conversation" },
+  const routes: { label: string; heading: string | RegExp }[] = [
+    // Chat's empty state depends on model availability: the normal heading, or
+    // the "Set up an AI model…" nudge when none is configured (e.g. in CI).
+    { label: "Chat", heading: /Start a conversation|Set up an AI model to start chatting/ },
     { label: "Knowledge", heading: "Knowledge Bases" },
     { label: "Memory", heading: "Memory" },
     { label: "Connectors", heading: "Connectors" },
@@ -48,7 +50,7 @@ test("DC-NAV-02: navigate to each page and verify heading", async ({ page }) => 
     await nav.navigateTo(route.label);
     await page.waitForTimeout(500);
 
-    const headingEl = page.locator(`text=${route.heading}`).first();
+    const headingEl = page.getByText(route.heading).first();
     await expect(headingEl).toBeVisible({ timeout: 5000 });
   }
 });


### PR DESCRIPTION
## What & why

The first-run wizard's Step 2 advanced silently: **Continue** always moved on even when the user downloaded no model and added no cloud key — dropping them into an app that can't chat, with no explanation. This makes the "download now / later / skip" choice explicit and gives skipped setup a place to land.

## Changes (frontend-only)

**Wizard — `routes/wizard.tsx`**
- Readiness-aware Step 2: a `Ready to chat` / `No model downloaded yet` hint next to the primary button.
- Button reflects state: confident **Continue** when set up, de-emphasized **Skip for now** otherwise.
- Clicking Continue while not ready opens an inline **informed-skip notice** (no blocking browser dialog — those break Tauri IPC) with **Download now** and **Skip — I'll set up later**, telling the user they can finish anytime from **Models**.

**Chat no-model nudge — `components/chat/message-list.tsx`, `routes/chat.tsx`**
- New `NoModelState` empty state ("Set up an AI model to start chatting") with **Download a local model** → `/models` and **Add a cloud key** → `/settings?tab=ai-providers`.
- Gated behind `modelsLoaded` so it never flashes during the initial model fetch. Reuses the existing `local-models` API and mirrors the Coder `NoModelsEmptyState` pattern.

## Verification
- `npx tsc --noEmit` clean.
- `npm run build` succeeds.
- Test-ids `chat-download-model` / `chat-add-cloud-key` added for a future E2E spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)