### PR TITLE
chore: release v1.0.0-21

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "contextuai-solo",
   "description": "ContextuAI Solo — Personal AI Desktop App",
   "private": true,
-  "version": "1.0.0-20",
+  "version": "1.0.0-21",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contextuai-solo"
-version = "1.0.0-20"
+version = "1.0.0-21"
 description = "ContextuAI Solo - Your AI Business Assistant"
 authors = ["ContextuAI"]
 edition = "2021"

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "ContextuAI Solo",
-  "version": "1.0.0-20",
+  "version": "1.0.0-21",
   "identifier": "com.contextuai.solo",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Release **v1.0.0-21**.

Bumps the three version files (frontend/package.json, tauri.conf.json, Cargo.toml) from 1.0.0-20 → 1.0.0-21.

### Ships in this release
- **feat(wizard):** clear model-download choice in the first-run wizard (readiness-aware Continue vs Skip, informed-skip notice) + a chat no-model nudge that guides users to the Model Hub or AI Providers when no model is set up (#65).

Squash-merging this to `main` triggers the `Release` workflow (tag → build all platforms → publish + latest.json).